### PR TITLE
MCO-780: enables optional pprof profiling in the MCO

### DIFF
--- a/cmd/machine-config-controller/start.go
+++ b/cmd/machine-config-controller/start.go
@@ -21,6 +21,7 @@ import (
 	"github.com/openshift/machine-config-operator/pkg/controller/pinnedimageset"
 	"github.com/openshift/machine-config-operator/pkg/controller/render"
 	"github.com/openshift/machine-config-operator/pkg/controller/template"
+	"github.com/openshift/machine-config-operator/pkg/pprof"
 	"github.com/openshift/machine-config-operator/pkg/version"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -45,6 +46,8 @@ var (
 		tlsCipherSuites          []string
 		tlsMinVersion            string
 	}
+
+	pprofConfig *pprof.Config
 )
 
 func init() {
@@ -54,6 +57,11 @@ func init() {
 	startCmd.PersistentFlags().StringVar(&startOpts.promMetricsListenAddress, "metrics-listen-address", "127.0.0.1:8797", "Listen address for prometheus metrics listener")
 	startCmd.PersistentFlags().StringSliceVar(&startOpts.tlsCipherSuites, "tls-cipher-suites", nil, "Comma-separated list of cipher suites for the metrics server")
 	startCmd.PersistentFlags().StringVar(&startOpts.tlsMinVersion, "tls-min-version", "VersionTLS12", "Minimum TLS version supported for the metrics server")
+
+	// Add pprof flags
+	pprofFlags, pprofCfg := pprof.GetPprofFlags()
+	pprofConfig = pprofCfg
+	startCmd.PersistentFlags().AddFlagSet(pprofFlags)
 }
 
 func runStartCmd(_ *cobra.Command, _ []string) {
@@ -66,6 +74,13 @@ func runStartCmd(_ *cobra.Command, _ []string) {
 
 	// To help debugging, immediately log version
 	klog.Infof("Version: %+v (%s)", version.Raw, version.Hash)
+
+	// Start pprof if enabled
+	if pprofConfig.Enabled {
+		if _, err := pprof.StartPprof(runContext, pprofConfig.Port); err != nil {
+			klog.Warningf("Failed to start pprof: %v", err)
+		}
+	}
 
 	cb, err := clients.NewBuilder(startOpts.kubeconfig)
 	if err != nil {

--- a/cmd/machine-config-daemon/start.go
+++ b/cmd/machine-config-daemon/start.go
@@ -19,6 +19,7 @@ import (
 	"github.com/openshift/machine-config-operator/pkg/daemon/constants"
 	"github.com/openshift/machine-config-operator/pkg/daemon/cri"
 	"github.com/openshift/machine-config-operator/pkg/daemon/internalreleaseimage"
+	"github.com/openshift/machine-config-operator/pkg/pprof"
 	"github.com/openshift/machine-config-operator/pkg/version"
 	"github.com/spf13/cobra"
 	"k8s.io/klog/v2"
@@ -46,6 +47,8 @@ var (
 		tlsCipherSuites            []string
 		tlsMinVersion              string
 	}
+
+	pprofConfig *pprof.Config
 )
 
 func init() {
@@ -61,6 +64,11 @@ func init() {
 	startCmd.PersistentFlags().StringVar(&startOpts.promMetricsURL, "metrics-url", "127.0.0.1:8797", "URL for prometheus metrics listener")
 	startCmd.PersistentFlags().StringSliceVar(&startOpts.tlsCipherSuites, "tls-cipher-suites", nil, "Comma-separated list of cipher suites for the metrics server")
 	startCmd.PersistentFlags().StringVar(&startOpts.tlsMinVersion, "tls-min-version", "VersionTLS12", "Minimum TLS version supported for the metrics server")
+
+	// Add pprof flags
+	pprofFlags, pprofCfg := pprof.GetPprofFlags()
+	pprofConfig = pprofCfg
+	startCmd.PersistentFlags().AddFlagSet(pprofFlags)
 }
 
 //nolint:gocritic
@@ -72,6 +80,14 @@ func runStartCmd(_ *cobra.Command, _ []string) {
 
 	// To help debugging, immediately log version
 	klog.Infof("Version: %+v (%s)", version.Raw, version.Hash)
+
+	// Start pprof if enabled
+	if pprofConfig.Enabled {
+		ctx := context.Background()
+		if _, err := pprof.StartPprof(ctx, pprofConfig.Port); err != nil {
+			klog.Warningf("Failed to start pprof: %v", err)
+		}
+	}
 
 	// See https://github.com/coreos/rpm-ostree/pull/1880
 	os.Setenv("RPMOSTREE_CLIENT_ID", "machine-config-operator")

--- a/cmd/machine-config-operator/start.go
+++ b/cmd/machine-config-operator/start.go
@@ -11,6 +11,7 @@ import (
 	"github.com/openshift/machine-config-operator/internal/clients"
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
 	"github.com/openshift/machine-config-operator/pkg/operator"
+	"github.com/openshift/machine-config-operator/pkg/pprof"
 	"github.com/openshift/machine-config-operator/pkg/version"
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/tools/leaderelection"
@@ -29,12 +30,19 @@ var (
 		kubeconfig string
 		imagesFile string
 	}
+
+	pprofConfig *pprof.Config
 )
 
 func init() {
 	rootCmd.AddCommand(startCmd)
 	startCmd.PersistentFlags().StringVar(&startOpts.kubeconfig, "kubeconfig", "", "Kubeconfig file to access a remote cluster (testing only)")
 	startCmd.PersistentFlags().StringVar(&startOpts.imagesFile, "images-json", "", "images.json file for MCO.")
+
+	// Add pprof flags for debugging when CVO is disabled
+	pprofFlags, pprofCfg := pprof.GetPprofFlags()
+	pprofConfig = pprofCfg
+	startCmd.PersistentFlags().AddFlagSet(pprofFlags)
 }
 
 func runStartCmd(_ *cobra.Command, _ []string) {
@@ -47,6 +55,13 @@ func runStartCmd(_ *cobra.Command, _ []string) {
 
 	// To help debugging, immediately log version
 	klog.Infof("Version: %s (Raw: %s, Hash: %s)", version.ReleaseVersion, version.Raw, version.Hash)
+
+	// Start pprof if enabled via CLI flags (useful when CVO is disabled)
+	if pprofConfig.Enabled {
+		if _, err := pprof.StartPprof(runContext, pprofConfig.Port); err != nil {
+			klog.Warningf("Failed to start pprof via CLI flags: %v", err)
+		}
+	}
 
 	if startOpts.imagesFile == "" {
 		klog.Fatal("--images-json cannot be empty")
@@ -122,6 +137,11 @@ func runStartCmd(_ *cobra.Command, _ []string) {
 			iriInformer,
 			ctrlctx,
 		)
+
+		// If pprof was enabled via CLI flags, mark it to skip ConfigMap-based reconciliation
+		if pprofConfig.Enabled {
+			controller.SetPprofEnabledViaCLI()
+		}
 
 		ctrlctx.InformerFactory.Start(ctrlctx.Stop)
 		ctrlctx.ConfigInformerFactory.Start(ctrlctx.Stop)

--- a/cmd/machine-config-server/start.go
+++ b/cmd/machine-config-server/start.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"context"
 	"flag"
 
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
+	"github.com/openshift/machine-config-operator/pkg/pprof"
 	"github.com/openshift/machine-config-operator/pkg/server"
 	"github.com/openshift/machine-config-operator/pkg/version"
 	"github.com/spf13/cobra"
@@ -24,6 +26,8 @@ var (
 		kubeconfig   string
 		apiserverURL string
 	}
+
+	pprofConfig *pprof.Config
 )
 
 func init() {
@@ -31,6 +35,10 @@ func init() {
 	startCmd.PersistentFlags().StringVar(&startOpts.kubeconfig, "kubeconfig", "", "Kubeconfig file to access a remote cluster (testing only)")
 	startCmd.PersistentFlags().StringVar(&startOpts.apiserverURL, "apiserver-url", "", "URL for apiserver; Used to generate kubeconfig")
 
+	// Add pprof flags
+	pprofFlags, pprofCfg := pprof.GetPprofFlags()
+	pprofConfig = pprofCfg
+	startCmd.PersistentFlags().AddFlagSet(pprofFlags)
 }
 
 func runStartCmd(_ *cobra.Command, _ []string) {
@@ -42,6 +50,14 @@ func runStartCmd(_ *cobra.Command, _ []string) {
 
 	// To help debugging, immediately log version
 	klog.Infof("Version: %+v (%s)", version.Raw, version.Hash)
+
+	// Start pprof if enabled
+	if pprofConfig.Enabled {
+		ctx := context.Background()
+		if _, err := pprof.StartPprof(ctx, pprofConfig.Port); err != nil {
+			klog.Warningf("Failed to start pprof: %v", err)
+		}
+	}
 
 	if startOpts.apiserverURL == "" {
 		klog.Exitf("--apiserver-url cannot be empty")

--- a/cmd/machine-os-builder/start.go
+++ b/cmd/machine-os-builder/start.go
@@ -9,6 +9,7 @@ import (
 	"github.com/openshift/machine-config-operator/internal/clients"
 	"github.com/openshift/machine-config-operator/pkg/controller/build"
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
+	"github.com/openshift/machine-config-operator/pkg/pprof"
 	"k8s.io/client-go/tools/leaderelection"
 
 	"github.com/openshift/machine-config-operator/pkg/version"
@@ -27,11 +28,18 @@ var (
 	startOpts struct {
 		kubeconfig string
 	}
+
+	pprofConfig *pprof.Config
 )
 
 func init() {
 	rootCmd.AddCommand(startCmd)
 	startCmd.PersistentFlags().StringVar(&startOpts.kubeconfig, "kubeconfig", "", "Kubeconfig file to access a remote cluster (testing only)")
+
+	// Add pprof flags
+	pprofFlags, pprofCfg := pprof.GetPprofFlags()
+	pprofConfig = pprofCfg
+	startCmd.PersistentFlags().AddFlagSet(pprofFlags)
 }
 
 func runStartCmd(_ *cobra.Command, _ []string) {
@@ -48,6 +56,13 @@ func runStartCmd(_ *cobra.Command, _ []string) {
 	// the leader elections. Cancelling this is "stop everything, we are shutting down".
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+
+	// Start pprof if enabled
+	if pprofConfig.Enabled {
+		if _, err := pprof.StartPprof(ctx, pprofConfig.Port); err != nil {
+			klog.Warningf("Failed to start pprof: %v", err)
+		}
+	}
 
 	cb, err := clients.NewBuilder("")
 	if err != nil {

--- a/docs/enable-pprof-example.yaml
+++ b/docs/enable-pprof-example.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: enable-pprof
+  namespace: openshift-machine-config-operator
+data:
+  # Optional: global port override (applies to all components)
+  # pprof-port: "6060"
+
+  # Optional: per-component port overrides
+  # machine-config-controller-port: "6060"
+  # machine-config-daemon-port: "6061"
+  # machine-config-operator-port: "6062"
+  # machine-config-server-port: "6063"
+  # machine-os-builder-port: "6064"

--- a/docs/pprof.md
+++ b/docs/pprof.md
@@ -1,0 +1,244 @@
+# pprof Support in Machine Config Operator
+
+The Machine Config Operator (MCO) components support runtime pprof profiling for debugging memory and performance issues in production environments.
+
+## Overview
+
+pprof profiling can be enabled dynamically for all MCO components by creating a ConfigMap in the `openshift-machine-config-operator` namespace.
+
+## Supported Components
+
+- machine-config-controller (MCC)
+- machine-config-daemon (MCD)
+- machine-config-operator (MCO)
+- machine-config-server (MCS)
+- machine-os-builder (MOB)
+
+## Enabling pprof
+
+### Basic Enablement (Default Ports)
+
+Create the `enable-pprof` ConfigMap with no data to use default ports:
+
+```bash
+oc create configmap enable-pprof -n openshift-machine-config-operator
+```
+
+This will enable pprof on the following default ports:
+
+- machine-config-controller: 6060
+- machine-config-daemon: 6061
+- machine-config-operator: 6062
+- machine-config-server: 6063
+- machine-os-builder: 6064
+
+### Custom Port Configuration
+
+To customize ports, create the ConfigMap with port configuration:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: enable-pprof
+  namespace: openshift-machine-config-operator
+data:
+  # Global port override (applies to all components)
+  pprof-port: "7070"
+
+  # Per-component overrides (take precedence over global setting)
+  # Can be used together with pprof-port - specify only the components you want to override
+  machine-config-controller-port: "6060"
+  machine-config-daemon-port: "6061"
+```
+
+**Port Configuration Priority:**
+
+- Per-component settings (e.g., `machine-config-controller-port`) take precedence over the global `pprof-port` setting
+- You can combine global and per-component settings: set `pprof-port` as a baseline and override specific components as needed
+- If neither is specified for a component, the default port is used
+
+### Behavior by Component
+
+**machine-config-controller, machine-config-daemon, machine-config-server, machine-os-builder:**
+
+- Deployments/DaemonSets are automatically rerendered with pprof flags when the ConfigMap is created
+- Requires pod restart (automatic when deployment/daemonset is updated)
+
+**machine-config-operator:**
+
+- **Option 1 (Recommended):** ConfigMap-based enablement - pprof starts/stops dynamically as part of the reconciliation loop. **No pod restart required** - pprof will start automatically within seconds of creating the ConfigMap.
+- **Option 2 (CVO disabled):** CLI flags - When the cluster-version-operator is disabled for debugging, you can start the machine-config-operator with `--enable-pprof` and `--pprof-port` flags. Requires restarting the operator pod with the new flags.
+- **Note:** If both CLI flags and ConfigMap are present, CLI flags take precedence and ConfigMap-based reconciliation is disabled to avoid port conflicts.
+
+## Accessing pprof Endpoints
+
+All pprof servers bind to `127.0.0.1` (localhost only) for security. Access requires `oc port-forward`.
+
+### Accessing machine-config-controller
+
+```bash
+# Port-forward to MCC deployment
+oc port-forward -n openshift-machine-config-operator deployment/machine-config-controller 6060:6060
+
+# In another terminal, access pprof
+curl http://localhost:6060/debug/pprof/
+
+# Or use go tool pprof
+go tool pprof http://localhost:6060/debug/pprof/heap
+go tool pprof http://localhost:6060/debug/pprof/profile?seconds=30
+```
+
+### Accessing machine-config-daemon (on specific node)
+
+```bash
+# Find MCD pod on the node you want to profile
+oc get pods -n openshift-machine-config-operator -l k8s-app=machine-config-daemon -o wide
+
+# Port-forward to that specific pod
+oc port-forward -n openshift-machine-config-operator machine-config-daemon-xxxxx 6061:6061
+
+# Access pprof
+curl http://localhost:6061/debug/pprof/
+```
+
+### Accessing machine-config-operator
+
+**When using ConfigMap-based enablement (normal clusters):**
+
+```bash
+# Port-forward to MCO deployment
+oc port-forward -n openshift-machine-config-operator deployment/machine-config-operator 6062:6062
+
+# Access pprof
+curl http://localhost:6062/debug/pprof/
+```
+
+**When using CLI flags (CVO disabled for debugging):**
+
+```bash
+# First, edit the MCO deployment to add pprof flags
+oc edit deployment/machine-config-operator -n openshift-machine-config-operator
+
+# Add to the args section:
+# - "--enable-pprof"
+# - "--pprof-port=6062"
+
+# Wait for pod to restart
+oc rollout status deployment/machine-config-operator -n openshift-machine-config-operator
+
+# Then port-forward as normal
+oc port-forward -n openshift-machine-config-operator deployment/machine-config-operator 6062:6062
+curl http://localhost:6062/debug/pprof/
+```
+
+## Available pprof Endpoints
+
+All components expose the standard pprof endpoints:
+
+- `/debug/pprof/` - Index of available profiles
+- `/debug/pprof/heap` - Heap memory allocation
+- `/debug/pprof/goroutine` - Stack traces of all goroutines
+- `/debug/pprof/profile` - CPU profile (30 seconds by default)
+- `/debug/pprof/trace` - Execution trace
+- `/debug/pprof/block` - Contention profiling
+- `/debug/pprof/mutex` - Mutex profiling
+
+## Common Profiling Tasks
+
+### Investigating Memory Leaks
+
+```bash
+# Get heap profile
+go tool pprof http://localhost:6060/debug/pprof/heap
+
+# In pprof interactive mode:
+(pprof) top10        # Show top 10 memory consumers
+(pprof) list <func>  # Show source code for a function
+(pprof) web          # Generate SVG visualization (requires graphviz)
+```
+
+### CPU Profiling
+
+```bash
+# 30-second CPU profile
+go tool pprof http://localhost:6060/debug/pprof/profile?seconds=30
+
+# In pprof interactive mode:
+(pprof) top10
+(pprof) web
+```
+
+### Goroutine Analysis
+
+```bash
+# Get goroutine dump
+curl http://localhost:6060/debug/pprof/goroutine?debug=2 > goroutines.txt
+
+# Or use pprof
+go tool pprof http://localhost:6060/debug/pprof/goroutine
+```
+
+## Disabling pprof
+
+To disable pprof, delete the ConfigMap:
+
+```bash
+oc delete configmap enable-pprof -n openshift-machine-config-operator
+```
+
+- For machine-config-controller, machine-config-daemon, machine-config-server, machine-os-builder: Deployments/DaemonSets will be rerendered without pprof flags (automatic pod restart)
+- For machine-config-operator: pprof stops automatically in the next reconciliation loop (within seconds, no restart needed)
+
+## Example Workflows
+
+### Basic Usage (Default Ports)
+
+```bash
+# 1. Enable pprof with default ports
+oc create configmap enable-pprof -n openshift-machine-config-operator
+
+# 2. Wait for MCC pod to restart (or a few seconds for MCO)
+oc rollout status deployment/machine-config-controller -n openshift-machine-config-operator
+
+# 3. Port-forward to MCC
+oc port-forward -n openshift-machine-config-operator deployment/machine-config-controller 6060:6060 &
+
+# 4. Take a heap profile
+go tool pprof -http=:8080 http://localhost:6060/debug/pprof/heap
+
+# 5. When done, disable pprof
+oc delete configmap enable-pprof -n openshift-machine-config-operator
+```
+
+### Combining Global and Per-Component Port Settings
+
+```bash
+# Use port 7000 for all components, except MCC on 6060 and MCD on 6061
+cat <<EOF | oc apply -f -
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: enable-pprof
+  namespace: openshift-machine-config-operator
+data:
+  # Set global baseline port
+  pprof-port: "7000"
+  # Override specific components
+  machine-config-controller-port: "6060"
+  machine-config-daemon-port: "6061"
+EOF
+
+# Result:
+# - machine-config-controller: 6060 (per-component override)
+# - machine-config-daemon: 6061 (per-component override)
+# - machine-config-operator: 7000 (global setting)
+# - machine-config-server: 7000 (global setting)
+# - machine-os-builder: 7000 (global setting)
+```
+
+## References
+
+- [Go pprof documentation](https://pkg.go.dev/net/http/pprof)
+- [Profiling Go Programs](https://go.dev/blog/pprof)
+- [Diagnostics - Profiling](https://go.dev/doc/diagnostics#profiling)

--- a/manifests/machineconfigcontroller/deployment.yaml
+++ b/manifests/machineconfigcontroller/deployment.yaml
@@ -26,6 +26,9 @@ spec:
         - "--payload-version={{.ReleaseVersion}}"
         - "--tls-cipher-suites={{join .TLSCipherSuites ","}}"
         - "--tls-min-version={{.TLSMinVersion}}"
+        {{if .PprofEnabled}}- "--enable-pprof"
+        - "--pprof-port={{index .PprofPorts "machine-config-controller"}}"
+        {{end}}
         resources:
           requests:
             cpu: 20m

--- a/manifests/machineconfigdaemon/daemonset.yaml
+++ b/manifests/machineconfigdaemon/daemonset.yaml
@@ -29,6 +29,9 @@ spec:
           - "--v={{.LogLevel}}"
           - "--tls-cipher-suites={{join .TLSCipherSuites ","}}"
           - "--tls-min-version={{.TLSMinVersion}}"
+          {{if .PprofEnabled}}- "--enable-pprof"
+          - "--pprof-port={{index .PprofPorts "machine-config-daemon"}}"
+          {{end}}
         resources:
           requests:
             cpu: 20m

--- a/manifests/machineconfigserver/daemonset.yaml
+++ b/manifests/machineconfigserver/daemonset.yaml
@@ -27,6 +27,9 @@ spec:
           - "--tls-cipher-suites={{join .TLSCipherSuites ","}}"
           - "--tls-min-version={{.TLSMinVersion}}"
           - "--v={{.LogLevel}}"
+          {{if .PprofEnabled}}- "--enable-pprof"
+          - "--pprof-port={{index .PprofPorts "machine-config-server"}}"
+          {{end}}
         ports:
         - containerPort: 22623
           name: https

--- a/manifests/machineosbuilder/deployment.yaml
+++ b/manifests/machineosbuilder/deployment.yaml
@@ -23,6 +23,9 @@ spec:
         args:
         - "start"
         - "--v={{.LogLevel}}"
+        {{if .PprofEnabled}}- "--enable-pprof"
+        - "--pprof-port={{index .PprofPorts "machine-os-builder"}}"
+        {{end}}
         resources:
           requests:
             cpu: 20m

--- a/pkg/operator/bootstrap.go
+++ b/pkg/operator/bootstrap.go
@@ -148,7 +148,7 @@ func buildSpec(dependencies *BootstrapDependencies, imgs *ctrlcommon.Images, rel
 	}
 
 	config := getRenderConfig("", dependencies.KubeAPIServerServingCA, spec,
-		&imgs.RenderConfigImages, dependencies.Infrastructure, nil, nil, "2")
+		&imgs.RenderConfigImages, dependencies.Infrastructure, nil, nil, "2", nil)
 	return config, nil
 }
 

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -9,6 +9,7 @@ import (
 	operatorinformersv1alpha1 "github.com/openshift/client-go/operator/informers/externalversions/operator/v1alpha1"
 	operatorlistersv1alpha1 "github.com/openshift/client-go/operator/listers/operator/v1alpha1"
 	"github.com/openshift/machine-config-operator/pkg/osimagestream"
+	"github.com/openshift/machine-config-operator/pkg/pprof"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/clock"
 
@@ -131,6 +132,9 @@ type Operator struct {
 	provisioningLister       dynamiclister.Lister
 	provisioningListerSynced cache.InformerSynced
 
+	pprofManager       *pprof.Manager
+	pprofEnabledViaCLI bool
+
 	crdListerSynced                  cache.InformerSynced
 	deployListerSynced               cache.InformerSynced
 	daemonsetListerSynced            cache.InformerSynced
@@ -173,6 +177,7 @@ type Operator struct {
 	queue workqueue.TypedRateLimitingInterface[string]
 
 	stopCh <-chan struct{}
+	ctx    context.Context
 
 	renderConfig *renderConfig
 
@@ -255,9 +260,10 @@ func New(
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
 			workqueue.TypedRateLimitingQueueConfig[string]{Name: "machineconfigoperator"}),
-		fgHandler: fgHandler,
-		ctrlctx:   ctrlctx,
-		logLevel:  2,
+		fgHandler:    fgHandler,
+		ctrlctx:      ctrlctx,
+		logLevel:     2,
+		pprofManager: pprof.NewManager(),
 	}
 
 	err := corev1.AddToScheme(scheme.Scheme)
@@ -414,6 +420,12 @@ func New(
 	return optr
 }
 
+// SetPprofEnabledViaCLI marks that pprof was enabled via CLI flags, which disables
+// ConfigMap-based pprof reconciliation to avoid conflicts
+func (optr *Operator) SetPprofEnabledViaCLI() {
+	optr.pprofEnabledViaCLI = true
+}
+
 // Run runs the machine config operator.
 func (optr *Operator) Run(workers int, stopCh <-chan struct{}) {
 	defer utilruntime.HandleCrash()
@@ -505,7 +517,24 @@ func (optr *Operator) Run(workers int, stopCh <-chan struct{}) {
 	klog.Info("Starting MachineConfigOperator")
 	defer klog.Info("Shutting down MachineConfigOperator")
 
+	// Create context from stopCh for proper shutdown of long-running components
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		<-stopCh
+		cancel()
+	}()
+
 	optr.stopCh = stopCh
+	optr.ctx = ctx
+
+	// Ensure pprof server is stopped on shutdown
+	defer func() {
+		if optr.pprofManager.IsRunning() {
+			klog.Info("Stopping pprof server")
+			optr.pprofManager.Stop()
+		}
+	}()
 
 	for i := 0; i < workers; i++ {
 		go wait.Until(optr.worker, time.Second, stopCh)
@@ -612,6 +641,8 @@ func (optr *Operator) sync(key string) error {
 		// OSImageStream must run FIRST to provide OS image information as RenderConfig will read
 		// images references from OSImageStream
 		{"OSImageStream", optr.syncOSImageStream},
+		// Pprof runs early as it's lightweight and doesn't depend on other resources
+		{"Pprof", optr.syncPprof},
 		// "RenderConfig" should be the first one to run (except OSImageStream) as it sets the renderConfig in
 		// the operator for the sync funcs below
 		{"RenderConfig", optr.syncRenderConfig},

--- a/pkg/operator/render.go
+++ b/pkg/operator/render.go
@@ -38,6 +38,13 @@ const (
 	ingressLB LoadBalancerType = "Ingress"
 )
 
+// pprofRenderConfig holds pprof configuration for manifest rendering
+// This is returned by getPprofConfig() and used to populate renderConfig
+type pprofRenderConfig struct {
+	Enabled bool
+	Ports   map[string]int
+}
+
 type renderConfig struct {
 	TargetNamespace        string
 	Version                string
@@ -52,6 +59,8 @@ type renderConfig struct {
 	TLSMinVersion          string
 	TLSCipherSuites        []string
 	LogLevel               string
+	PprofEnabled           bool
+	PprofPorts             map[string]int
 }
 
 type assetRenderer struct {

--- a/pkg/operator/render_test.go
+++ b/pkg/operator/render_test.go
@@ -258,8 +258,8 @@ func TestRenderAsset(t *testing.T) {
 			// Test that machineconfigdaemon DaemonSets are rendered correctly with proxy config
 			Path: "manifests/machineconfigdaemon/daemonset.yaml",
 			RenderConfig: &renderConfig{
-				TargetNamespace:  "testing-namespace",
-				ReleaseVersion:   "4.8.0-rc.0",
+				TargetNamespace: "testing-namespace",
+				ReleaseVersion:  "4.8.0-rc.0",
 				Images: &ctrlcommon.RenderConfigImages{
 					MachineConfigOperator: "mco-operator-image",
 					KubeRbacProxy:         "kube-rbac-proxy-image",
@@ -295,6 +295,118 @@ func TestRenderAsset(t *testing.T) {
 			},
 			FindExpected: []string{
 				"--payload-version=4.8.0-rc.0",
+			},
+		},
+		{
+			// Test that pprof flags are NOT rendered when PprofEnabled is false
+			Path: "manifests/machineconfigcontroller/deployment.yaml",
+			RenderConfig: &renderConfig{
+				TargetNamespace: "testing-namespace",
+				ReleaseVersion:  "4.8.0-rc.0",
+				Images: &ctrlcommon.RenderConfigImages{
+					MachineConfigOperator: "mco-operator-image",
+				},
+				PprofEnabled: false,
+			},
+			NotFindExpected: []string{
+				"--enable-pprof",
+				"--pprof-port",
+			},
+		},
+		{
+			// Test that pprof flags ARE rendered when PprofEnabled is true with default ports
+			Path: "manifests/machineconfigcontroller/deployment.yaml",
+			RenderConfig: &renderConfig{
+				TargetNamespace: "testing-namespace",
+				ReleaseVersion:  "4.8.0-rc.0",
+				Images: &ctrlcommon.RenderConfigImages{
+					MachineConfigOperator: "mco-operator-image",
+				},
+				PprofEnabled: true,
+				PprofPorts: map[string]int{
+					"machine-config-controller": 6060,
+				},
+			},
+			FindExpected: []string{
+				"--enable-pprof",
+				"--pprof-port=6060",
+			},
+		},
+		{
+			// Test that pprof flags with custom port are rendered correctly
+			Path: "manifests/machineconfigcontroller/deployment.yaml",
+			RenderConfig: &renderConfig{
+				TargetNamespace: "testing-namespace",
+				ReleaseVersion:  "4.8.0-rc.0",
+				Images: &ctrlcommon.RenderConfigImages{
+					MachineConfigOperator: "mco-operator-image",
+				},
+				PprofEnabled: true,
+				PprofPorts: map[string]int{
+					"machine-config-controller": 7070,
+				},
+			},
+			FindExpected: []string{
+				"--enable-pprof",
+				"--pprof-port=7070",
+			},
+		},
+		{
+			// Test pprof flags for machine-config-daemon
+			Path: "manifests/machineconfigdaemon/daemonset.yaml",
+			RenderConfig: &renderConfig{
+				TargetNamespace: "testing-namespace",
+				ReleaseVersion:  "4.8.0-rc.0",
+				Images: &ctrlcommon.RenderConfigImages{
+					MachineConfigOperator: "mco-operator-image",
+					KubeRbacProxy:         "kube-rbac-proxy-image",
+				},
+				PprofEnabled: true,
+				PprofPorts: map[string]int{
+					"machine-config-daemon": 6061,
+				},
+			},
+			FindExpected: []string{
+				"--enable-pprof",
+				"--pprof-port=6061",
+			},
+		},
+		{
+			// Test pprof flags for machine-config-server
+			Path: "manifests/machineconfigserver/daemonset.yaml",
+			RenderConfig: &renderConfig{
+				TargetNamespace: "testing-namespace",
+				ReleaseVersion:  "4.8.0-rc.0",
+				Images: &ctrlcommon.RenderConfigImages{
+					MachineConfigOperator: "mco-operator-image",
+				},
+				PprofEnabled: true,
+				PprofPorts: map[string]int{
+					"machine-config-server": 6063,
+				},
+			},
+			FindExpected: []string{
+				"--enable-pprof",
+				"--pprof-port=6063",
+			},
+		},
+		{
+			// Test pprof flags for machine-os-builder
+			Path: "manifests/machineosbuilder/deployment.yaml",
+			RenderConfig: &renderConfig{
+				TargetNamespace: "testing-namespace",
+				ReleaseVersion:  "4.8.0-rc.0",
+				Images: &ctrlcommon.RenderConfigImages{
+					MachineConfigOperator: "mco-operator-image",
+				},
+				PprofEnabled: true,
+				PprofPorts: map[string]int{
+					"machine-os-builder": 6064,
+				},
+			},
+			FindExpected: []string{
+				"--enable-pprof",
+				"--pprof-port=6064",
 			},
 		},
 	}

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -58,6 +58,7 @@ import (
 	templatectrl "github.com/openshift/machine-config-operator/pkg/controller/template"
 	daemonconsts "github.com/openshift/machine-config-operator/pkg/daemon/constants"
 	"github.com/openshift/machine-config-operator/pkg/helpers"
+	"github.com/openshift/machine-config-operator/pkg/pprof"
 	"github.com/openshift/machine-config-operator/pkg/secrets"
 	"github.com/openshift/machine-config-operator/pkg/server"
 	"github.com/openshift/machine-config-operator/pkg/upgrademonitor"
@@ -167,7 +168,6 @@ type syncError struct {
 }
 
 func (optr *Operator) syncAll(syncFuncs []syncFunc) error {
-
 	co, err := optr.fetchClusterOperator()
 	if err != nil {
 		return err
@@ -241,7 +241,6 @@ func (optr *Operator) syncAll(syncFuncs []syncFunc) error {
 	// Handle these errors after as CO status updates should have priority over this
 	if syncUpgradeableStatusErr != nil {
 		return fmt.Errorf("syncingUpgradeableStatus: %w", syncUpgradeableStatusErr)
-
 	}
 	if syncClusterFleetEvaluationErr != nil {
 		return fmt.Errorf("updating cluster operator status: %w", syncClusterFleetEvaluationErr)
@@ -370,7 +369,64 @@ func (optr *Operator) syncCloudConfig(spec *mcfgv1.ControllerConfigSpec, infra *
 	return nil
 }
 
+// syncPprof manages the pprof endpoint (only for the machine-config-operator component) based on the enable-pprof ConfigMap
+//
 //nolint:gocyclo
+func (optr *Operator) syncPprof(_ *renderConfig, _ *configv1.ClusterOperator) error {
+	// Skip ConfigMap-based reconciliation if pprof was enabled via CLI flags
+	if optr.pprofEnabledViaCLI {
+		klog.V(4).Info("Skipping ConfigMap-based pprof reconciliation (pprof enabled via CLI flags)")
+		return nil
+	}
+
+	cm, err := optr.mcoCmLister.ConfigMaps(ctrlcommon.MCONamespace).Get(pprof.EnablePprofConfigMapName)
+	if err != nil {
+		// ConfigMap doesn't exist or error getting it
+		if !apierrors.IsNotFound(err) {
+			return fmt.Errorf("error getting enable-pprof ConfigMap: %w", err)
+		}
+
+		// ConfigMap not found - ensure pprof is stopped
+		if optr.pprofManager.IsRunning() {
+			klog.Info("enable-pprof ConfigMap not found, stopping pprof")
+			optr.pprofManager.Stop()
+		}
+		return nil
+	}
+
+	// ConfigMap exists - determine port and start pprof if not running
+	port := 6062 // default for MCO
+
+	// Check for global port override (lower priority)
+	if globalPortStr, ok := cm.Data["pprof-port"]; ok {
+		if p, err := strconv.Atoi(globalPortStr); err == nil {
+			port = p
+		} else {
+			klog.Warningf("Invalid pprof-port value in enable-pprof ConfigMap: key=%q value=%q error=%v", "pprof-port", globalPortStr, err)
+		}
+	}
+
+	// Check for component-specific override (higher priority)
+	if componentPortStr, ok := cm.Data["machine-config-operator-port"]; ok {
+		if p, err := strconv.Atoi(componentPortStr); err == nil {
+			port = p
+		} else {
+			klog.Warningf("Invalid machine-config-operator-port value in enable-pprof ConfigMap: key=%q value=%q error=%v", "machine-config-operator-port", componentPortStr, err)
+		}
+	}
+
+	if !optr.pprofManager.IsRunning() {
+		klog.Infof("enable-pprof ConfigMap found, starting pprof on port %d", port)
+		if err := optr.pprofManager.Start(optr.ctx, port); err != nil {
+			return fmt.Errorf("failed to start pprof: %w", err)
+		}
+	} else {
+		klog.V(4).Infof("pprof already running")
+	}
+
+	return nil
+}
+
 func (optr *Operator) syncRenderConfig(_ *renderConfig, _ *configv1.ClusterOperator) error {
 	if optr.inClusterBringup {
 		klog.V(4).Info("Starting inClusterBringup informers cache sync")
@@ -597,7 +653,6 @@ func (optr *Operator) syncRenderConfig(_ *renderConfig, _ *configv1.ClusterOpera
 	oscontainer, osextensionscontainer, err := optr.getOsImageURLs(optr.namespace, "")
 	if err != nil {
 		return fmt.Errorf("could not get OS images: %w", err)
-
 	}
 	imgs.BaseOSContainerImage = oscontainer
 	imgs.BaseOSExtensionsContainerImage = osextensionscontainer
@@ -652,7 +707,8 @@ func (optr *Operator) syncRenderConfig(_ *renderConfig, _ *configv1.ClusterOpera
 		optr.setOperatorLogLevel(mcop.Spec.OperatorLogLevel)
 	}
 
-	optr.renderConfig = getRenderConfig(optr.namespace, string(kubeAPIServerServingCABytes), spec, &imgs.RenderConfigImages, infra, pointerConfigData, apiServer, fmt.Sprintf("%d", optr.logLevel))
+	pprofCfg := optr.getPprofConfig()
+	optr.renderConfig = getRenderConfig(optr.namespace, string(kubeAPIServerServingCABytes), spec, &imgs.RenderConfigImages, infra, pointerConfigData, apiServer, fmt.Sprintf("%d", optr.logLevel), pprofCfg)
 
 	return nil
 }
@@ -1448,7 +1504,6 @@ func (optr *Operator) isMachineOSBuilderRunning(mob *appsv1.Deployment) (bool, e
 }
 
 func (optr *Operator) reconcileSimpleContentAccessSecrets(layeredMCPs []*mcfgv1.MachineConfigPool) error {
-
 	// Create set of layered and non layeredPools
 	layeredPoolSet := sets.Set[string]{}
 	for _, pool := range layeredMCPs {
@@ -2154,7 +2209,62 @@ func setGVK(obj runtime.Object, scheme *runtime.Scheme) error {
 	return nil
 }
 
-func getRenderConfig(tnamespace, kubeAPIServerServingCA string, ccSpec *mcfgv1.ControllerConfigSpec, imgs *ctrlcommon.RenderConfigImages, infra *configv1.Infrastructure, pointerConfigData []byte, apiServer *configv1.APIServer, logLevel string) *renderConfig {
+// getPprofConfig checks for enable-pprof ConfigMap and returns configuration
+func (optr *Operator) getPprofConfig() *pprofRenderConfig {
+	cm, err := optr.mcoCmLister.ConfigMaps(ctrlcommon.MCONamespace).Get(pprof.EnablePprofConfigMapName)
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			klog.V(4).Infof("Error getting enable-pprof ConfigMap: %v", err)
+		}
+		return nil
+	}
+
+	// ConfigMap exists, pprof is enabled
+	ports := map[string]int{
+		"machine-config-controller": 6060,
+		"machine-config-daemon":     6061,
+		"machine-config-operator":   6062,
+		"machine-config-server":     6063,
+		"machine-os-builder":        6064,
+	}
+
+	// Check for global port override
+	if globalPort, ok := cm.Data["pprof-port"]; ok {
+		if port, err := strconv.Atoi(globalPort); err == nil {
+			for k := range ports {
+				ports[k] = port
+			}
+		} else {
+			klog.Warningf("Invalid pprof-port value in enable-pprof ConfigMap: key=%q value=%q error=%v", "pprof-port", globalPort, err)
+		}
+	}
+
+	// Check for per-component overrides
+	for component := range ports {
+		key := component + "-port"
+		if portStr, ok := cm.Data[key]; ok {
+			if port, err := strconv.Atoi(portStr); err == nil {
+				ports[component] = port
+			} else {
+				klog.Warningf("Invalid %s value in enable-pprof ConfigMap: key=%q value=%q error=%v", key, key, portStr, err)
+			}
+		}
+	}
+
+	return &pprofRenderConfig{
+		Enabled: true,
+		Ports:   ports,
+	}
+}
+
+func getRenderConfig(tnamespace, kubeAPIServerServingCA string, ccSpec *mcfgv1.ControllerConfigSpec, imgs *ctrlcommon.RenderConfigImages, infra *configv1.Infrastructure, pointerConfigData []byte, apiServer *configv1.APIServer, logLevel string, pprofCfg *pprofRenderConfig) *renderConfig {
+	var pprofEnabled bool
+	var pprofPorts map[string]int
+	if pprofCfg != nil {
+		pprofEnabled = pprofCfg.Enabled
+		pprofPorts = pprofCfg.Ports
+	}
+
 	tlsMinVersion, tlsCipherSuites := ctrlcommon.GetSecurityProfileCiphersFromAPIServer(apiServer)
 	return &renderConfig{
 		TargetNamespace:        tnamespace,
@@ -2169,6 +2279,8 @@ func getRenderConfig(tnamespace, kubeAPIServerServingCA string, ccSpec *mcfgv1.C
 		TLSMinVersion:          tlsMinVersion,
 		TLSCipherSuites:        tlsCipherSuites,
 		LogLevel:               logLevel,
+		PprofEnabled:           pprofEnabled,
+		PprofPorts:             pprofPorts,
 	}
 }
 
@@ -2334,7 +2446,6 @@ func cmToData(cm *corev1.ConfigMap, key string) ([]byte, error) {
 // Validates configuration provided in the MachineConfiguration object's spec for each feature
 // and updates the status of the object as necessary
 func (optr *Operator) syncMachineConfiguration(_ *renderConfig, _ *configv1.ClusterOperator) error {
-
 	// Grab the cluster CR
 	mcop, err := optr.mcopLister.Get(ctrlcommon.MCOOperatorKnobsObjectName)
 	if err != nil {
@@ -2647,7 +2758,6 @@ func (optr *Operator) getCurrentOCPVersionFromClusterVersion() string {
 //   - The CR does not exist (cluster is using the machine-os-images path introduced in 4.10)
 //   - The field is empty (same as above)
 func (optr *Operator) isBareMetalOnLegacyProvisioningPath() bool {
-
 	if optr.provisioningListerSynced != nil && !optr.provisioningListerSynced() {
 		klog.V(2).Info("Provisioning informer not synced yet; assuming legacy provisioning path for safety")
 		return true

--- a/pkg/pprof/pprof.go
+++ b/pkg/pprof/pprof.go
@@ -1,0 +1,195 @@
+// Package pprof provides runtime profiling support for MCO components.
+// It offers both simple fire-and-forget profiling (via StartPprof) and
+// dynamic lifecycle management (via Manager) for ConfigMap-based enablement.
+package pprof
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/pprof"
+	"sync"
+	"time"
+
+	"github.com/spf13/pflag"
+	"k8s.io/klog/v2"
+)
+
+const (
+	// DefaultPprofPort is the default port for pprof HTTP server
+	DefaultPprofPort = 6060
+
+	// EnablePprofConfigMapName is the name of the ConfigMap used to enable pprof
+	EnablePprofConfigMapName = "enable-pprof"
+)
+
+// Config holds pprof configuration values for CLI flags
+type Config struct {
+	Enabled bool
+	Port    int
+}
+
+// GetPprofFlags returns the CLI flags for pprof configuration and a pointer to a Config struct
+// that will be populated with the parsed flag values
+func GetPprofFlags() (*pflag.FlagSet, *Config) {
+	config := &Config{}
+	flags := pflag.NewFlagSet("pprof", pflag.ContinueOnError)
+	flags.BoolVar(&config.Enabled, "enable-pprof", false, "Enable pprof profiling endpoint")
+	flags.IntVar(&config.Port, "pprof-port", DefaultPprofPort, "Port for pprof HTTP server")
+	return flags, config
+}
+
+// createPprofServer creates a new HTTP server with pprof handlers
+func createPprofServer(port int) *http.Server {
+	// Create dedicated mux to avoid polluting default mux
+	mux := http.NewServeMux()
+
+	// Register pprof handlers
+	mux.HandleFunc("/debug/pprof/", pprof.Index)
+	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+	return &http.Server{
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second, // Prevent Slowloris attacks
+	}
+}
+
+// StartPprof starts the pprof HTTP server on its own mux
+// This is a simple fire-and-forget function for binaries that use CLI flags
+// Uses context for graceful shutdown
+// Returns a done channel that is closed when the server has fully stopped
+func StartPprof(ctx context.Context, port int) (<-chan struct{}, error) {
+	server := createPprofServer(port)
+
+	// Bind the listener synchronously to catch any bind errors immediately
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to bind pprof listener on %s: %w", addr, err)
+	}
+
+	klog.Infof("Starting pprof server on %s", addr)
+
+	// Create done channel to signal shutdown completion
+	done := make(chan struct{})
+
+	// Start serving in a goroutine
+	serveDone := make(chan struct{})
+	go func() {
+		defer close(serveDone)
+		if err := server.Serve(listener); err != nil && err != http.ErrServerClosed {
+			klog.Errorf("pprof server error: %v", err)
+		}
+	}()
+
+	// Graceful shutdown - monitors the input context
+	// #nosec G118 -- context.Background is required here because ctx is already cancelled at shutdown time
+	go func() {
+		defer close(done)
+		<-ctx.Done()
+		// Create a new context for shutdown (can't reuse cancelled ctx)
+		// Give the server 5 seconds to shut down gracefully
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := server.Shutdown(shutdownCtx); err != nil {
+			klog.Errorf("pprof server shutdown error: %v", err)
+		} else {
+			klog.Info("pprof server stopped")
+		}
+		// Wait for Serve to actually return
+		<-serveDone
+	}()
+
+	return done, nil
+}
+
+// Manager manages the lifecycle of a pprof server with dynamic start/stop capability
+// This is used by machine-config-operator for ConfigMap-based enablement
+type Manager struct {
+	mu       sync.Mutex
+	cancelFn context.CancelFunc
+	done     <-chan struct{}
+	running  bool
+}
+
+// NewManager creates a new pprof Manager
+func NewManager() *Manager {
+	return &Manager{}
+}
+
+// Start starts the pprof server if not already running
+// This is idempotent - calling Start when already running is a no-op
+func (m *Manager) Start(ctx context.Context, port int) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.running {
+		klog.V(4).Info("pprof server already running, ignoring Start request")
+		return nil
+	}
+
+	// Create a child context that can be cancelled independently
+	serverCtx, cancel := context.WithCancel(ctx)
+	m.cancelFn = cancel
+
+	// Use the shared StartPprof function
+	done, err := StartPprof(serverCtx, port)
+	if err != nil {
+		cancel()
+		return err
+	}
+
+	m.done = done
+	m.running = true
+	return nil
+}
+
+// Stop stops the pprof server if running
+// This is idempotent - calling Stop when not running is a no-op
+// Waits for shutdown to complete before returning
+func (m *Manager) Stop() {
+	m.mu.Lock()
+
+	if !m.running {
+		m.mu.Unlock()
+		klog.V(4).Info("pprof server not running, ignoring Stop request")
+		return
+	}
+
+	// Trigger shutdown by cancelling the context
+	if m.cancelFn != nil {
+		m.cancelFn()
+	}
+
+	// Copy done channel while holding lock
+	done := m.done
+
+	// Release lock before waiting to avoid blocking other operations
+	m.mu.Unlock()
+
+	// Wait for shutdown to complete (safe even if done is nil or already closed)
+	if done != nil {
+		<-done
+	}
+
+	// Reacquire lock to clear state
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.cancelFn = nil
+	m.done = nil
+	m.running = false
+}
+
+// IsRunning returns true if the pprof server is currently running
+func (m *Manager) IsRunning() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.running
+}

--- a/pkg/pprof/pprof_test.go
+++ b/pkg/pprof/pprof_test.go
@@ -1,0 +1,298 @@
+package pprof
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestManager_StartStop(t *testing.T) {
+	t.Parallel()
+
+	m := NewManager()
+	require.NotNil(t, m)
+
+	port := 16062
+	ctx := context.Background()
+
+	// Initially not running
+	assert.False(t, m.IsRunning())
+
+	// Start the manager
+	err := m.Start(ctx, port)
+	require.NoError(t, err)
+	assert.True(t, m.IsRunning())
+
+	// Give server time to start
+	time.Sleep(100 * time.Millisecond)
+
+	// Verify server is accessible
+	resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/debug/pprof/", port))
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Stop the manager
+	m.Stop()
+	assert.False(t, m.IsRunning())
+
+	// Give server time to shut down
+	time.Sleep(200 * time.Millisecond)
+
+	// Verify server is no longer accessible
+	_, err = http.Get(fmt.Sprintf("http://127.0.0.1:%d/debug/pprof/", port))
+	assert.Error(t, err, "server should be stopped")
+}
+
+func TestManager_StartIdempotent(t *testing.T) {
+	t.Parallel()
+
+	m := NewManager()
+	port := 16063
+	ctx := context.Background()
+
+	// Start the manager
+	err := m.Start(ctx, port)
+	require.NoError(t, err)
+	assert.True(t, m.IsRunning())
+
+	// Start again - should be no-op
+	err = m.Start(ctx, port)
+	require.NoError(t, err)
+	assert.True(t, m.IsRunning())
+
+	// Start with different port - should still be no-op (same server keeps running)
+	err = m.Start(ctx, 9999)
+	require.NoError(t, err)
+	assert.True(t, m.IsRunning())
+
+	// Verify original server still works
+	time.Sleep(100 * time.Millisecond)
+	resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/debug/pprof/", port))
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Verify new port was NOT started
+	_, err = http.Get("http://127.0.0.1:9999/debug/pprof/")
+	assert.Error(t, err, "second Start call should not have started a new server")
+
+	// Cleanup
+	m.Stop()
+}
+
+func TestManager_StopIdempotent(t *testing.T) {
+	t.Parallel()
+
+	m := NewManager()
+	port := 16064
+	ctx := context.Background()
+
+	// Start the manager
+	err := m.Start(ctx, port)
+	require.NoError(t, err)
+
+	// Stop once
+	m.Stop()
+	assert.False(t, m.IsRunning())
+
+	// Stop again - should be no-op (no panic)
+	m.Stop()
+	assert.False(t, m.IsRunning())
+}
+
+func TestManager_StopWithoutStart(t *testing.T) {
+	t.Parallel()
+
+	m := NewManager()
+
+	// Stop without starting - should be no-op (no panic)
+	m.Stop()
+	assert.False(t, m.IsRunning())
+}
+
+func TestManager_RestartAfterStop(t *testing.T) {
+	t.Parallel()
+
+	m := NewManager()
+	port := 16065
+	ctx := context.Background()
+
+	// Start
+	err := m.Start(ctx, port)
+	require.NoError(t, err)
+	assert.True(t, m.IsRunning())
+
+	time.Sleep(100 * time.Millisecond)
+
+	// Stop
+	m.Stop()
+	assert.False(t, m.IsRunning())
+
+	time.Sleep(200 * time.Millisecond)
+
+	// Restart on same port
+	err = m.Start(ctx, port)
+	require.NoError(t, err)
+	assert.True(t, m.IsRunning())
+
+	time.Sleep(100 * time.Millisecond)
+
+	// Verify server works
+	resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/debug/pprof/", port))
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Cleanup
+	m.Stop()
+}
+
+func TestManager_DifferentPortAfterStop(t *testing.T) {
+	t.Parallel()
+
+	m := NewManager()
+	port1 := 16066
+	port2 := 16067
+	ctx := context.Background()
+
+	// Start on port1
+	err := m.Start(ctx, port1)
+	require.NoError(t, err)
+	time.Sleep(100 * time.Millisecond)
+
+	// Stop
+	m.Stop()
+	time.Sleep(200 * time.Millisecond)
+
+	// Start on port2
+	err = m.Start(ctx, port2)
+	require.NoError(t, err)
+	time.Sleep(100 * time.Millisecond)
+
+	// Verify port2 works
+	resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/debug/pprof/", port2))
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Verify port1 is not running
+	_, err = http.Get(fmt.Sprintf("http://127.0.0.1:%d/debug/pprof/", port1))
+	assert.Error(t, err)
+
+	// Cleanup
+	m.Stop()
+}
+
+func TestManager_StartReturnsBindError(t *testing.T) {
+	t.Parallel()
+
+	port := 16068
+	ctx := context.Background()
+
+	// Start first manager to bind the port
+	m1 := NewManager()
+	err := m1.Start(ctx, port)
+	require.NoError(t, err)
+	assert.True(t, m1.IsRunning())
+	defer m1.Stop()
+
+	time.Sleep(100 * time.Millisecond)
+
+	// Try to start second manager on same port - should fail immediately
+	m2 := NewManager()
+	err = m2.Start(ctx, port)
+	assert.Error(t, err, "should return bind error when port is already in use")
+	assert.False(t, m2.IsRunning(), "manager should not be marked as running if bind fails")
+	assert.Contains(t, err.Error(), "failed to bind pprof listener")
+}
+
+func TestStartPprof_ReturnsBindError(t *testing.T) {
+	t.Parallel()
+
+	port := 16069
+	ctx := context.Background()
+
+	// Start first server to bind the port
+	_, err := StartPprof(ctx, port)
+	require.NoError(t, err)
+
+	time.Sleep(100 * time.Millisecond)
+
+	// Try to start second server on same port - should fail immediately
+	_, err = StartPprof(ctx, port)
+	assert.Error(t, err, "should return bind error when port is already in use")
+	assert.Contains(t, err.Error(), "failed to bind pprof listener")
+}
+
+func TestManager_StopWaitsForShutdown(t *testing.T) {
+	t.Parallel()
+
+	port := 16070
+	ctx := context.Background()
+
+	m := NewManager()
+	err := m.Start(ctx, port)
+	require.NoError(t, err)
+	assert.True(t, m.IsRunning())
+
+	time.Sleep(100 * time.Millisecond)
+
+	// Verify server is running
+	resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/debug/pprof/", port))
+	require.NoError(t, err)
+	_ = resp.Body.Close()
+
+	// Record time before stop
+	startStop := time.Now()
+
+	// Stop should wait for shutdown to complete
+	m.Stop()
+
+	// Stop should have waited (at least a few milliseconds for shutdown)
+	stopDuration := time.Since(startStop)
+	assert.True(t, stopDuration > 0, "Stop should have waited for shutdown")
+
+	// After Stop returns, server should be fully stopped
+	assert.False(t, m.IsRunning())
+
+	// Verify we can immediately start a new server on the same port
+	// (proves shutdown completed and released the port)
+	m2 := NewManager()
+	err = m2.Start(ctx, port)
+	require.NoError(t, err, "should be able to bind to the same port immediately after Stop returns")
+	assert.True(t, m2.IsRunning())
+
+	// Cleanup
+	m2.Stop()
+}
+
+func TestManager_RepeatedStopIsSafe(t *testing.T) {
+	t.Parallel()
+
+	port := 16071
+	ctx := context.Background()
+
+	m := NewManager()
+	err := m.Start(ctx, port)
+	require.NoError(t, err)
+
+	time.Sleep(100 * time.Millisecond)
+
+	// First stop
+	m.Stop()
+	assert.False(t, m.IsRunning())
+
+	// Second stop should not panic or deadlock
+	m.Stop()
+	assert.False(t, m.IsRunning())
+
+	// Third stop for good measure
+	m.Stop()
+	assert.False(t, m.IsRunning())
+}

--- a/test/e2e-2of2/pprof_test.go
+++ b/test/e2e-2of2/pprof_test.go
@@ -1,0 +1,361 @@
+package e2e_2of2_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openshift/machine-config-operator/pkg/controller/common"
+	"github.com/openshift/machine-config-operator/pkg/pprof"
+	"github.com/openshift/machine-config-operator/test/framework"
+	"github.com/openshift/machine-config-operator/test/helpers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+// TestPprofConfigMap validates that pprof can be enabled/disabled via ConfigMap
+// for all MCO components
+func TestPprofConfigMap(t *testing.T) {
+	cs := framework.NewClientSet("")
+
+	// Use test context (respects go test -timeout flag)
+	ctx := t.Context()
+
+	// Ensure ConfigMap doesn't exist at the start
+	_ = cs.CoreV1Interface.ConfigMaps(common.MCONamespace).Delete(
+		ctx,
+		pprof.EnablePprofConfigMapName,
+		metav1.DeleteOptions{},
+	)
+
+	// Give reconciliation time to process deletion if it existed
+	time.Sleep(5 * time.Second)
+
+	// Test components with their expected ports
+	components := []struct {
+		name           string
+		deploymentKind string // "Deployment" or "DaemonSet"
+		port           int
+	}{
+		{name: "machine-config-controller", deploymentKind: "Deployment", port: 6060},
+		{name: "machine-config-daemon", deploymentKind: "DaemonSet", port: 6061},
+		{name: "machine-config-operator", deploymentKind: "Deployment", port: 6062},
+		{name: "machine-config-server", deploymentKind: "DaemonSet", port: 6063},
+	}
+
+	// Step 1: Create enable-pprof ConfigMap
+	t.Log("Creating enable-pprof ConfigMap...")
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      pprof.EnablePprofConfigMapName,
+			Namespace: common.MCONamespace,
+		},
+	}
+	_, err := cs.CoreV1Interface.ConfigMaps(common.MCONamespace).Create(
+		ctx,
+		cm,
+		metav1.CreateOptions{},
+	)
+	require.NoError(t, err, "Failed to create enable-pprof ConfigMap")
+
+	// Cleanup: delete ConfigMap at the end (deferred, runs even if test fails)
+	t.Cleanup(func() {
+		t.Log("Cleaning up: Deleting enable-pprof ConfigMap...")
+		// Use background context since test context is cancelled at this point
+		err := cs.CoreV1Interface.ConfigMaps(common.MCONamespace).Delete(
+			context.Background(),
+			pprof.EnablePprofConfigMapName,
+			metav1.DeleteOptions{},
+		)
+		if err != nil && !apierrors.IsNotFound(err) {
+			t.Logf("Warning: Failed to cleanup ConfigMap: %v", err)
+		}
+	})
+
+	// Step 2: Wait for rollout and verify pprof is enabled
+	// Each component waits for its manifest to update, pods to rollout, and verifies pprof access
+	// Note: We don't use t.Parallel() here because we need all components to complete
+	// before deleting the ConfigMap in the next step
+	t.Log("Waiting for components to enable pprof and verifying access...")
+	for _, component := range components {
+		component := component // Capture for goroutine
+		t.Run(fmt.Sprintf("EnableAndVerify_%s", component.name), func(t *testing.T) {
+			// Special handling for MCO - it uses dynamic startup, not manifest args
+			if component.name == "machine-config-operator" {
+				t.Logf("Waiting for %s to enable pprof dynamically...", component.name)
+				// MCO doesn't update its manifest, just wait for pods to be ready
+				err := waitForPodsReady(ctx, t, cs, component.name, false)
+				require.NoError(t, err, "Pods for %s not ready", component.name)
+
+				// Give MCO time to reconcile and start pprof dynamically
+				time.Sleep(15 * time.Second)
+
+				// Verify pprof is accessible
+				verifyPprofEnabled(ctx, t, cs, component.name, component.port)
+				return
+			}
+
+			// For other components, wait for manifest to update
+			if component.deploymentKind == "Deployment" {
+				t.Logf("Waiting for deployment %s to rollout with pprof args...", component.name)
+				err := waitForDeploymentWithPprofArgs(ctx, cs, component.name)
+				require.NoError(t, err, "Deployment %s did not get pprof args", component.name)
+
+				// Wait for pods to be ready with pprof args
+				err = waitForPodsReady(ctx, t, cs, component.name, true)
+				require.NoError(t, err, "Pods for %s not ready with pprof args", component.name)
+			} else {
+				// DaemonSet
+				t.Logf("Waiting for daemonset %s to rollout with pprof args...", component.name)
+				err := waitForDaemonSetWithPprofArgs(ctx, cs, component.name)
+				require.NoError(t, err, "DaemonSet %s did not get pprof args", component.name)
+
+				// Wait for pods to be ready with pprof args
+				err = waitForPodsReady(ctx, t, cs, component.name, true)
+				require.NoError(t, err, "Pods for %s not ready with pprof args", component.name)
+			}
+
+			// Verify pprof is accessible
+			verifyPprofEnabled(ctx, t, cs, component.name, component.port)
+		})
+	}
+
+	// Step 3: Delete ConfigMap to disable pprof
+	t.Log("Deleting enable-pprof ConfigMap to test disablement...")
+	err = cs.CoreV1Interface.ConfigMaps(common.MCONamespace).Delete(
+		ctx,
+		pprof.EnablePprofConfigMapName,
+		metav1.DeleteOptions{},
+	)
+	require.NoError(t, err, "Failed to delete enable-pprof ConfigMap")
+
+	// Step 4: Verify pprof endpoints are disabled (parallelized)
+	for _, component := range components {
+		component := component // Capture for goroutine
+		t.Run(fmt.Sprintf("VerifyDisabled_%s", component.name), func(t *testing.T) {
+			t.Parallel()
+			t.Logf("Waiting for pprof to be disabled for %s...", component.name)
+			// Poll until pprof is disabled or timeout
+			err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 3*time.Minute, true, func(_ context.Context) (bool, error) {
+				disabled := verifyPprofDisabled(ctx, t, cs, component.name, component.port)
+				if disabled {
+					t.Logf("✓ pprof disabled for %s", component.name)
+					return true, nil
+				}
+				t.Logf("pprof still accessible for %s, retrying...", component.name)
+				return false, nil
+			})
+			require.NoError(t, err, "Timeout waiting for pprof to be disabled for %s", component.name)
+		})
+	}
+}
+
+// hasPprofArgs checks if any container in the pod spec has pprof flags
+func hasPprofArgs(podSpec corev1.PodSpec) bool {
+	for _, container := range podSpec.Containers {
+		hasPprofEnabled := false
+		hasPprofPort := false
+
+		for _, arg := range container.Args {
+			if arg == "--enable-pprof" {
+				hasPprofEnabled = true
+			}
+
+			if strings.HasPrefix(arg, "--pprof-port=") {
+				hasPprofPort = true
+			}
+		}
+
+		// If this container has both pprof flags, return true
+		if hasPprofEnabled && hasPprofPort {
+			return true
+		}
+	}
+
+	// No container had both pprof flags
+	return false
+}
+
+// waitForDeploymentWithPprofArgs waits for a deployment to have pprof args in its pod template
+func waitForDeploymentWithPprofArgs(ctx context.Context, cs *framework.ClientSet, name string) error {
+	return wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, true, func(_ context.Context) (bool, error) {
+		deployment, err := cs.AppsV1Interface.Deployments(common.MCONamespace).Get(
+			ctx,
+			name,
+			metav1.GetOptions{},
+		)
+		if err != nil {
+			// For all errors (transient API errors), retry
+			return false, nil
+		}
+
+		// Check if the pod template has pprof args
+		return hasPprofArgs(deployment.Spec.Template.Spec), nil
+	})
+}
+
+// waitForDaemonSetWithPprofArgs waits for a daemonset to have pprof args in its pod template
+func waitForDaemonSetWithPprofArgs(ctx context.Context, cs *framework.ClientSet, name string) error {
+	return wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, true, func(_ context.Context) (bool, error) {
+		daemonset, err := cs.AppsV1Interface.DaemonSets(common.MCONamespace).Get(
+			ctx,
+			name,
+			metav1.GetOptions{},
+		)
+		if err != nil {
+			// For all errors (transient API errors), retry
+			return false, nil
+		}
+
+		// Check if the pod template has pprof args
+		return hasPprofArgs(daemonset.Spec.Template.Spec), nil
+	})
+}
+
+// waitForPodsReady waits for pods of a component to be ready with the expected pprof configuration
+// expectPprofArgs: true = wait for pods WITH pprof args, false = wait for pods WITHOUT pprof args
+func waitForPodsReady(ctx context.Context, t *testing.T, cs *framework.ClientSet, componentName string, expectPprofArgs bool) error {
+	return wait.PollUntilContextTimeout(ctx, 5*time.Second, 3*time.Minute, true, func(_ context.Context) (bool, error) {
+		pod := getFirstAvailablePod(ctx, t, cs, componentName, expectPprofArgs)
+		return pod != nil, nil
+	})
+}
+
+// getFirstAvailablePod returns the first ready pod for a component with the expected pprof configuration
+// expectPprofArgs: true = find pod WITH pprof args, false = find pod WITHOUT pprof args
+// Returns nil if no matching ready pods are found (all errors are treated as retryable)
+func getFirstAvailablePod(ctx context.Context, t *testing.T, cs *framework.ClientSet, componentName string, expectPprofArgs bool) *corev1.Pod {
+	pods, err := cs.CoreV1Interface.Pods(common.MCONamespace).List(
+		ctx,
+		metav1.ListOptions{
+			LabelSelector: fmt.Sprintf("k8s-app=%s", componentName),
+		},
+	)
+	if err != nil {
+		// Log API errors but treat as retryable
+		t.Logf("Warning: Failed to list pods for %s: %v", componentName, err)
+		return nil
+	}
+
+	if len(pods.Items) == 0 {
+		// No pods found - this is retryable (pods may be creating)
+		t.Logf("Warning: No pods found for component %s", componentName)
+		return nil
+	}
+
+	// Track statistics for debugging
+	var readyCount, wrongConfigCount int
+
+	// Find the first ready pod with the expected pprof configuration
+	for i := range pods.Items {
+		pod := &pods.Items[i]
+
+		// Check if pod is ready
+		isReady := false
+		for _, condition := range pod.Status.Conditions {
+			if condition.Type == corev1.PodReady && condition.Status == corev1.ConditionTrue {
+				isReady = true
+				break
+			}
+		}
+
+		if !isReady {
+			continue
+		}
+
+		readyCount++
+
+		// Check if pod has the expected pprof configuration
+		podHasPprofArgs := hasPprofArgs(pod.Spec)
+		if podHasPprofArgs == expectPprofArgs {
+			return pod
+		}
+
+		wrongConfigCount++
+	}
+
+	// No matching pod found - log helpful debug info (retryable)
+	if readyCount == 0 {
+		t.Logf("Warning: Found %d pod(s) for %s but none are ready", len(pods.Items), componentName)
+	} else if wrongConfigCount > 0 {
+		expectedStr := "WITHOUT"
+		if expectPprofArgs {
+			expectedStr = "WITH"
+		}
+		t.Logf("Warning: Found %d ready pod(s) for %s but none have expected pprof config (%s pprof args)",
+			readyCount, componentName, expectedStr)
+	}
+
+	return nil
+}
+
+// verifyPprofEnabled verifies that pprof endpoint is accessible for a component
+func verifyPprofEnabled(ctx context.Context, t *testing.T, cs *framework.ClientSet, componentName string, port int) {
+	// For MCO, pprof is enabled dynamically, not via pod args, so expectPprofArgs=false
+	// For other components, pprof is in the pod args, so expectPprofArgs=true
+	expectPprofArgs := componentName != "machine-config-operator"
+	testPod := getFirstAvailablePod(ctx, t, cs, componentName, expectPprofArgs)
+	require.NotNil(t, testPod, "No ready pods found for %s with expected pprof configuration", componentName)
+
+	t.Logf("Testing pprof endpoint for %s (pod: %s, port: %d)", componentName, testPod.Name, port)
+
+	// Use curl from within the pod to access localhost pprof endpoint
+	url := fmt.Sprintf("http://127.0.0.1:%d/debug/pprof/", port)
+	output, err := execCmdOnPod(cs, testPod.Namespace, testPod.Name, componentName, "curl", "-s", "-m", "5", url)
+	require.NoError(t, err, "Failed to exec curl on pod %s", testPod.Name)
+
+	// Verify the output contains pprof index page markers
+	assert.Contains(t, output, "/debug/pprof", "pprof endpoint should return index page for %s", componentName)
+	t.Logf("✓ pprof endpoint is accessible for %s", componentName)
+}
+
+// verifyPprofDisabled checks if pprof endpoint is NOT accessible for a component
+// Returns true if disabled/inaccessible, false if still accessible or can't verify
+func verifyPprofDisabled(ctx context.Context, t *testing.T, cs *framework.ClientSet, componentName string, port int) bool {
+	// After disabling pprof, we expect pods WITHOUT pprof args (old pods or newly rolled out without pprof)
+	// For MCO, it never has pprof in args anyway, so expectPprofArgs=false
+	// For other components, after ConfigMap deletion and rollout, pods should not have pprof args
+	testPod := getFirstAvailablePod(ctx, t, cs, componentName, false)
+	if testPod == nil {
+		// No ready pods found without pprof args - still rolling out, return false to retry
+		return false
+	}
+
+	// Use curl from within the pod to try accessing localhost pprof endpoint
+	url := fmt.Sprintf("http://127.0.0.1:%d/debug/pprof/", port)
+	output, err := execCmdOnPod(cs, testPod.Namespace, testPod.Name, componentName, "curl", "-s", "-m", "5", url)
+
+	// We expect this to fail (connection refused) since pprof should be stopped
+	if err == nil && strings.Contains(output, "/debug/pprof") {
+		// Still accessible - return false
+		return false
+	}
+
+	// Not accessible - return true (disabled)
+	return true
+}
+
+// execCmdOnPod executes a command in a specific pod/container using oc rsh
+func execCmdOnPod(cs *framework.ClientSet, namespace, podName, containerName string, subArgs ...string) (string, error) {
+	args := []string{
+		"rsh",
+		"-n", namespace,
+		"-c", containerName,
+		podName,
+	}
+	args = append(args, subArgs...)
+
+	cmd, err := helpers.NewOcCommand(cs, args...)
+	if err != nil {
+		return "", err
+	}
+
+	output, err := cmd.CombinedOutput()
+	return string(output), err
+}


### PR DESCRIPTION
**- What I did**

I've added optional pprof profiling within all of the major MCO components. Doing this will enable us to identify the source of excessive CPU and memory utilization where and when necessary. This is not enabled by default because profiling is very CPU / memory intensive and should only be enabled whenever someone specifically asks for it.

**- How to verify it**

1. Deploy this PR into an OpenShift cluster.
2. Create a ConfigMap called `enable-pprof` in the MCO namespace. By default, no key / values are required. However, optional values may be added to specify which ports pprof should listen on. See the included docs/pprof.md file for details.
3. The MCO should re-render the Deployment and DaemonSets for the machine-config-controller, machine-config-daemon and machine-config-server which will cause these components to restart. Once the restart is complete, each component will have pprof running alongside it. The MCO itself does not require a pod restart to enable or disable pprof because there is no way to control the deployment object, which is managed by the cluster-version-operator. 
4. The pprof endpoints are purposely not publicly exposed. Connecting to them requires one to use port-fowarding like this:
```bash

oc port-forward -n openshift-machine-config-operator deployment/machine-config-controller 6060:6060 &
curl http://localhost:6060/debug/pprof/heap
# - or -
go tool pprof http://localhost:6060/debug/pprof/heap
```
5. Finally, delete the `enable-pprof` ConfigMap. This will cause the pprof process within the MCO to stop running and will cause the deployments and daemonsets to be rerendered without the `--enable-pprof` flags, which will cause these components to restart. 

**- Description for the changelog**
Enables optional pprof profiling in all MCO components

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional Go `pprof` profiling for Machine Config Operator components (controller, daemon, server, operator, and machine-os-builder).
  * Can be enabled via `enable-pprof` ConfigMap or CLI flags, with global and per-component port overrides.
  * `pprof` runs localhost-only and startup failures no longer block normal startup; managed stop behavior added.
  * Updated component deployment templates to conditionally include `pprof` flags.
* **Documentation**
  * Added end-user guide for enabling, accessing (port-forward), endpoints, and example profiling workflows.
* **Tests**
  * Added unit and e2e coverage for ConfigMap-driven enable/disable behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->