### PR TITLE
OCPBUGS-98210: Fix OSImageStream version-skew rejection during upgrades

### DIFF
--- a/pkg/operator/osimagestream_ocp.go
+++ b/pkg/operator/osimagestream_ocp.go
@@ -13,6 +13,7 @@ import (
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
 	"github.com/openshift/machine-config-operator/pkg/imageutils"
 	"github.com/openshift/machine-config-operator/pkg/osimagestream"
+	"github.com/openshift/machine-config-operator/pkg/version"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -313,14 +314,20 @@ func (optr *Operator) getExistingOSImageStream() (*mcfgv1.OSImageStream, error) 
 }
 
 // osImageStreamRequiresRebuild checks if the OSImageStream needs to be created or updated.
-// Returns true if osImageStream is nil, or if its release image annotation doesn't match the
-// current release payload image. This uses the release payload image digest rather than the
-// MCO binary hash so that upgrades are detected even when the MCO image itself hasn't changed
-// (e.g., in CI upgrade jobs where only RHCOS images are rebuilt).
+// Returns true if the OSImageStream is nil, if the release payload image changed, or if
+// the MCO binary version changed. The release payload image check detects real content
+// changes (new RHCOS images). The version.Hash check ensures the render controller's
+// version-skew guard is satisfied — it compares ReleaseImageVersionAnnotationKey against
+// its own version.Hash, so the annotation must be kept in sync even when the release
+// payload image hasn't changed (e.g., CI upgrade jobs where only the MCO binary is rebuilt).
 func osImageStreamRequiresRebuild(osImageStream *mcfgv1.OSImageStream, releaseImage string) bool {
 	if osImageStream == nil {
 		return true
 	}
 	storedImage, ok := osImageStream.Annotations[ctrlcommon.ReleasePayloadImageAnnotationKey]
-	return !ok || storedImage != releaseImage
+	if !ok || storedImage != releaseImage {
+		return true
+	}
+	storedVersion, ok := osImageStream.Annotations[ctrlcommon.ReleaseImageVersionAnnotationKey]
+	return !ok || storedVersion != version.Hash
 }


### PR DESCRIPTION
During an upgrade, the pre-upgrade MCO operator may sync after ClusterVersion.Status.Desired.Image is updated but before the operator pod is replaced. This causes the old operator to rebuild the OSImageStream with the new release payload image but its own (old) version.Hash in ReleaseImageVersionAnnotationKey.

When the new operator starts, it sees ReleasePayloadImageAnnotationKey already matches the current release image and skips the rebuild. ReleaseImageVersionAnnotationKey remains set to the old operator's hash. The render controller then permanently rejects the OSImageStream because its version-skew guard compares the annotation against the new binary's version.Hash.

Fix by also checking ReleaseImageVersionAnnotationKey against version.Hash in the rebuild predicate, so the OSImageStream is rebuilt whenever the MCO binary version changes.

/hold

We may want this as part of https://github.com/openshift/machine-config-operator/pull/6278 instead

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * OS image streams are now rebuilt when the machine configuration operator version is missing or out of sync.
  * Prevents stale OS image streams when the release payload image remains unchanged but the operator version has changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->