### PR TITLE
MCO-2184: Adapt scale extended tests to support osstreams

### DIFF
--- a/test/extended-priv/controlplanemachineset.go
+++ b/test/extended-priv/controlplanemachineset.go
@@ -49,6 +49,23 @@ func NewControlPlaneMachineSetList(oc *exutil.CLI, namespace string) *ControlPla
 }
 
 // GetState returns the state of the ControlPlaneMachineSet (Active or Inactive)
+// GetOSStreamLabel returns the value of the machineconfiguration.openshift.io/osstream label
+func (cpms ControlPlaneMachineSet) GetOSStreamLabel() (string, error) {
+	return cpms.GetLabel("machineconfiguration.openshift.io/osstream")
+}
+
+// GetOSStream returns the OS stream used by this ControlPlaneMachineSet.
+// If the osstream label is set, it returns its value. Otherwise it defaults to rhel-9.
+// The logic should be more complex.
+// If the label is not set, then we should return the osstream used by the master pool
+func (cpms ControlPlaneMachineSet) GetOSStream() string {
+	stream, err := cpms.GetOSStreamLabel()
+	if err != nil || stream == "" {
+		return OSImageStreamRHEL9
+	}
+	return stream
+}
+
 func (cpms ControlPlaneMachineSet) GetState() (string, error) {
 	return cpms.Get(`{.spec.state}`)
 }

--- a/test/extended-priv/machineset.go
+++ b/test/extended-priv/machineset.go
@@ -67,6 +67,19 @@ func (ms MachineSet) GetReplicaOfSpec() string {
 	return ms.GetOrFail(`{.spec.replicas}`)
 }
 
+// GetOSStream returns the OS stream used by this MachineSet.
+// If the osstream label is set, it returns its value. Otherwise it defaults to rhel-9.
+// The logic should be more complex. To find the right osstream if the label does not exist we should:
+// 1. Read the user-data secret and find out the pool configured for this machineset reading the ignition URL
+// 2. Get the osstream used by this pool
+func (ms MachineSet) GetOSStream() string {
+	stream, err := ms.GetOSStreamLabel()
+	if err != nil || stream == "" {
+		return OSImageStreamRHEL9
+	}
+	return stream
+}
+
 // AddToScale scales the MachineSet adding the given value (positive or negative).
 func (ms MachineSet) AddToScale(delta int) error {
 	currentReplicas, err := strconv.Atoi(ms.GetOrFail(`{.spec.replicas}`))

--- a/test/extended-priv/mco_bootimages.go
+++ b/test/extended-priv/mco_bootimages.go
@@ -930,11 +930,11 @@ func getBackdatedBootImage(oc *exutil.CLI) string {
 		rhcosHandler, err := GetRHCOSHandler(platform)
 		o.Expect(err).NotTo(o.HaveOccurred(), "Error getting the rhcos handler")
 
-		baseImage, err := rhcosHandler.GetBaseImageFromRHCOSImageInfo(imageVersion, arch, "")
+		baseImage, err := rhcosHandler.GetBaseImageFromRHCOSImageInfo(imageVersion, OSImageStreamRHEL9, arch, "")
 		o.Expect(err).NotTo(o.HaveOccurred(), "Error getting the base image")
 		logger.Infof("Using base image %s", baseImage)
 
-		baseImageURL, err := rhcosHandler.GetBaseImageURLFromRHCOSImageInfo(imageVersion, arch)
+		baseImageURL, err := rhcosHandler.GetBaseImageURLFromRHCOSImageInfo(imageVersion, OSImageStreamRHEL9, arch)
 		o.Expect(err).NotTo(o.HaveOccurred(), "Error getting the base image URL")
 
 		// To avoid collisions we will add prefix to identify our image

--- a/test/extended-priv/mco_scale.go
+++ b/test/extended-priv/mco_scale.go
@@ -335,11 +335,14 @@ func cloneMachineSet(oc *exutil.CLI, ms *MachineSet, newMsName, imageVersion, ig
 	architecture, err := ms.GetArchitecture()
 	o.Expect(err).NotTo(o.HaveOccurred(), "Error getting the arechitecture from machineset %s", ms.GetName())
 
-	baseImage, err := rhcosHandler.GetBaseImageFromRHCOSImageInfo(imageVersion, architecture, getCurrentRegionOrFail(oc.AsAdmin()))
+	stream := ms.GetOSStream()
+	logger.Infof("MachineSet %s is using OS stream %s", ms.GetName(), stream)
+
+	baseImage, err := rhcosHandler.GetBaseImageFromRHCOSImageInfo(imageVersion, stream, architecture, getCurrentRegionOrFail(oc.AsAdmin()))
 	o.Expect(err).NotTo(o.HaveOccurred(), "Error getting the base image")
 	logger.Infof("Using base image %s", baseImage)
 
-	baseImageURL, err := rhcosHandler.GetBaseImageURLFromRHCOSImageInfo(imageVersion, architecture)
+	baseImageURL, err := rhcosHandler.GetBaseImageURLFromRHCOSImageInfo(imageVersion, stream, architecture)
 	o.Expect(err).NotTo(o.HaveOccurred(), "Error getting the base image URL")
 
 	// In vshpere we will upload the image. To avoid collisions we will add prefix to identify our image
@@ -397,17 +400,20 @@ func removeClonedMachineSet(ms *MachineSet, mcp *MachineConfigPool, expectedNumW
 	}
 }
 
-func getRHCOSImagesInfo(version string) (string, error) {
+func getRHCOSImagesInfo(version, stream string) (string, error) {
 	var (
 		err        error
 		resp       *http.Response
 		numRetries = 3
 		retryDelay = time.Minute
-		rhcosURL   = fmt.Sprintf("https://raw.githubusercontent.com/openshift/installer/release-%s/data/data/rhcos.json", version)
+		rhcosURL   = fmt.Sprintf("https://raw.githubusercontent.com/openshift/installer/release-%s/data/data/coreos/coreos-%s.json", version, stream)
 	)
 
-	if CompareVersions(version, ">=", "4.10") {
+	if CompareVersions(version, "<", "4.22") {
 		rhcosURL = fmt.Sprintf("https://raw.githubusercontent.com/openshift/installer/release-%s/data/data/coreos/rhcos.json", version)
+	}
+	if CompareVersions(version, "<", "4.10") {
+		rhcosURL = fmt.Sprintf("https://raw.githubusercontent.com/openshift/installer/release-%s/data/data/rhcos.json", version)
 	}
 
 	// To mitigate network errors we will retry in case of failure
@@ -529,20 +535,20 @@ func GetRHCOSHandler(platform string) (RHCOSHandler, error) {
 }
 
 type RHCOSHandler interface {
-	GetBaseImageFromRHCOSImageInfo(version string, arch architecture.Architecture, region string) (string, error)
-	GetBaseImageURLFromRHCOSImageInfo(version string, arch architecture.Architecture) (string, error)
+	GetBaseImageFromRHCOSImageInfo(version, stream string, arch architecture.Architecture, region string) (string, error)
+	GetBaseImageURLFromRHCOSImageInfo(version, stream string, arch architecture.Architecture) (string, error)
 }
 
 type AWSRHCOSHandler struct{}
 
-func (aws AWSRHCOSHandler) GetBaseImageFromRHCOSImageInfo(version string, arch architecture.Architecture, region string) (string, error) {
+func (aws AWSRHCOSHandler) GetBaseImageFromRHCOSImageInfo(version, stream string, arch architecture.Architecture, region string) (string, error) {
 	var (
 		path       string
 		stringArch = arch.GNUString()
 		platform   = AWSPlatform
 	)
 
-	rhcosImageInfo, err := getRHCOSImagesInfo(version)
+	rhcosImageInfo, err := getRHCOSImagesInfo(version, stream)
 	if err != nil {
 		return "", err
 	}
@@ -567,13 +573,13 @@ func (aws AWSRHCOSHandler) GetBaseImageFromRHCOSImageInfo(version string, arch a
 	return baseImage.String(), nil
 }
 
-func (aws AWSRHCOSHandler) GetBaseImageURLFromRHCOSImageInfo(version string, arch architecture.Architecture) (string, error) {
-	return getBaseImageURLFromRHCOSImageInfo(version, "aws", "vmdk.gz", arch.GNUString())
+func (aws AWSRHCOSHandler) GetBaseImageURLFromRHCOSImageInfo(version, stream string, arch architecture.Architecture) (string, error) {
+	return getBaseImageURLFromRHCOSImageInfo(version, stream, "aws", "vmdk.gz", arch.GNUString())
 }
 
 type GCPRHCOSHandler struct{}
 
-func (gcp GCPRHCOSHandler) GetBaseImageFromRHCOSImageInfo(version string, arch architecture.Architecture, region string) (string, error) {
+func (gcp GCPRHCOSHandler) GetBaseImageFromRHCOSImageInfo(version, stream string, arch architecture.Architecture, region string) (string, error) {
 	var (
 		imagePath   string
 		projectPath string
@@ -585,7 +591,7 @@ func (gcp GCPRHCOSHandler) GetBaseImageFromRHCOSImageInfo(version string, arch a
 		return "", fmt.Errorf("there is no image base image supported for platform %s in version %s", platform, version)
 	}
 
-	rhcosImageInfo, err := getRHCOSImagesInfo(version)
+	rhcosImageInfo, err := getRHCOSImagesInfo(version, stream)
 	if err != nil {
 		return "", err
 	}
@@ -617,14 +623,14 @@ func (gcp GCPRHCOSHandler) GetBaseImageFromRHCOSImageInfo(version string, arch a
 	return fmt.Sprintf("projects/%s/global/images/%s", project.String(), baseImage.String()), nil
 }
 
-func (gcp GCPRHCOSHandler) GetBaseImageURLFromRHCOSImageInfo(version string, arch architecture.Architecture) (string, error) {
-	return getBaseImageURLFromRHCOSImageInfo(version, "gcp", "tar.gz", arch.GNUString())
+func (gcp GCPRHCOSHandler) GetBaseImageURLFromRHCOSImageInfo(version, stream string, arch architecture.Architecture) (string, error) {
+	return getBaseImageURLFromRHCOSImageInfo(version, stream, "gcp", "tar.gz", arch.GNUString())
 }
 
 type VsphereRHCOSHandler struct{}
 
-func (vsp VsphereRHCOSHandler) GetBaseImageFromRHCOSImageInfo(version string, arch architecture.Architecture, _ string) (string, error) {
-	baseImageURL, err := vsp.GetBaseImageURLFromRHCOSImageInfo(version, arch)
+func (vsp VsphereRHCOSHandler) GetBaseImageFromRHCOSImageInfo(version, stream string, arch architecture.Architecture, _ string) (string, error) {
+	baseImageURL, err := vsp.GetBaseImageURLFromRHCOSImageInfo(version, stream, arch)
 	if err != nil {
 		return "", err
 	}
@@ -632,18 +638,18 @@ func (vsp VsphereRHCOSHandler) GetBaseImageFromRHCOSImageInfo(version string, ar
 	return path.Base(baseImageURL), nil
 }
 
-func (vsp VsphereRHCOSHandler) GetBaseImageURLFromRHCOSImageInfo(version string, arch architecture.Architecture) (string, error) {
-	return getBaseImageURLFromRHCOSImageInfo(version, "vmware", "ova", arch.GNUString())
+func (vsp VsphereRHCOSHandler) GetBaseImageURLFromRHCOSImageInfo(version, stream string, arch architecture.Architecture) (string, error) {
+	return getBaseImageURLFromRHCOSImageInfo(version, stream, "vmware", "ova", arch.GNUString())
 }
 
-func getBaseImageURLFromRHCOSImageInfo(version, platform, format, stringArch string) (string, error) {
+func getBaseImageURLFromRHCOSImageInfo(version, stream, platform, format, stringArch string) (string, error) {
 	var (
 		imagePath    string
 		baseURIPath  string
 		olderThan410 = CompareVersions(version, "<", "4.10")
 	)
 
-	rhcosImageInfo, err := getRHCOSImagesInfo(version)
+	rhcosImageInfo, err := getRHCOSImagesInfo(version, stream)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
**- What I did**

Now the rhcos images are not stored in one single rhcos.json file like

[installer/data/data/coreos/rhcos.json at release-4.21 · openshift/installer](https://github.com/openshift/installer/blob/release-4.21/data/data/coreos/rhcos.json) 

From 4.22 on there will be 2 files 

[installer/data/data/coreos/coreos-rhel-9.json at release-4.22 · openshift/installer](https://github.com/openshift/installer/blob/release-4.22/data/data/coreos/coreos-rhel-9.json) 

[installer/data/data/coreos/coreos-rhel-10.json at release-4.22 · openshift/installer](https://github.com/openshift/installer/blob/release-4.22/data/data/coreos/coreos-rhel-10.json)


In this PR we modify the code so that this new scenario is supported.


**- How to verify it**

Bootimages, scale and cpms tests should pass.

Manually create a scale up test using 4.22 version, execute it and check that it passes.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved machine image selection by honoring the configured operating system stream.
  * Added a fallback to the default RHEL 9 image stream when no valid stream is configured.
  * Updated image retrieval for AWS, GCP, and vSphere environments to use the selected stream.
  * Improved compatibility with image data sources across supported platform and release versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->