### PR TITLE
MCO-2205: Make ImageModeStatusReporting MCP count test more resilient on SNO

### DIFF
--- a/pkg/upgrademonitor/upgrade_monitor.go
+++ b/pkg/upgrademonitor/upgrade_monitor.go
@@ -10,8 +10,8 @@ import (
 	machineconfigurationv1 "github.com/openshift/client-go/machineconfiguration/applyconfigurations/machineconfiguration/v1"
 	mcfgclientset "github.com/openshift/client-go/machineconfiguration/clientset/versioned"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/utils/ptr"
 
 	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
@@ -117,7 +117,6 @@ func generateAndApplyMachineConfigNodes(
 			Message:            childCondition.Message,
 			LastTransitionTime: metav1.Now(),
 		}
-
 	}
 	reset := false
 	if newParentCondition.Type == string(mcfgv1.MachineConfigNodeUpdated) {
@@ -533,11 +532,12 @@ func GenerateAndApplyMachineConfigNodeSpec(fgHandler ctrlcommon.FeatureGatesHand
 
 	// Update the existing MCN with the new Spec values or create a new MCN
 	if !needNewMCNode {
-		// No-diff guard: only the three fields below are included in the SSA
-		// payload, so skip the call if they are all unchanged.
+		// No-diff guard: skip the SSA call if all spec fields are unchanged.
 		if mcNode.Spec.Node.Name == newMCNode.Spec.Node.Name &&
 			mcNode.Spec.Pool.Name == newMCNode.Spec.Pool.Name &&
-			mcNode.Spec.ConfigVersion.Desired == newMCNode.Spec.ConfigVersion.Desired {
+			mcNode.Spec.ConfigVersion.Desired == newMCNode.Spec.ConfigVersion.Desired &&
+			(!fgHandler.Enabled(features.FeatureGateImageModeStatusReporting) ||
+				mcNode.Spec.ConfigImage.DesiredImage == newMCNode.Spec.ConfigImage.DesiredImage) {
 			klog.V(4).Infof("MCN spec for node %q is unchanged, skipping SSA apply", node.Name)
 			return nil
 		}
@@ -545,6 +545,10 @@ func GenerateAndApplyMachineConfigNodeSpec(fgHandler ctrlcommon.FeatureGatesHand
 		poolRefApplyConfig := machineconfigurationv1.MCOObjectReference().WithName(newMCNode.Spec.Pool.Name)
 		specconfigVersionApplyConfig := machineconfigurationv1.MachineConfigNodeSpecMachineConfigVersion().WithDesired(newMCNode.Spec.ConfigVersion.Desired)
 		specApplyConfig := machineconfigurationv1.MachineConfigNodeSpec().WithNode(nodeRefApplyConfig).WithPool(poolRefApplyConfig).WithConfigVersion(specconfigVersionApplyConfig)
+		if fgHandler.Enabled(features.FeatureGateImageModeStatusReporting) {
+			configImageApplyConfig := machineconfigurationv1.MachineConfigNodeSpecConfigImage().WithDesiredImage(newMCNode.Spec.ConfigImage.DesiredImage)
+			specApplyConfig = specApplyConfig.WithConfigImage(configImageApplyConfig)
+		}
 		mcnodeApplyConfig := machineconfigurationv1.MachineConfigNode(newMCNode.Name).WithSpec(specApplyConfig)
 		_, err := mcfgClient.MachineconfigurationV1().MachineConfigNodes().Apply(context.TODO(), mcnodeApplyConfig, metav1.ApplyOptions{FieldManager: "machine-config-operator", Force: true})
 		if err != nil {

--- a/test/extended/image_mode_status_reporting.go
+++ b/test/extended/image_mode_status_reporting.go
@@ -2,10 +2,8 @@ package extended
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"path/filepath"
-	"syscall"
 	"time"
 
 	g "github.com/onsi/ginkgo/v2"
@@ -33,9 +31,7 @@ var (
 var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/disruptive][Serial][Disruptive][OCPFeatureGate:ImageModeStatusReporting]", g.Ordered, func() {
 	defer g.GinkgoRecover()
 
-	var (
-		oc = exutil.NewCLI("mco-image-mode-status", exutil.KubeConfigPath()).AsAdmin()
-	)
+	oc := exutil.NewCLI("mco-image-mode-status", exutil.KubeConfigPath()).AsAdmin()
 
 	g.JustBeforeEach(func() {
 		extpriv.PreChecks(oc)
@@ -306,6 +302,10 @@ func runImageModeMCNTestDefaultMCP(oc *exutil.CLI, machineConfigClient *machinec
 	extpriv.ValidateMOSCIsGarbageCollected(mosc, mcp)
 	logger.Infof("OK!\n")
 
+	exutil.By("Waiting for MCP to return to Updated after MOSC removal")
+	WaitForMCPToBeReady(machineConfigClient, mcpAndMoscName, int32(len(mcpNodes)), "", 15*time.Minute)
+	logger.Infof("OK!\n")
+
 	if mcName != "" {
 		exutil.By("Removing the MC")
 		DeleteMCAndWaitForMCPUpdate(oc, machineConfigClient, mcName, mcpAndMoscName, true)
@@ -332,8 +332,6 @@ func validateMCNTransitions(oc *exutil.CLI, machineConfigClient *machineconfigcl
 	logger.Infof("Checking all conditions other than 'Updated' are False.")
 	o.Expect(ConfirmUpdatedMCNStatus(machineConfigClient, nodeToTestName)).Should(o.BeTrue(), "Error, all conditions must be 'False' when Updated=True.")
 	logger.Infof("OK!\n")
-
-	return
 }
 
 // `runMachineCountTest` runs through the general flow of validating machine count transitions in
@@ -406,66 +404,49 @@ func runMachineCountTest(machineConfigClient *machineconfigclient.Clientset, oc 
 // `validateMCPMachineCountTransitions` validates the actual machine counts reported in a MCP's
 // status matches the expected machine counts determined by checking the node annotations of the
 // targeted nodes. This function runs until one of the following termination conditions is met:
-//   - The expected and actual machine counts do not match within a 8 second tolerance window
+//   - The MCP machine counts have not matched the expected counts for longer than the mismatch
+//     deadline of 2 minutes for non-layered clusters and 5 minutes for layered clusters
 //   - The MCP is fully updated
 //   - The overall timeout for this function has been met
 //   - Some other error has occurred in a step of the function
 func validateMCPMachineCountTransitions(machineConfigClient *machineconfigclient.Clientset, oc *exutil.CLI, mcpName string, startTime metav1.Time, mosc *extpriv.MachineOSConfig, layered bool) {
 	timeout := 15 * time.Minute
 	interval := 10 * time.Second
-	loopCount := 3
-	// For on-cluster image mode updates, set the timeout to be longer
+	mismatchDeadline := 2 * time.Minute
 	if layered {
 		logger.Infof("Layered update, setting longer update timeout.")
 		timeout = 45 * time.Minute
 		interval = 30 * time.Second
-		// SNO clusters require a longer time to reconcile due to the MCC restart in
-		// reboot-required updates, so allow for more retries.
-		isSNO, isSNOErr := extpriv.IsSNOSafe(oc)
-		o.Expect(isSNOErr).NotTo(o.HaveOccurred(), fmt.Sprintf("Error checking if cluster is SNO: %v", isSNOErr))
-		if isSNO {
-			logger.Infof("Cluster is SNO, setting higher retry count.")
-			loopCount = 10
-		}
+		mismatchDeadline = 5 * time.Minute
 	}
 
+	var firstMismatchTime time.Time
 	o.Eventually(func() bool {
-		// Check if the MCP machine counts match what is expected from the pool's node annotation
-		// values. Note that there is some latency between when the node annotations are set and
-		// when the MCP machine counts are updates, so we'll try this a few times to make sure we
-		// don't fail just because of unlucky timing.
-		for i := 0; i <= loopCount; i++ {
-			logger.Infof("Checking if the MCP machine counts match the expected values...")
-			countsMatch, isConnErr := mcnAndNodeAnnotationMachineCountsMatch(machineConfigClient, oc, mcpName, mosc)
+		logger.Infof("Checking if the MCP machine counts match the expected values...")
+		countsMatch, isConnErr := mcnAndNodeAnnotationMachineCountsMatch(machineConfigClient, oc, mcpName, mosc)
 
-			// Handle success case
-			if countsMatch {
-				break
-			}
-
-			// Continue to next retry if there is a connection error. Connection errors are common
-			// in SNO suite runs, so we may need additional tries times to get the machine counts.
-			if isConnErr {
-				logger.Infof("Got connection error. Waiting %v seconds then trying again.", interval)
-				return false
-			}
-
-			// Handle case when the counts are not as expected. If we reach this point in the third
-			// itteration, we've exhausted our attempts and are likely seeing a true discrepancy
-			// between the expected and actual machine counts.
-			o.Expect(i).NotTo(o.BeNumerically("==", loopCount), "The actual MCP machine counts did not match the expected machine counts")
-			// If we have not exhausted our attempts, wait a few seconds and check again
-			if i != (loopCount - 1) {
-				logger.Infof("The MCP machine counts did match the expected values.  Waiting %v seconds then trying again.", (i+1)*4)
-				time.Sleep(time.Duration((i+1)*4) * time.Second)
-			}
+		// If we hit a connection error, continue to the next iteration
+		if isConnErr {
+			return false
 		}
 
-		// Check if the MCP is updated
-		// TODO: check if this properly handles the OCL case
+		// Handle the case when counts don't match, which can happen due to latency in MCP syncs
+		if !countsMatch {
+			if firstMismatchTime.IsZero() {
+				firstMismatchTime = time.Now()
+			}
+			elapsed := time.Since(firstMismatchTime)
+			if elapsed > mismatchDeadline {
+				o.StopTrying(fmt.Sprintf("MCP '%v' machine counts do not match expected values.", mcpName)).Now()
+			}
+			logger.Infof("Counts do not match yet. Will retry.")
+			return false
+		}
+
+		// Counts match — reset tracker and check if the MCP update is complete
+		firstMismatchTime = time.Time{}
 		return MCPIsUpdatedToNewConfig(machineConfigClient, mcpName, startTime)
 	}, timeout, interval).Should(o.BeTrue(), "Timed out waiting for MCP '%v' to complete update.", mcpName)
-
 }
 
 // `mcnAndNodeAnnotationMachineCountsMatch` checks whether the updated and degraded machine counts
@@ -474,17 +455,18 @@ func validateMCPMachineCountTransitions(machineConfigClient *machineconfigclient
 // otherwise. The second boolean return is `true`if there was a connection error when trying to get
 // a resource (this allows for resiliency in SNO clsuters).
 func mcnAndNodeAnnotationMachineCountsMatch(machineConfigClient *machineconfigclient.Clientset, oc *exutil.CLI,
-	mcpName string, mosc *extpriv.MachineOSConfig) (countsMatch, isConnErr bool) {
+	mcpName string, mosc *extpriv.MachineOSConfig,
+) (countsMatch, isConnErr bool) {
 	// Get machine counts from MCP
 	mcp, mcpErr := machineConfigClient.MachineconfigurationV1().MachineConfigPools().Get(context.TODO(), mcpName, metav1.GetOptions{})
 	// If we fail to get the MCP, it could be due to a connection error or other infrastructure
 	// instability, so we should log a warning but not error out. This is especially important for SNO.
 	if mcpErr != nil {
-		if errors.Is(mcpErr, syscall.ECONNREFUSED) {
-			logger.Infof("Error connecting to cluster when getting MCP `%v`, will retry.", mcpName)
+		if isTransientConnectionError(mcpErr) {
+			logger.Infof("Transient error getting MCP `%v`, will retry: %v", mcpName, mcpErr)
 			return false, true
 		}
-		logger.Infof("Errored getting MCP `%v`, but not connection err.", mcpName)
+		logger.Infof("Non-transient error getting MCP `%v`: %v", mcpName, mcpErr)
 		return false, false
 	}
 	actualUpdatedCount := mcp.Status.UpdatedMachineCount
@@ -495,11 +477,11 @@ func mcnAndNodeAnnotationMachineCountsMatch(machineConfigClient *machineconfigcl
 	// If we fail to get the nodes, it could be due to a connection error or other infrastructure
 	// instability, so we should log a warning but not error out. This is especially important for SNO.
 	if nodesErr != nil {
-		if errors.Is(nodesErr, syscall.ECONNREFUSED) {
-			logger.Infof("Error getting nodes in MCP `%v`, will retry.", mcpName)
+		if isTransientConnectionError(nodesErr) {
+			logger.Infof("Transient error getting nodes in MCP `%v`, will retry: %v", mcpName, nodesErr)
 			return false, true
 		}
-		logger.Infof("Errored getting nodes in MCP `%v`, but not connection err.", mcpName)
+		logger.Infof("Non-transient error getting nodes in MCP `%v`: %v", mcpName, nodesErr)
 		return false, false
 	}
 	var expectedUpdatedCount int32

--- a/test/extended/machineconfignode.go
+++ b/test/extended/machineconfignode.go
@@ -158,9 +158,12 @@ func isTransientConnectionError(err error) bool {
 // match the desired status (ex. wait until "Updated" is "False"). If the desired condition is
 // "Unknown," the function will also return true if the condition is "True," which ensures that we
 // do not fail when an update progresses quickly through the intermediary "Unknown" phase.
+// Similarly, for reboot and post-action conditions, if the desired status is "True," the function
+// will also return true if the condition has returned to "False," indicating the update completed
+// and conditions were reset before the "True" state could be observed.
 func waitForMCNConditionStatus(machineConfigClient *machineconfigclient.Clientset, mcnName string, conditionType mcfgv1.StateProgress, status metav1.ConditionStatus,
-	timeout time.Duration, interval time.Duration, stopOnTransientError bool) (bool, error) {
-
+	timeout time.Duration, interval time.Duration, stopOnTransientError bool,
+) (bool, error) {
 	conditionMet := false
 	var conditionErr error
 	var workerNodeMCN *mcfgv1.MachineConfigNode
@@ -184,6 +187,15 @@ func waitForMCNConditionStatus(machineConfigClient *machineconfigclient.Clientse
 			conditionMet = checkMCNConditionStatus(workerNodeMCN, conditionType, metav1.ConditionTrue)
 			if conditionMet {
 				logger.Infof("MCN '%v' %v condition was %v, missed transition through %v.", mcnName, conditionType, metav1.ConditionTrue, status)
+			}
+		}
+		// For reboot and post-action conditions, the "True" state can be missed because the
+		// update completes and resets all conditions to "False" before we observe "True."
+		if !conditionMet && status == metav1.ConditionTrue &&
+			(conditionType == mcfgv1.MachineConfigNodeUpdateRebooted || conditionType == mcfgv1.MachineConfigNodeUpdatePostActionComplete) {
+			conditionMet = checkMCNConditionStatus(workerNodeMCN, conditionType, metav1.ConditionFalse)
+			if conditionMet {
+				logger.Infof("MCN '%v' %v condition was %v, missed transition through %v.", mcnName, conditionType, metav1.ConditionFalse, status)
 			}
 		}
 		return conditionMet, nil
@@ -213,7 +225,7 @@ func waitForMCNConditionStatus(machineConfigClient *machineconfigclient.Clientse
 // the test can "miss" catching the phases. For test stability, if we fail to catch an "Unknown"
 // status, a warning will be logged instead of erroring out the test.
 //
-//nolint:dupl // (ijanssen): Ignoring a duplication error the linter is throwing because of two similar, but unique if blocks.
+//nolint:dupl,gocyclo // (ijanssen): Ignoring a duplication error the linter is throwing because of two similar, but unique if blocks.
 func ValidateTransitionThroughConditions(oc *exutil.CLI, machineConfigClient *machineconfigclient.Clientset, updatingNodeName string, isImageMode bool) {
 	// Get the start time of the update
 	updateStartTime := metav1.Now()
@@ -227,12 +239,12 @@ func ValidateTransitionThroughConditions(oc *exutil.CLI, machineConfigClient *ma
 	isSNO, isSNOErr := extpriv.IsSNOSafe(oc)
 	o.Expect(isSNOErr).NotTo(o.HaveOccurred(), fmt.Sprintf("Error checking if cluster is SNO: %v", isSNOErr))
 	if isImageMode {
-		updatingWaitTime = 25 * time.Minute
+		updatingWaitTime = 35 * time.Minute
 		updatingWaitInterval = 5 * time.Second
 	} else if isSNO {
 		// SNO transition times can also be a bit longer due to cluster connection instability, so
 		// set the times for longer in such clusters. (Longer image updates timing takes precedence.)
-		updatingWaitTime = 5 * time.Minute
+		updatingWaitTime = 3 * time.Minute
 		updatingWaitInterval = 5 * time.Second
 	}
 
@@ -276,18 +288,26 @@ func ValidateTransitionThroughConditions(oc *exutil.CLI, machineConfigClient *ma
 	// "ImagePulledFromRegistry" phases
 	if isImageMode {
 		logger.Infof("Waiting for AppliedOSImage=Unknown")
-		conditionMet, err = waitForMCNConditionStatus(machineConfigClient, updatingNodeName, mcfgv1.MachineConfigNodeUpdateOS, metav1.ConditionUnknown, 30*time.Second, 1*time.Second, false)
-		o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occurred while waiting for AppliedOSImage=Unknown: %v", err))
-		o.Expect(conditionMet).To(o.BeTrue(), "Error, could not detect AppliedOSImage=Unknown.")
+		conditionMet, err = waitForMCNConditionStatus(machineConfigClient, updatingNodeName, mcfgv1.MachineConfigNodeUpdateOS, metav1.ConditionUnknown, 30*time.Second, 1*time.Second, isSNO)
+		if isSNO && isTransientConnectionError(err) {
+			logger.Infof("Warning, got connection error detecting AppliedOSImage=Unknown. The node likely started rebooting.")
+		} else {
+			o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occurred while waiting for AppliedOSImage=Unknown: %v", err))
+			o.Expect(conditionMet).To(o.BeTrue(), "Error, could not detect AppliedOSImage=Unknown.")
+		}
 
 		logger.Infof("Waiting for ImagePulledFromRegistry=Unknown")
 		timeout := 30 * time.Second
 		if isSNO {
 			timeout = 1 * time.Minute
 		}
-		conditionMet, err = waitForMCNConditionStatus(machineConfigClient, updatingNodeName, mcfgv1.MachineConfigNodeImagePulledFromRegistry, metav1.ConditionUnknown, timeout, 1*time.Second, false)
-		o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occurred while waiting for ImagePulledFromRegistry=Unknown: %v", err))
-		o.Expect(conditionMet).To(o.BeTrue(), "Error, could not detect ImagePulledFromRegistry=Unknown.")
+		conditionMet, err = waitForMCNConditionStatus(machineConfigClient, updatingNodeName, mcfgv1.MachineConfigNodeImagePulledFromRegistry, metav1.ConditionUnknown, timeout, 1*time.Second, isSNO)
+		if isSNO && isTransientConnectionError(err) {
+			logger.Infof("Warning, got connection error detecting ImagePulledFromRegistry=Unknown. The node likely started rebooting.")
+		} else {
+			o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occurred while waiting for ImagePulledFromRegistry=Unknown: %v", err))
+			o.Expect(conditionMet).To(o.BeTrue(), "Error, could not detect ImagePulledFromRegistry=Unknown.")
+		}
 
 		logger.Infof("Waiting for AppliedOSImage=True")
 		conditionMet, err = waitForMCNConditionStatus(machineConfigClient, updatingNodeName, mcfgv1.MachineConfigNodeUpdateOS, metav1.ConditionTrue, 4*time.Minute, 2*time.Second, true)
@@ -357,36 +377,59 @@ func ValidateTransitionThroughConditions(oc *exutil.CLI, machineConfigClient *ma
 
 		logger.Infof("Waiting for RebootedNode=True")
 		conditionMet, err = waitForMCNConditionStatus(machineConfigClient, updatingNodeName, mcfgv1.MachineConfigNodeUpdateRebooted, metav1.ConditionTrue, 15*time.Minute, 1*time.Second, false)
-		o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occurred while waiting for RebootedNode=True: %v", err))
-		o.Expect(conditionMet).To(o.BeTrue(), "Error, could not detect RebootedNode=True.")
+		if isSNO && isTransientConnectionError(err) {
+			logger.Infof("Warning, got connection error detecting RebootedNode=True. The node likely rebooted.")
+		} else {
+			o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occurred while waiting for RebootedNode=True: %v", err))
+			o.Expect(conditionMet).To(o.BeTrue(), "Error, could not detect RebootedNode=True.")
+		}
 	}
 
-	// The final steps of the update happen quickly, so sometimes we can miss the final condition
-	// transitions. If we do, we will not error out, but record that the condition was missed.
-	logger.Infof("Waiting for Resumed=True")
-	timeout := 45 * time.Second
-	if isSNO {
-		timeout = 3 * time.Minute
+	// If the reboot/post-action condition is already back to False, the update completed and
+	// all conditions were reset before we could observe the intermediate states (Resumed,
+	// UpdateComplete, Uncordoned). Skip those checks — they would just timeout on False.
+	updateAlreadyCompleted := false
+	var postActionCondition mcfgv1.StateProgress
+	if isImageMode {
+		postActionCondition = mcfgv1.MachineConfigNodeUpdateRebooted
+	} else {
+		postActionCondition = mcfgv1.MachineConfigNodeUpdatePostActionComplete
 	}
-	conditionMet, err = waitForMCNConditionStatus(machineConfigClient, updatingNodeName, mcfgv1.MachineConfigNodeResumed, metav1.ConditionTrue, timeout, 1*time.Second, false)
-	o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occurred while waiting for Resumed=True: %v", err))
-	if !conditionMet {
-		logger.Infof("Warning, could not detect Resumed=True.")
+	postActionMCN, postActionErr := machineConfigClient.MachineconfigurationV1().MachineConfigNodes().Get(context.TODO(), updatingNodeName, metav1.GetOptions{})
+	if postActionErr == nil && checkMCNConditionStatus(postActionMCN, postActionCondition, metav1.ConditionFalse) {
+		updateAlreadyCompleted = true
+		logger.Infof("%v is already False — the update completed and conditions were reset. Skipping intermediate condition checks.", postActionCondition)
 	}
-	// Only nodes that cordon and drain go through the "UpdateComplete" and "Uncordoned" stages, so
-	// skip these checks for standard, non-rebootless (non-image based), updates and in SNO clusters.
-	if isImageMode && !isSNO {
-		logger.Infof("Waiting for UpdateComplete=True")
-		conditionMet, err = waitForMCNConditionStatus(machineConfigClient, updatingNodeName, mcfgv1.MachineConfigNodeUpdateComplete, metav1.ConditionTrue, 10*time.Second, 1*time.Second, false)
-		o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occurred while waiting for UpdateComplete=True: %v", err))
-		if !conditionMet {
-			logger.Infof("Warning, could not detect UpdateComplete=True.")
+
+	var timeout time.Duration
+	if !updateAlreadyCompleted {
+		// The final steps of the update happen quickly, so sometimes we can miss the final condition
+		// transitions. If we do, we will not error out, but record that the condition was missed.
+		logger.Infof("Waiting for Resumed=True")
+		timeout = 45 * time.Second
+		if isSNO {
+			timeout = 3 * time.Minute
 		}
-		logger.Infof("Waiting for Uncordoned=True")
-		conditionMet, err = waitForMCNConditionStatus(machineConfigClient, updatingNodeName, mcfgv1.MachineConfigNodeUpdateUncordoned, metav1.ConditionTrue, 10*time.Second, 1*time.Second, false)
-		o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occurred while waiting for Uncordoned=True: %v", err))
+		conditionMet, err = waitForMCNConditionStatus(machineConfigClient, updatingNodeName, mcfgv1.MachineConfigNodeResumed, metav1.ConditionTrue, timeout, 1*time.Second, false)
+		o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occurred while waiting for Resumed=True: %v", err))
 		if !conditionMet {
-			logger.Infof("Warning, could not detect Uncordoned=True.")
+			logger.Infof("Warning, could not detect Resumed=True.")
+		}
+		// Only nodes that cordon and drain go through the "UpdateComplete" and "Uncordoned" stages, so
+		// skip these checks for standard, non-rebootless (non-image based), updates and in SNO clusters.
+		if isImageMode && !isSNO {
+			logger.Infof("Waiting for UpdateComplete=True")
+			conditionMet, err = waitForMCNConditionStatus(machineConfigClient, updatingNodeName, mcfgv1.MachineConfigNodeUpdateComplete, metav1.ConditionTrue, 10*time.Second, 1*time.Second, false)
+			o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occurred while waiting for UpdateComplete=True: %v", err))
+			if !conditionMet {
+				logger.Infof("Warning, could not detect UpdateComplete=True.")
+			}
+			logger.Infof("Waiting for Uncordoned=True")
+			conditionMet, err = waitForMCNConditionStatus(machineConfigClient, updatingNodeName, mcfgv1.MachineConfigNodeUpdateUncordoned, metav1.ConditionTrue, 10*time.Second, 1*time.Second, false)
+			o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occurred while waiting for Uncordoned=True: %v", err))
+			if !conditionMet {
+				logger.Infof("Warning, could not detect Uncordoned=True.")
+			}
 		}
 	}
 

--- a/test/extended/machineconfigpool.go
+++ b/test/extended/machineconfigpool.go
@@ -44,8 +44,16 @@ func WaitForMCPToBeReady(machineConfigClient *machineconfigclient.Clientset, poo
 			logger.Infof("MCP '%v' has the desired %v ready machines.", poolName, mcp.Status.UpdatedMachineCount)
 			// If an old rendered MC has been provided, make sure the MCP has been updated to a new rendered MC
 			if oldRenderedMC != "" {
-				// If the MC in the MCP is not equal to the old rendered MC, it meas we have updated to a new MC
+				// If the MC in the MCP is not equal to the old rendered MC, it means we have updated to a new MC
 				if mcp.Spec.Configuration.Name != oldRenderedMC {
+					// Guard against a stale Updated=True from the previous update cycle: verify
+					// that the new rendered config has actually been applied to all nodes by
+					// checking that spec and status configs match.
+					if mcp.Spec.Configuration.Name != mcp.Status.Configuration.Name {
+						logger.Infof("MCP '%v' has a new rendered MC (%v) but it has not been applied yet (status: %v). Waiting for the update to complete.",
+							poolName, mcp.Spec.Configuration.Name, mcp.Status.Configuration.Name)
+						return false
+					}
 					logger.Infof("MCP '%v' has updated to a new rendered MC: %v.", poolName, mcp.Spec.Configuration.Name)
 					return true
 				}


### PR DESCRIPTION
**- What I did**
This adds some resiliency to the ImageModeStatusReporting test to help prevent against flakes as seen in https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-machine-config-operator-release-5.0-periodics-e2e-aws-mco-single-node-disruptive-techpreview-3of3/2075276858378686464.

**- How to verify it**
All ImageModeStatusReporting tests should continue passing in the non-SNO suite and start consistently passing in the SNO suite.

**- Description for the changelog**
[MCO-2205](https://redhat.atlassian.net/browse/MCO-2205): Make ImageModeStatusReporting MCP count test more resilient on SNO

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `Topology:<name>` label filtering for extension test selection (in addition to existing platform include/exclude filters).
* **Tests**
  * Improved machine-count transition validation using deadline-based retries (with different time budgets for layered vs non-layered).
  * Reduced flaky failures when reading MCP/node machine counts by classifying transient connection issues as retryable.
  * Hardened MCP readiness checks to ensure status has caught up after rendered configuration changes.
  * Improved test stability by skipping earlier when the cluster API is unreachable and guarding cleanup when setup is skipped.
  * Simplified and adjusted several test setups for more reliable initialization and teardown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->