### PR TITLE
OCPBUGS-98745: MCO-2424: add missing RBAC for pkis resource in MCC ClusterRole

### DIFF
--- a/manifests/machineconfigcontroller/clusterrole.yaml
+++ b/manifests/machineconfigcontroller/clusterrole.yaml
@@ -16,7 +16,7 @@ rules:
   resources: ["secrets"]
   verbs: ["get", "list", "watch", "create", "update", "delete"]
 - apiGroups: ["config.openshift.io"]
-  resources: ["images", "clusterversions", "featuregates", "nodes", "schedulers", "apiservers", "infrastructures", "imagedigestmirrorsets", "imagetagmirrorsets", "clusterimagepolicies", "imagepolicies", "criocredentialproviderconfigs"]
+  resources: ["images", "clusterversions", "featuregates", "nodes", "schedulers", "apiservers", "infrastructures", "imagedigestmirrorsets", "imagetagmirrorsets", "clusterimagepolicies", "imagepolicies", "criocredentialproviderconfigs", "pkis"]
   verbs: ["get", "list", "watch"]
 - apiGroups: ["config.openshift.io"]
   resources: ["imagepolicies/status", "criocredentialproviderconfigs/status"]


### PR DESCRIPTION
machine-config-controller ClusterRole is missing get, list, watch permissions for the pkis resource in the config.openshift.io API group.
controller logs
```

E0714 19:57:17.870954       1 reflector.go:204] "Failed to watch" err="failed to list *v1alpha1.PKI: [pkis.config.openshift.io](http://pkis.config.openshift.io/) is forbidden: User \"system:serviceaccount:openshift-machine-config-operator:machine-config-controller\" cannot list resource \"pkis\" in API group \"[config.openshift.io](http://config.openshift.io/)\" at the cluster scope" reflector="http://github.com/openshift/client-go/config/informers/externalversions/factory.go:126 " type="*v1alpha1.PKI"
```
Compared this where it was getting failed on nightly build 
https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-machine-config-operator-release-5.0-periodics-e2e-vsphere-mco-tp-longduration-1of2/2076949317708419072

https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-machine-config-operator-release-5.0-periodics-e2e-vsphere-mco-tp-longduration-1of2/2075463456202428416



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved access to additional cluster configuration resources, supporting more reliable configuration monitoring and management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->