### PR TITLE
MCO-2424: Fix cert rotation timeout

### DIFF
--- a/test/extended-priv/secret.go
+++ b/test/extended-priv/secret.go
@@ -174,7 +174,7 @@ func rotateTLSSecretOrFail(secret *Secret) string {
 		"The secret %s could not be patched in order to rotate the certificate", secret)
 
 	logger.Infof("Wait for certificate rotation")
-	o.Eventually(secret.GetDataValueOrFail, "3m", "20s").WithArguments("tls.crt").
+	o.Eventually(secret.GetDataValueOrFail, "5m", "20s").WithArguments("tls.crt").
 		ShouldNot(exutil.Secure(o.Equal(initialCert)),
 			"The certificate was not rotated in %s", secret)
 


### PR DESCRIPTION
In Failing runs, the controller took ~3m05s to rotate (the events fired 5 seconds after the 3m timeout)
