### PR TITLE
OCPBUGS-86429: Unpin libreswan and add 5.x compat for IPsec scaling fix

### DIFF
--- a/templates/common/_base/files/wait-for-ipsec-connect.yaml
+++ b/templates/common/_base/files/wait-for-ipsec-connect.yaml
@@ -9,15 +9,18 @@ contents:
       exit 0
     fi
 
-    # Modify existing IPsec connection entries with "auto=start"
+    # Modify existing IPsec out connection entries with "auto=start"
     # option and restart ipsec systemd service. This helps to
     # establish IKE SAs for the existing IPsec connections with
     # peer nodes. This option will be deleted from connections
     # once ovs-monitor-ipsec process spinned up on the node by
     # ovn-ipsec-host pod, but still it won't reestablish IKE SAs
     # again with peer nodes, so it shouldn't be a problem.
+    # We are updating only out connections with "auto=start" to
+    # avoid cross stream issue with Libreswan 5.2.
+    # The in connections use default auto=route parameter.
     if ! grep -q "auto=start" /etc/ipsec.d/openshift.conf; then
-      sed -i '/^.*conn ovn.*$/a\    auto=start' /etc/ipsec.d/openshift.conf
+      sed -i '/^.*conn ovn.*-out-1$/a\    auto=start' /etc/ipsec.d/openshift.conf
     fi
     chroot /proc/1/root ipsec restart
 

--- a/templates/common/_base/files/wait-for-ipsec-connect.yaml
+++ b/templates/common/_base/files/wait-for-ipsec-connect.yaml
@@ -28,7 +28,7 @@ contents:
     establishedsa=""
     while [[ $elapsed -lt $timeout ]]; do
       desiredconn=$(grep -E '^\s*conn\s+' /etc/ipsec.d/openshift.conf | grep -v '%default' | awk '{print $2}' | tr ' ' '\n' | sort | tr '\n' ' ')
-      establishedsa=$(ipsec showstates | grep STATE_V2_ESTABLISHED_CHILD_SA | grep -o '"[^"]*"' | sed 's/"//g' | tr ' ' '\n' | sort | uniq | tr '\n' ' ')
+      establishedsa=$(ipsec showstates | grep ESTABLISHED_CHILD_SA | grep -o '"[^"]*"' | sed 's/"//g' | tr ' ' '\n' | sort | uniq | tr '\n' ' ')
       if [ "$desiredconn" == "$establishedsa" ]; then
         echo "IPsec SAs are established for desired connections after ${elapsed}s"
         break

--- a/templates/common/_base/files/wait-for-ipsec-connect.yaml
+++ b/templates/common/_base/files/wait-for-ipsec-connect.yaml
@@ -9,15 +9,18 @@ contents:
       exit 0
     fi
 
-    # Modify existing IPsec connection entries with "auto=start"
+    # Modify existing IPsec out connection entries with "auto=start"
     # option and restart ipsec systemd service. This helps to
     # establish IKE SAs for the existing IPsec connections with
     # peer nodes. This option will be deleted from connections
     # once ovs-monitor-ipsec process spinned up on the node by
     # ovn-ipsec-host pod, but still it won't reestablish IKE SAs
     # again with peer nodes, so it shouldn't be a problem.
+    # We are updating only out connections with "auto=start" to
+    # avoid cross stream issue with Libreswan 5.2.
+    # The in connections use default auto=route parameter.
     if ! grep -q "auto=start" /etc/ipsec.d/openshift.conf; then
-      sed -i '/^.*conn ovn.*$/a\    auto=start' /etc/ipsec.d/openshift.conf
+      sed -i '/^.*conn ovn.*-out-1$/a\    auto=start' /etc/ipsec.d/openshift.conf
     fi
     chroot /proc/1/root ipsec restart
 
@@ -28,7 +31,7 @@ contents:
     establishedsa=""
     while [[ $elapsed -lt $timeout ]]; do
       desiredconn=$(grep -E '^\s*conn\s+' /etc/ipsec.d/openshift.conf | grep -v '%default' | awk '{print $2}' | tr ' ' '\n' | sort | tr '\n' ' ')
-      establishedsa=$(ipsec showstates | grep STATE_V2_ESTABLISHED_CHILD_SA | grep -o '"[^"]*"' | sed 's/"//g' | tr ' ' '\n' | sort | uniq | tr '\n' ' ')
+      establishedsa=$(ipsec showstates | grep ESTABLISHED_CHILD_SA | grep -o '"[^"]*"' | sed 's/"//g' | tr ' ' '\n' | sort | uniq | tr '\n' ' ')
       if [ "$desiredconn" == "$establishedsa" ]; then
         echo "IPsec SAs are established for desired connections after ${elapsed}s"
         break


### PR DESCRIPTION
## Summary
Backport libreswan 5.x compatibility changes to 4.18 to support unpinning libreswan from 4.6 to 5.x, mitigating IPsec scaling issues at 75+ node clusters.

Combines two changes already merged on main/4.19:
- **#4959** ([CORENET-5524](https://redhat.atlassian.net/browse/CORENET-5524)): Update `ipsec showstates` regex from `STATE_V2_ESTABLISHED_CHILD_SA` to `ESTABLISHED_CHILD_SA` — libreswan 5.2 changed the state name format, shorter pattern is backward compatible with 4.x
- **#5035** (OCPBUGS-55809): Use `auto=start` only for IPsec out connections (`-out-1` suffix) to avoid cross-stream issue with libreswan 5.2. In connections use default `auto=route`

## Background
At 75+ node IPsec mesh scale, libreswan 4.6 pluto crashes with a segfault in `set_larval_v2_transition()` during concurrent Child SA negotiation, causing permanent tunnel failures. Libreswan 5.x fixes this. This PR is part of a set that unpins libreswan in 4.18.z:
- openshift/os: unpin libreswan in RHCOS extensions
- **openshift/machine-config-operator: this PR**
- openshift/cluster-network-operator: skip `_stackmanager` for libreswan 5.3+
- openshift/ovn-kubernetes: unpin libreswan in Dockerfile