### PR TITLE
NO-JIRA: Update MCO clusterrole for pkis resource

### DIFF
--- a/manifests/machineconfigcontroller/clusterrole.yaml
+++ b/manifests/machineconfigcontroller/clusterrole.yaml
@@ -16,7 +16,7 @@ rules:
   resources: ["secrets"]
   verbs: ["get", "list", "watch", "create", "update", "delete"]
 - apiGroups: ["config.openshift.io"]
-  resources: ["images", "clusterversions", "featuregates", "nodes", "schedulers", "apiservers", "infrastructures", "imagedigestmirrorsets", "imagetagmirrorsets", "clusterimagepolicies", "imagepolicies", "criocredentialproviderconfigs"]
+  resources: ["images", "clusterversions", "featuregates", "nodes", "schedulers", "apiservers", "infrastructures", "imagedigestmirrorsets", "imagetagmirrorsets", "clusterimagepolicies", "imagepolicies", "criocredentialproviderconfigs", "pkis"]
   verbs: ["get", "list", "watch"]
 - apiGroups: ["config.openshift.io"]
   resources: ["imagepolicies/status", "criocredentialproviderconfigs/status"]


### PR DESCRIPTION
Regeneration of certificate was blocked due to missing resource pkis in clusterrole

**- What I did**
I add a newly added pkis resource in clusterrole so that this can work on that resource

**- How to verify it**
Regenerate the machine-config-server-tls with new pki config, it will regenerate the certificate successfully 

**- Description for the changelog**
<!--
pkis resource is added to provide custom key size and algorithm to generate the certs with different key size and algorithms. while regenerating the certificate machine-config-server-tls , it was observed that regeneration failed to missing resource listing in clusterrole which is added now
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded cluster configuration permissions to support additional image, credential provider, and PKI resource types.
  * Improves compatibility with configurations that use these resource categories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->