### PR TITLE
MCO-1814, MCO-2377: Setup metrics for builds, Add metric to gather how many people are using OCL

### DIFF
--- a/cmd/machine-os-builder/start.go
+++ b/cmd/machine-os-builder/start.go
@@ -25,13 +25,19 @@ var (
 	}
 
 	startOpts struct {
-		kubeconfig string
+		kubeconfig               string
+		promMetricsListenAddress string
+		tlsCipherSuites          []string
+		tlsMinVersion            string
 	}
 )
 
 func init() {
 	rootCmd.AddCommand(startCmd)
 	startCmd.PersistentFlags().StringVar(&startOpts.kubeconfig, "kubeconfig", "", "Kubeconfig file to access a remote cluster (testing only)")
+	startCmd.PersistentFlags().StringVar(&startOpts.promMetricsListenAddress, "metrics-listen-address", "127.0.0.1:8797", "Listen address for prometheus metrics listener")
+	startCmd.PersistentFlags().StringSliceVar(&startOpts.tlsCipherSuites, "tls-cipher-suites", nil, "Comma-separated list of cipher suites for the metrics server")
+	startCmd.PersistentFlags().StringVar(&startOpts.tlsMinVersion, "tls-min-version", "VersionTLS12", "Minimum TLS version supported for the metrics server")
 }
 
 func runStartCmd(_ *cobra.Command, _ []string) {
@@ -60,6 +66,9 @@ func runStartCmd(_ *cobra.Command, _ []string) {
 		go common.SignalHandler(cancel)
 
 		ctrlCtx := ctrlcommon.CreateControllerContext(ctx, cb)
+
+		// Start the metrics listener for OCL telemetry
+		go ctrlcommon.StartMetricsListener(startOpts.promMetricsListenAddress, ctrlCtx.Stop, build.RegisterOCLMetrics, startOpts.tlsMinVersion, startOpts.tlsCipherSuites)
 
 		ctrl := build.NewOSBuildControllerFromControllerContext(ctrlCtx)
 

--- a/install/0000_90_machine-config_01_prometheus-rules.yaml
+++ b/install/0000_90_machine-config_01_prometheus-rules.yaml
@@ -65,7 +65,46 @@ spec:
             severity: info
           annotations:
             summary: "Boot image skew enforcement is disabled. Scaling operations may not be successful."
-            description: "Boot image skew enforcement mode is set to None. When scaling up, new nodes may be provisioned with older boot images that could introduce compatibility issues. Consider manually updating boot images to match the cluster version. Please refer to docs at https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/machine_configuration/mco-update-boot-skew-mgmt for additional details."            
+            description: "Boot image skew enforcement mode is set to None. When scaling up, new nodes may be provisioned with older boot images that could introduce compatibility issues. Consider manually updating boot images to match the cluster version. Please refer to docs at https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/machine_configuration/mco-update-boot-skew-mgmt for additional details."
+    - name: ocl-build-failure
+      rules:
+        - alert: OCLBuildFailed
+          expr: |
+            increase(ocl_build_total{state="failed"}[5m]) > 0
+          for: 10m
+          labels:
+            namespace: openshift-machine-config-operator
+            severity: warning
+          annotations:
+            summary: "On-Cluster Layering build failed for pool {{ $labels.pool }}"
+            description: "An OCL image build has failed for MachineConfigPool {{ $labels.pool }}. Nodes in this pool will not receive updated layered images until the build succeeds. Check the machine-os-builder pod logs for details."
+            runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/machine-config-operator/OCLBuildFailed.md
+    - name: ocl-build-degraded
+      rules:
+        - alert: OCLBuildDegraded
+          expr: |
+            ocl_build_state{state="failed"} == 1
+          for: 10m
+          labels:
+            namespace: openshift-machine-config-operator
+            severity: warning
+          annotations:
+            summary: "On-Cluster Layering build is degraded for pool {{ $labels.pool }}"
+            description: "OCL build {{ $labels.build_name }} for MachineConfigPool {{ $labels.pool }} is in a persistent failed state. Check the MachineOSBuild {{ $labels.build_name }} status conditions and machine-os-builder pod logs."
+            runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/machine-config-operator/OCLBuildDegraded.md
+    - name: ocl-image-push-failure
+      rules:
+        - alert: OCLImagePushFailed
+          expr: |
+            increase(ocl_image_push_total{state="failed"}[5m]) > 0
+          for: 10m
+          labels:
+            namespace: openshift-machine-config-operator
+            severity: warning
+          annotations:
+            summary: "On-Cluster Layering image push failed for pool {{ $labels.pool }}"
+            description: "An OCL image push failed for MachineConfigPool {{ $labels.pool }}. The build job completed but the image was not pushed to the registry. Check registry credentials and machine-os-builder pod logs."
+            runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/machine-config-operator/OCLImagePushFailed.md
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule

--- a/install/0000_90_machine-config_01_prometheus-rules.yaml
+++ b/install/0000_90_machine-config_01_prometheus-rules.yaml
@@ -71,7 +71,7 @@ spec:
         - alert: OCLBuildFailed
           expr: |
             increase(ocl_build_total{state="failed"}[5m]) > 0
-          for: 10m
+          for: 1m
           labels:
             namespace: openshift-machine-config-operator
             severity: warning
@@ -90,7 +90,7 @@ spec:
             severity: warning
           annotations:
             summary: "On-Cluster Layering build is degraded for pool {{ $labels.pool }}"
-            description: "OCL build {{ $labels.build_name }} for MachineConfigPool {{ $labels.pool }} is in a persistent failed state. Check the MachineOSBuild {{ $labels.build_name }} status conditions and machine-os-builder pod logs."
+            description: "OCL build for MachineConfigPool {{ $labels.pool }} is in a persistent failed state. Check the MachineOSBuild status conditions and machine-os-builder pod logs."
             runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/machine-config-operator/OCLBuildDegraded.md
     - name: ocl-image-push-failure
       rules:

--- a/install/0000_90_machine-config_01_prometheus-rules.yaml
+++ b/install/0000_90_machine-config_01_prometheus-rules.yaml
@@ -15,6 +15,10 @@ spec:
       rules:
         - expr: sum(os_image_url_override)
           record: os_image_url_override:sum
+    - name: ocl-adoption.rules
+      rules:
+        - expr: mco_mosc_count
+          record: mco_mosc_count:sum
     - name: runc-deprecated
       rules:
         - alert: RuncDeprecated

--- a/pkg/controller/build/ocl_metrics.go
+++ b/pkg/controller/build/ocl_metrics.go
@@ -1,0 +1,309 @@
+package build
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// pushStartTimes stores the time each image push began, keyed by "pool/buildName".
+// Used to compute push duration across separate AddJob and UpdateJob reconciler events.
+var pushStartTimes sync.Map
+
+// OCL Build Metrics for tracking On-Cluster Layering processes
+var (
+	// oclBuildState tracks the current state of OCL builds per pool
+	oclBuildState = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "ocl_build_state",
+			Help: "Current state of OCL build for a pool; gauge is 1 for the active state label, 0 otherwise",
+		}, []string{"pool", "state"})
+
+	// oclBuildDuration tracks how long OCL builds take to complete
+	oclBuildDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "ocl_build_duration_seconds",
+			Help:    "Duration of OCL build processes in seconds",
+			Buckets: []float64{60, 180, 300, 600, 900, 1200, 1800, 2400, 3000, 3600}, // 1m to 1h
+		}, []string{"pool", "state"})
+
+	// oclBuildStartTime tracks when a build started
+	oclBuildStartTime = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "ocl_build_start_timestamp_seconds",
+			Help: "Timestamp when OCL build started",
+		}, []string{"pool"})
+
+	// oclBuildEndTime tracks when a build completed/failed
+	oclBuildEndTime = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "ocl_build_end_timestamp_seconds",
+			Help: "Timestamp when OCL build completed or failed",
+		}, []string{"pool", "state"})
+
+	// oclBuildTotal counts total number of builds by state
+	oclBuildTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "ocl_build_total",
+			Help: "Total number of OCL builds by final state",
+		}, []string{"pool", "state"})
+
+	// oclBuildJobState tracks the state of build jobs
+	oclBuildJobState = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "ocl_build_job_state",
+			Help: "State of OCL build job; gauge is 1 for the active state label, 0 otherwise",
+		}, []string{"pool", "state"})
+
+	// oclConfigChangeTotal counts config changes triggering builds
+	oclConfigChangeTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "ocl_config_change_total",
+			Help: "Total number of config changes triggering OCL builds",
+		}, []string{"pool"})
+
+	// oclBuildRetries tracks build retry attempts
+	oclBuildRetries = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "ocl_build_retries_total",
+			Help: "Total number of OCL build retry attempts",
+		}, []string{"pool"})
+
+	// oclLayeredNodesCount tracks number of nodes using layered images
+	oclLayeredNodesCount = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "ocl_layered_nodes_count",
+			Help: "Number of nodes currently using OCL layered images",
+		}, []string{"pool"})
+
+	// oclImagePushState tracks the state of image push operations
+	oclImagePushState = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "ocl_image_push_state",
+			Help: "State of OCL image push operations; gauge is 1 for the active state label, 0 otherwise",
+		}, []string{"pool", "state"})
+
+	// oclImagePushTotal counts total image push attempts by final state
+	oclImagePushTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "ocl_image_push_total",
+			Help: "Total number of OCL image push operations by final state",
+		}, []string{"pool", "state"})
+
+	// oclRolloutUpdatedNodes tracks how many nodes have adopted the current layered image
+	oclRolloutUpdatedNodes = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "ocl_rollout_updated_nodes",
+			Help: "Number of nodes in an OCL pool that have adopted the current layered image",
+		}, []string{"pool"})
+
+	// oclRolloutTotalNodes tracks total node count in an OCL pool
+	oclRolloutTotalNodes = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "ocl_rollout_total_nodes",
+			Help: "Total number of nodes in an OCL pool",
+		}, []string{"pool"})
+
+	// oclBuildQueueDuration tracks time between build creation and job going active
+	oclBuildQueueDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "ocl_build_queue_duration_seconds",
+			Help:    "Time in seconds between OCL build creation and the build job becoming active",
+			Buckets: []float64{5, 15, 30, 60, 120, 300, 600},
+		}, []string{"pool"})
+
+	// oclImagePushDuration tracks how long image push operations take
+	oclImagePushDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "ocl_image_push_duration_seconds",
+			Help:    "Duration of OCL image push operations in seconds",
+			Buckets: []float64{10, 30, 60, 120, 180, 300, 600},
+		}, []string{"pool", "state"})
+
+	// oclActiveBuilds tracks the number of builds currently in progress per pool
+	oclActiveBuilds = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "ocl_active_builds",
+			Help: "Number of OCL builds currently in progress per pool",
+		}, []string{"pool"})
+)
+
+// Build state constants for consistent labeling
+const (
+	StateNone        = "none"
+	StatePending     = "pending"
+	StateBuilding    = "building"
+	StateSucceeded   = "succeeded"
+	StateFailed      = "failed"
+	StateInterrupted = "interrupted"
+	StatePushing     = "pushing"
+)
+
+// RegisterOCLMetrics registers all OCL-related Prometheus metrics
+func RegisterOCLMetrics() error {
+	err := ctrlcommon.RegisterMetrics([]prometheus.Collector{
+		oclBuildState,
+		oclBuildDuration,
+		oclBuildStartTime,
+		oclBuildEndTime,
+		oclBuildTotal,
+		oclBuildJobState,
+		oclConfigChangeTotal,
+		oclBuildRetries,
+		oclLayeredNodesCount,
+		oclImagePushState,
+		oclImagePushTotal,
+		oclRolloutUpdatedNodes,
+		oclRolloutTotalNodes,
+		oclBuildQueueDuration,
+		oclImagePushDuration,
+		oclActiveBuilds,
+	})
+
+	if err != nil {
+		return fmt.Errorf("could not register OCL metrics: %w", err)
+	}
+
+	// Initialize GaugeVecs to ensure metrics are accessible even without values
+	oclBuildState.WithLabelValues("init", StateNone).Set(0)
+	oclBuildJobState.WithLabelValues("init", StateNone).Set(0)
+	oclLayeredNodesCount.WithLabelValues("init").Set(0)
+	oclImagePushState.WithLabelValues("init", StateNone).Set(0)
+	oclRolloutUpdatedNodes.WithLabelValues("init").Set(0)
+	oclRolloutTotalNodes.WithLabelValues("init").Set(0)
+	oclActiveBuilds.WithLabelValues("init").Set(0)
+
+	return nil
+}
+
+// RecordBuildStarted records when a build starts
+func RecordBuildStarted(pool string) {
+	now := float64(time.Now().Unix())
+
+	// Clear previous states for this pool
+	oclBuildState.DeletePartialMatch(prometheus.Labels{"pool": pool})
+
+	// Set new state
+	oclBuildState.WithLabelValues(pool, StatePending).Set(1)
+	oclBuildStartTime.WithLabelValues(pool).Set(now)
+	oclActiveBuilds.WithLabelValues(pool).Inc()
+}
+
+// RecordBuildBuilding records when a build transitions to building state
+func RecordBuildBuilding(pool string) {
+	// Clear pending state
+	oclBuildState.DeletePartialMatch(prometheus.Labels{"pool": pool})
+
+	// Set building state
+	oclBuildState.WithLabelValues(pool, StateBuilding).Set(1)
+}
+
+// RecordBuildCompleted records when a build completes successfully
+func RecordBuildCompleted(pool string, startTime time.Time) {
+	now := time.Now()
+	duration := now.Sub(startTime).Seconds()
+
+	// Clear previous states
+	oclBuildState.DeletePartialMatch(prometheus.Labels{"pool": pool})
+	pushStartTimes.Delete(pool)
+
+	// Set succeeded state
+	oclBuildState.WithLabelValues(pool, StateSucceeded).Set(1)
+	oclBuildEndTime.WithLabelValues(pool, StateSucceeded).Set(float64(now.Unix()))
+	oclBuildDuration.WithLabelValues(pool, StateSucceeded).Observe(duration)
+	oclBuildTotal.WithLabelValues(pool, StateSucceeded).Inc()
+	oclActiveBuilds.WithLabelValues(pool).Dec()
+}
+
+// RecordBuildFailed records when a build fails
+func RecordBuildFailed(pool string, startTime time.Time) {
+	now := time.Now()
+	duration := now.Sub(startTime).Seconds()
+
+	// Clear previous states
+	oclBuildState.DeletePartialMatch(prometheus.Labels{"pool": pool})
+	pushStartTimes.Delete(pool)
+
+	// Set failed state
+	oclBuildState.WithLabelValues(pool, StateFailed).Set(1)
+	oclBuildEndTime.WithLabelValues(pool, StateFailed).Set(float64(now.Unix()))
+	oclBuildDuration.WithLabelValues(pool, StateFailed).Observe(duration)
+	oclBuildTotal.WithLabelValues(pool, StateFailed).Inc()
+	oclActiveBuilds.WithLabelValues(pool).Dec()
+}
+
+// RecordBuildInterrupted records when a build is interrupted
+func RecordBuildInterrupted(pool string) {
+	// Clear previous states
+	oclBuildState.DeletePartialMatch(prometheus.Labels{"pool": pool})
+	pushStartTimes.Delete(pool)
+
+	// Set interrupted state
+	oclBuildState.WithLabelValues(pool, StateInterrupted).Set(1)
+	oclBuildEndTime.WithLabelValues(pool, StateInterrupted).Set(float64(time.Now().Unix()))
+	oclBuildTotal.WithLabelValues(pool, StateInterrupted).Inc()
+	oclActiveBuilds.WithLabelValues(pool).Dec()
+}
+
+// RecordBuildJobState records the state of a build job
+func RecordBuildJobState(pool, state string) {
+	oclBuildJobState.DeletePartialMatch(prometheus.Labels{"pool": pool})
+	oclBuildJobState.WithLabelValues(pool, state).Set(1)
+}
+
+// RecordConfigChange records when a config change triggers a build
+func RecordConfigChange(pool string) {
+	oclConfigChangeTotal.WithLabelValues(pool).Inc()
+}
+
+// RecordBuildRetry records a build retry attempt
+func RecordBuildRetry(pool string) {
+	oclBuildRetries.WithLabelValues(pool).Inc()
+}
+
+// UpdateLayeredNodesCount updates the count of nodes using layered images
+func UpdateLayeredNodesCount(pool string, count int) {
+	oclLayeredNodesCount.WithLabelValues(pool).Set(float64(count))
+}
+
+// RecordImagePushStarted records when a build job becomes active (image push begins).
+func RecordImagePushStarted(pool string) {
+	oclImagePushState.DeletePartialMatch(prometheus.Labels{"pool": pool})
+	oclImagePushState.WithLabelValues(pool, StatePushing).Set(1)
+	pushStartTimes.Store(pool, time.Now())
+}
+
+// RecordImagePushCompleted records a successful image push.
+func RecordImagePushCompleted(pool string) {
+	oclImagePushState.DeletePartialMatch(prometheus.Labels{"pool": pool})
+	oclImagePushState.WithLabelValues(pool, StateSucceeded).Set(1)
+	oclImagePushTotal.WithLabelValues(pool, StateSucceeded).Inc()
+	if start, ok := pushStartTimes.LoadAndDelete(pool); ok {
+		oclImagePushDuration.WithLabelValues(pool, StateSucceeded).Observe(time.Since(start.(time.Time)).Seconds())
+	}
+}
+
+// RecordImagePushFailed records a failed image push.
+func RecordImagePushFailed(pool string) {
+	oclImagePushState.DeletePartialMatch(prometheus.Labels{"pool": pool})
+	oclImagePushState.WithLabelValues(pool, StateFailed).Set(1)
+	oclImagePushTotal.WithLabelValues(pool, StateFailed).Inc()
+	if start, ok := pushStartTimes.LoadAndDelete(pool); ok {
+		oclImagePushDuration.WithLabelValues(pool, StateFailed).Observe(time.Since(start.(time.Time)).Seconds())
+	}
+}
+
+// RecordBuildQueueDuration records how long a build waited before its job went active.
+// queuedAt should be the MachineOSBuild's CreationTimestamp.
+func RecordBuildQueueDuration(pool string, queuedAt time.Time) {
+	oclBuildQueueDuration.WithLabelValues(pool).Observe(time.Since(queuedAt).Seconds())
+}
+
+// UpdateOCLRolloutCounts updates the OCL rollout node counts from MachineConfigPool status.
+func UpdateOCLRolloutCounts(pool string, updatedNodes, totalNodes int32) {
+	oclRolloutUpdatedNodes.WithLabelValues(pool).Set(float64(updatedNodes))
+	oclRolloutTotalNodes.WithLabelValues(pool).Set(float64(totalNodes))
+}

--- a/pkg/controller/build/ocl_metrics.go
+++ b/pkg/controller/build/ocl_metrics.go
@@ -167,15 +167,6 @@ func RegisterOCLMetrics() error {
 		return fmt.Errorf("could not register OCL metrics: %w", err)
 	}
 
-	// Initialize GaugeVecs to ensure metrics are accessible even without values
-	oclBuildState.WithLabelValues("init", StateNone).Set(0)
-	oclBuildJobState.WithLabelValues("init", StateNone).Set(0)
-	oclLayeredNodesCount.WithLabelValues("init").Set(0)
-	oclImagePushState.WithLabelValues("init", StateNone).Set(0)
-	oclRolloutUpdatedNodes.WithLabelValues("init").Set(0)
-	oclRolloutTotalNodes.WithLabelValues("init").Set(0)
-	oclActiveBuilds.WithLabelValues("init").Set(0)
-
 	return nil
 }
 

--- a/pkg/controller/build/ocl_metrics.go
+++ b/pkg/controller/build/ocl_metrics.go
@@ -129,6 +129,13 @@ var (
 			Name: "ocl_active_builds",
 			Help: "Number of OCL builds currently in progress per pool",
 		}, []string{"pool"})
+
+	// oclMOSCCount is the number of MachineOSConfig objects in the cluster, used to determine OCL adoption
+	oclMOSCCount = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "mco_mosc_count",
+			Help: "number of MachineOSConfig objects in the cluster; non-zero value indicates on-cluster layering is in use",
+		})
 )
 
 // Build state constants for consistent labeling
@@ -161,6 +168,7 @@ func RegisterOCLMetrics() error {
 		oclBuildQueueDuration,
 		oclImagePushDuration,
 		oclActiveBuilds,
+		oclMOSCCount,
 	})
 
 	if err != nil {

--- a/pkg/controller/build/ocl_metrics_test.go
+++ b/pkg/controller/build/ocl_metrics_test.go
@@ -1,0 +1,209 @@
+package build
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+// resetMetric deletes all label combinations for the given GaugeVec so tests
+// don't bleed into each other.
+func resetGaugeVec(g *prometheus.GaugeVec, labels prometheus.Labels) {
+	g.DeletePartialMatch(labels)
+}
+
+func TestRecordImagePushStarted(t *testing.T) {
+	t.Parallel()
+
+	resetGaugeVec(oclImagePushState, prometheus.Labels{"pool": "worker"})
+
+	RecordImagePushStarted("worker")
+
+	v := testutil.ToFloat64(oclImagePushState.WithLabelValues("worker", StatePushing))
+	if v != 1 {
+		t.Errorf("expected ocl_image_push_state{state=%q} = 1, got %v", StatePushing, v)
+	}
+}
+
+func TestRecordImagePushCompleted(t *testing.T) {
+	t.Parallel()
+
+	resetGaugeVec(oclImagePushState, prometheus.Labels{"pool": "worker2"})
+
+	RecordImagePushStarted("worker2")
+	RecordImagePushCompleted("worker2")
+
+	gauge := testutil.ToFloat64(oclImagePushState.WithLabelValues("worker2", StateSucceeded))
+	if gauge != 1 {
+		t.Errorf("expected ocl_image_push_state{state=%q} = 1, got %v", StateSucceeded, gauge)
+	}
+
+	// pushing state should be cleared
+	pushing := testutil.ToFloat64(oclImagePushState.WithLabelValues("worker2", StatePushing))
+	if pushing != 0 {
+		t.Errorf("expected ocl_image_push_state{state=%q} = 0 after completion, got %v", StatePushing, pushing)
+	}
+}
+
+func TestRecordImagePushFailed(t *testing.T) {
+	t.Parallel()
+
+	resetGaugeVec(oclImagePushState, prometheus.Labels{"pool": "worker3"})
+
+	RecordImagePushStarted("worker3")
+	RecordImagePushFailed("worker3")
+
+	gauge := testutil.ToFloat64(oclImagePushState.WithLabelValues("worker3", StateFailed))
+	if gauge != 1 {
+		t.Errorf("expected ocl_image_push_state{state=%q} = 1, got %v", StateFailed, gauge)
+	}
+
+	// pushing state should be cleared
+	pushing := testutil.ToFloat64(oclImagePushState.WithLabelValues("worker3", StatePushing))
+	if pushing != 0 {
+		t.Errorf("expected ocl_image_push_state{state=%q} = 0 after failure, got %v", StatePushing, pushing)
+	}
+}
+
+func TestImagePushTotalCounters(t *testing.T) {
+	t.Parallel()
+
+	// Use unique pool name to avoid counter bleed from other tests
+	pool := "counter-test-pool"
+
+	before := testutil.ToFloat64(oclImagePushTotal.WithLabelValues(pool, StateSucceeded))
+	RecordImagePushCompleted(pool)
+	after := testutil.ToFloat64(oclImagePushTotal.WithLabelValues(pool, StateSucceeded))
+	if after-before != 1 {
+		t.Errorf("expected ocl_image_push_total{state=%q} to increment by 1, got %v -> %v", StateSucceeded, before, after)
+	}
+
+	before = testutil.ToFloat64(oclImagePushTotal.WithLabelValues(pool, StateFailed))
+	RecordImagePushFailed(pool)
+	after = testutil.ToFloat64(oclImagePushTotal.WithLabelValues(pool, StateFailed))
+	if after-before != 1 {
+		t.Errorf("expected ocl_image_push_total{state=%q} to increment by 1, got %v -> %v", StateFailed, before, after)
+	}
+}
+
+func TestUpdateOCLRolloutCounts(t *testing.T) {
+	t.Parallel()
+
+	pool := "rollout-pool"
+
+	UpdateOCLRolloutCounts(pool, 3, 5)
+
+	updated := testutil.ToFloat64(oclRolloutUpdatedNodes.WithLabelValues(pool))
+	if updated != 3 {
+		t.Errorf("expected ocl_rollout_updated_nodes = 3, got %v", updated)
+	}
+
+	total := testutil.ToFloat64(oclRolloutTotalNodes.WithLabelValues(pool))
+	if total != 5 {
+		t.Errorf("expected ocl_rollout_total_nodes = 5, got %v", total)
+	}
+}
+
+func TestUpdateOCLRolloutCountsUpdates(t *testing.T) {
+	t.Parallel()
+
+	pool := "rollout-pool2"
+
+	UpdateOCLRolloutCounts(pool, 2, 10)
+	UpdateOCLRolloutCounts(pool, 8, 10)
+
+	updated := testutil.ToFloat64(oclRolloutUpdatedNodes.WithLabelValues(pool))
+	if updated != 8 {
+		t.Errorf("expected ocl_rollout_updated_nodes to reflect latest value 8, got %v", updated)
+	}
+}
+
+func TestActiveBuildsGauge(t *testing.T) {
+	t.Parallel()
+
+	pool := "active-builds-pool"
+	oclActiveBuilds.WithLabelValues(pool).Set(0)
+
+	RecordBuildStarted(pool)
+	if v := testutil.ToFloat64(oclActiveBuilds.WithLabelValues(pool)); v != 1 {
+		t.Errorf("expected ocl_active_builds = 1 after start, got %v", v)
+	}
+
+	RecordBuildStarted(pool)
+	if v := testutil.ToFloat64(oclActiveBuilds.WithLabelValues(pool)); v != 2 {
+		t.Errorf("expected ocl_active_builds = 2 after second start, got %v", v)
+	}
+
+	RecordBuildCompleted(pool, time.Now())
+	if v := testutil.ToFloat64(oclActiveBuilds.WithLabelValues(pool)); v != 1 {
+		t.Errorf("expected ocl_active_builds = 1 after completion, got %v", v)
+	}
+
+	RecordBuildFailed(pool, time.Now())
+	if v := testutil.ToFloat64(oclActiveBuilds.WithLabelValues(pool)); v != 0 {
+		t.Errorf("expected ocl_active_builds = 0 after failure, got %v", v)
+	}
+}
+
+func TestActiveBuildsDecrementsOnInterrupted(t *testing.T) {
+	t.Parallel()
+
+	pool := "interrupted-pool"
+	oclActiveBuilds.WithLabelValues(pool).Set(0)
+
+	RecordBuildStarted(pool)
+	RecordBuildInterrupted(pool)
+
+	if v := testutil.ToFloat64(oclActiveBuilds.WithLabelValues(pool)); v != 0 {
+		t.Errorf("expected ocl_active_builds = 0 after interruption, got %v", v)
+	}
+}
+
+func TestBuildQueueDuration(t *testing.T) {
+	t.Parallel()
+
+	pool := "queue-pool"
+	queuedAt := time.Now().Add(-30 * time.Second)
+
+	before := testutil.CollectAndCount(oclBuildQueueDuration)
+	RecordBuildQueueDuration(pool, queuedAt)
+	after := testutil.CollectAndCount(oclBuildQueueDuration)
+
+	if after <= before {
+		t.Errorf("expected ocl_build_queue_duration_seconds to have more observations after recording, got count %v -> %v", before, after)
+	}
+}
+
+func TestImagePushDurationRecorded(t *testing.T) {
+	t.Parallel()
+
+	pool := "push-duration-pool"
+
+	before := testutil.CollectAndCount(oclImagePushDuration)
+	RecordImagePushStarted(pool)
+	time.Sleep(5 * time.Millisecond)
+	RecordImagePushCompleted(pool)
+	after := testutil.CollectAndCount(oclImagePushDuration)
+
+	if after <= before {
+		t.Errorf("expected ocl_image_push_duration_seconds to have more observations after push completed, got count %v -> %v", before, after)
+	}
+}
+
+func TestImagePushDurationOnFailure(t *testing.T) {
+	t.Parallel()
+
+	pool := "push-duration-fail-pool"
+
+	before := testutil.CollectAndCount(oclImagePushDuration)
+	RecordImagePushStarted(pool)
+	time.Sleep(5 * time.Millisecond)
+	RecordImagePushFailed(pool)
+	after := testutil.CollectAndCount(oclImagePushDuration)
+
+	if after <= before {
+		t.Errorf("expected ocl_image_push_duration_seconds to have more observations after push failed, got count %v -> %v", before, after)
+	}
+}

--- a/pkg/controller/build/ocl_metrics_test.go
+++ b/pkg/controller/build/ocl_metrics_test.go
@@ -207,3 +207,17 @@ func TestImagePushDurationOnFailure(t *testing.T) {
 		t.Errorf("expected ocl_image_push_duration_seconds to have more observations after push failed, got count %v -> %v", before, after)
 	}
 }
+
+func TestOCLMOSCCount(t *testing.T) {
+	t.Parallel()
+
+	oclMOSCCount.Set(0)
+	if v := testutil.ToFloat64(oclMOSCCount); v != 0 {
+		t.Errorf("expected mco_mosc_count = 0, got %v", v)
+	}
+
+	oclMOSCCount.Set(3)
+	if v := testutil.ToFloat64(oclMOSCCount); v != 3 {
+		t.Errorf("expected mco_mosc_count = 3, got %v", v)
+	}
+}

--- a/pkg/controller/build/reconciler.go
+++ b/pkg/controller/build/reconciler.go
@@ -544,8 +544,9 @@ func (b *buildReconciler) updateMachineConfigPool(ctx context.Context, oldMCP, c
 		}
 	}
 
-	UpdateOCLRolloutCounts(curMCP.Name, curMCP.Status.UpdatedMachineCount, curMCP.Status.MachineCount)
-	UpdateLayeredNodesCount(curMCP.Name, int(curMCP.Status.UpdatedMachineCount))
+	if _, err := utils.GetMachineOSConfigForMachineConfigPool(curMCP, b.utilListers()); err == nil {
+		UpdateOCLRolloutCounts(curMCP.Name, curMCP.Status.UpdatedMachineCount, curMCP.Status.MachineCount)
+	}
 
 	return b.syncAll(ctx)
 }
@@ -588,6 +589,8 @@ func (b *buildReconciler) startBuild(ctx context.Context, mosb *mcfgv1.MachineOS
 		}
 		return fmt.Errorf("imagebuilder could not start build for MachineOSBuild %q: %w", mosb.Name, err)
 	}
+
+	RecordBuildStarted(poolName)
 
 	klog.Infof("Started new build %s for MachineOSBuild", utils.GetBuildJobName(mosb))
 

--- a/pkg/controller/build/reconciler.go
+++ b/pkg/controller/build/reconciler.go
@@ -1387,6 +1387,8 @@ func (b *buildReconciler) syncMachineOSConfigs(ctx context.Context) error {
 			return err
 		}
 
+		oclMOSCCount.Set(float64(len(moscs)))
+
 		for _, mosc := range moscs {
 			if err := b.syncMachineOSConfig(ctx, mosc); err != nil {
 				return fmt.Errorf("could not sync MachineOSConfig %q: %w", mosc.Name, err)

--- a/pkg/controller/build/reconciler.go
+++ b/pkg/controller/build/reconciler.go
@@ -233,6 +233,13 @@ func (b *buildReconciler) AddJob(ctx context.Context, job *batchv1.Job) error {
 		mosb, err := b.getMachineOSBuildForJob(job)
 		if err == nil && mosb != nil {
 			b.eventRecorder.RecordJobCreated(mosb, job)
+			mosc, err := utils.GetMachineOSConfigForMachineOSBuild(mosb, b.utilListers())
+			if err == nil {
+				poolName := mosc.Spec.MachineConfigPool.Name
+				RecordBuildJobState(poolName, "active")
+				RecordImagePushStarted(poolName)
+				RecordBuildQueueDuration(poolName, mosb.CreationTimestamp.Time)
+			}
 		}
 
 		if err := b.updateMachineOSBuildWithStatus(ctx, job); err != nil {
@@ -259,6 +266,25 @@ func (b *buildReconciler) UpdateJob(ctx context.Context, oldJob, curJob *batchv1
 			if curJob.Status.Active > 0 && (oldJob.Status.Active == 0) {
 				b.eventRecorder.RecordJobStarted(mosb, curJob)
 				b.eventRecorder.RecordBuildBuilding(mosb)
+			}
+
+			mosc, err := utils.GetMachineOSConfigForMachineOSBuild(mosb, b.utilListers())
+			if err == nil {
+				poolName := mosc.Spec.MachineConfigPool.Name
+
+				if curJob.Status.Succeeded > 0 && (oldJob.Status.Succeeded == 0) {
+					RecordBuildJobState(poolName, StateSucceeded)
+					RecordImagePushCompleted(poolName)
+				}
+
+				if curJob.Status.Failed > 0 && (oldJob.Status.Failed == 0) {
+					RecordBuildJobState(poolName, StateFailed)
+					RecordImagePushFailed(poolName)
+				}
+
+				if curJob.Status.Failed > oldJob.Status.Failed && curJob.Status.Failed <= constants.JobMaxRetries {
+					RecordBuildRetry(poolName)
+				}
 			}
 		}
 
@@ -327,8 +353,16 @@ func (b *buildReconciler) updateMachineOSBuild(ctx context.Context, old, current
 		return nil
 	}
 
+	poolName := mosc.Spec.MachineConfigPool.Name
+
 	if !oldState.IsBuildFailure() && curState.IsBuildFailure() {
 		klog.Infof("MachineOSBuild %s failed, leaving ephemeral objects in place for inspection", current.Name)
+
+		if old.CreationTimestamp.Time.IsZero() {
+			RecordBuildFailed(poolName, time.Now())
+		} else {
+			RecordBuildFailed(poolName, old.CreationTimestamp.Time)
+		}
 
 		mcp, err := b.machineConfigPoolLister.Get(mosc.Spec.MachineConfigPool.Name)
 		if err != nil {
@@ -353,6 +387,12 @@ func (b *buildReconciler) updateMachineOSBuild(ctx context.Context, old, current
 		klog.Infof("MachineOSBuild %s succeeded, cleaning up all ephemeral objects used for the build", current.Name)
 
 		b.eventRecorder.RecordBuildCompleted(current, string(current.Status.DigestedImagePushSpec))
+
+		if old.CreationTimestamp.Time.IsZero() {
+			RecordBuildCompleted(poolName, time.Now())
+		} else {
+			RecordBuildCompleted(poolName, old.CreationTimestamp.Time)
+		}
 
 		mcp, err := b.machineConfigPoolLister.Get(mosc.Spec.MachineConfigPool.Name)
 		if err != nil {
@@ -382,6 +422,14 @@ func (b *buildReconciler) updateMachineOSBuild(ctx context.Context, old, current
 		if err := b.updateMachineOSConfigStatus(ctx, mosc, current); err != nil {
 			return fmt.Errorf("could not update MachineOSConfig %q status for successful MachineOSBuild %q: %w", mosc.Name, current.Name, err)
 		}
+	}
+
+	if !oldState.IsBuilding() && curState.IsBuilding() {
+		RecordBuildBuilding(poolName)
+	}
+
+	if !oldState.IsBuildInterrupted() && curState.IsBuildInterrupted() {
+		RecordBuildInterrupted(poolName)
 	}
 
 	return nil
@@ -490,10 +538,14 @@ func (b *buildReconciler) updateMachineConfigPool(ctx context.Context, oldMCP, c
 	if oldMCP.Spec.Configuration.Name != curMCP.Spec.Configuration.Name {
 		klog.Infof("Rendered config for pool %s changed from %s to %s", curMCP.Name, oldMCP.Spec.Configuration.Name, curMCP.Spec.Configuration.Name)
 		b.eventRecorder.RecordPoolConfigChanged(curMCP, oldMCP.Spec.Configuration.Name, curMCP.Spec.Configuration.Name)
+		RecordConfigChange(curMCP.Name)
 		if err := b.reconcilePoolChange(ctx, curMCP); err != nil {
 			return fmt.Errorf("could not create or reuse existing MachineOSBuild for MachineConfigPool %q change: %w", curMCP.Name, err)
 		}
 	}
+
+	UpdateOCLRolloutCounts(curMCP.Name, curMCP.Status.UpdatedMachineCount, curMCP.Status.MachineCount)
+	UpdateLayeredNodesCount(curMCP.Name, int(curMCP.Status.UpdatedMachineCount))
 
 	return b.syncAll(ctx)
 }
@@ -510,6 +562,8 @@ func (b *buildReconciler) startBuild(ctx context.Context, mosb *mcfgv1.MachineOS
 		return err
 	}
 
+	poolName := mosc.Spec.MachineConfigPool.Name
+
 	// If there are any other in-progress builds for this MachineOSConfig, stop them first.
 	if err := b.deleteOtherBuildsForMachineOSConfig(ctx, mosb, mosc); err != nil {
 		return fmt.Errorf("could not delete other non-terminal MachineOSBuilds for MachineOSConfig %s: %w", mosc.Name, err)
@@ -517,6 +571,7 @@ func (b *buildReconciler) startBuild(ctx context.Context, mosb *mcfgv1.MachineOS
 
 	b.eventRecorder.RecordBuildStarted(mosb, mosc)
 	b.eventRecorder.RecordBuildPreparing(mosb, fmt.Sprintf("creating build job for pool %q", mosc.Spec.MachineConfigPool.Name))
+	RecordBuildStarted(poolName)
 
 	// Next, create our new MachineOSBuild.
 	if err := imagebuilder.NewJobImageBuilder(b.kubeclient, b.mcfgclient, mosb, mosc).Start(ctx); err != nil {


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
- Added a new `OCLMetrics` module that registers Prometheus metrics for build telemetry
- Wired the metrics into the `buildReconciler` to track the full OCL build lifecycle: build state, duration, job state, image push operations, config change counts, rollout progress, active build counts, and track how many people are using OCL
- Metrics are emitted per pool and build name, making it easy to scope dashboards and alerts to specific pools

**- How to verify it**
```bash
go test ./pkg/controller/build/
```

Or on a live cluster:
1) Trigger a build by creating / updating a MOSC
2) Port forward the MOSB metrics endpoint:
   ```bash
   oc port-forward -n openshift-machine-config-operator deploy/machine-os-builder 8797:8797
   ```
3) Scrape the metric:
   ```bash
   curl -s http://localhost:8797/metrics | grep ocl_
   ```
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Add Prometheus metrics for OCL build telemetry

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Prometheus metrics for On-Cluster Layering build and image-push lifecycle, including queue timing, retries, active builds, layered nodes, and rollout adoption.
  * Enabled configurable metrics endpoint settings (address and TLS parameters) at startup.
  * Added Prometheus alerts for OCL build failure/degraded states and image-push failures (with runbook links).
* **Bug Fixes**
  * Improved accuracy of lifecycle transitions, timestamps, and metrics for succeeded/failed/interrupted flows and retries.
  * Cleaned up alert description formatting.
* **Tests**
  * Added unit tests covering metric transitions, counters, duration observations, and active-build gauge behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->