### PR TITLE
WIP: OCPBUGS-10431: clear staticPodPath template default when user sets it to empty

### DIFF
--- a/pkg/controller/kubelet-config/helpers.go
+++ b/pkg/controller/kubelet-config/helpers.go
@@ -548,6 +548,18 @@ func generateKubeletIgnFiles(kubeletConfig *mcfgv1.KubeletConfig, originalKubeCo
 		if strings.Contains(string(kubeletConfig.Spec.KubeletConfig.Raw), protectKernelDefaultsStr) {
 			originalKubeConfig.ProtectKernelDefaults = false
 		}
+		// staticPodPath is a string field with `omitempty`, so an explicit "" from the user
+		// is indistinguishable from unset after decoding and mergo will not overwrite the
+		// template default with an empty value. Detect the explicit empty value in the raw
+		// config and clear the default before merging, same as protectKernelDefaults above.
+		var rawFields map[string]interface{}
+		d := yaml.NewYAMLOrJSONDecoder(bytes.NewReader(kubeletConfig.Spec.KubeletConfig.Raw), len(kubeletConfig.Spec.KubeletConfig.Raw))
+		if err := d.Decode(&rawFields); err != nil {
+			return nil, nil, nil, fmt.Errorf("could not decode raw kubelet config to map: %w", err)
+		}
+		if v, ok := rawFields["staticPodPath"]; ok && v == "" {
+			originalKubeConfig.StaticPodPath = ""
+		}
 		// Merge the Old and New
 		err = mergo.Merge(originalKubeConfig, specKubeletConfig, mergo.WithOverride)
 		if err != nil {

--- a/pkg/controller/kubelet-config/staticpodpath_render_test.go
+++ b/pkg/controller/kubelet-config/staticpodpath_render_test.go
@@ -1,0 +1,111 @@
+package kubeletconfig
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"net/url"
+	"strings"
+	"testing"
+
+	ign3types "github.com/coreos/ignition/v2/config/v3_5/types"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	kubeletconfigv1beta1 "k8s.io/kubelet/config/v1beta1"
+
+	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
+)
+
+// renderedKubeletConf extracts the rendered kubelet.conf contents from the ignition file.
+func renderedKubeletConf(t *testing.T, ignFile *ign3types.File) string {
+	t.Helper()
+	if ignFile == nil || ignFile.Contents.Source == nil {
+		t.Fatal("no kubelet ignition file rendered")
+	}
+	src := *ignFile.Contents.Source
+	idx := strings.Index(src, ",")
+	if idx < 0 {
+		t.Fatalf("unexpected ignition source format: %.60s", src)
+	}
+	payload := src[idx+1:]
+	if strings.Contains(src[:idx], "base64") {
+		decoded, err := base64.StdEncoding.DecodeString(payload)
+		if err != nil {
+			t.Fatalf("could not base64-decode ignition contents: %v", err)
+		}
+		return string(decoded)
+	}
+	decoded, err := url.PathUnescape(payload)
+	if err != nil {
+		t.Fatalf("could not decode ignition contents: %v", err)
+	}
+	return decoded
+}
+
+func TestStaticPodPathEmptyRender(t *testing.T) {
+	// simulate the worker template default
+	originalKubeConfig := &kubeletconfigv1beta1.KubeletConfiguration{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "KubeletConfiguration",
+			APIVersion: kubeletconfigv1beta1.SchemeGroupVersion.String(),
+		},
+		StaticPodPath: "/etc/kubernetes/manifests",
+		ClusterDomain: "cluster.local",
+	}
+
+	// user KubeletConfig CR with staticPodPath: ""
+	userCfg, err := json.Marshal(&kubeletconfigv1beta1.KubeletConfiguration{
+		StaticPodPath: "",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	kc := &mcfgv1.KubeletConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "disable-static-pods"},
+		Spec: mcfgv1.KubeletConfigSpec{
+			KubeletConfig: &runtime.RawExtension{Raw: userCfg},
+		},
+	}
+
+	kubeletIgn, _, _, err := generateKubeletIgnFiles(kc, originalKubeConfig)
+	if err != nil {
+		t.Fatalf("generateKubeletIgnFiles failed: %v", err)
+	}
+
+	conf := renderedKubeletConf(t, kubeletIgn)
+	// marshaling the struct drops the empty key via omitempty, so this is
+	// equivalent to the user not mentioning staticPodPath at all and the
+	// template default must be retained
+	if !strings.Contains(conf, "/etc/kubernetes/manifests") {
+		t.Errorf("unset staticPodPath should keep the template default")
+	}
+
+	// also test the raw form a user would actually write, with explicit empty string key present
+	rawJSON := []byte(`{"staticPodPath":""}`)
+	kc2 := kc.DeepCopy()
+	kc2.Spec.KubeletConfig = &runtime.RawExtension{Raw: rawJSON}
+	original2 := originalKubeConfig.DeepCopy()
+
+	kubeletIgn2, _, _, err := generateKubeletIgnFiles(kc2, original2)
+	if err != nil {
+		t.Fatalf("generateKubeletIgnFiles (raw) failed: %v", err)
+	}
+	conf2 := renderedKubeletConf(t, kubeletIgn2)
+	if strings.Contains(conf2, "/etc/kubernetes/manifests") {
+		t.Errorf("FUNCTIONAL GAP (raw form): rendered config still contains /etc/kubernetes/manifests")
+	}
+
+	// YAML payloads are accepted by DecodeKubeletConfig, so the empty value
+	// detection must handle them too
+	kc3 := kc.DeepCopy()
+	kc3.Spec.KubeletConfig = &runtime.RawExtension{Raw: []byte("staticPodPath: \"\"\n")}
+	original3 := originalKubeConfig.DeepCopy()
+
+	kubeletIgn3, _, _, err := generateKubeletIgnFiles(kc3, original3)
+	if err != nil {
+		t.Fatalf("generateKubeletIgnFiles (yaml) failed: %v", err)
+	}
+	conf3 := renderedKubeletConf(t, kubeletIgn3)
+	if strings.Contains(conf3, "/etc/kubernetes/manifests") {
+		t.Errorf("FUNCTIONAL GAP (yaml form): rendered config still contains /etc/kubernetes/manifests")
+	}
+}


### PR DESCRIPTION
**- What I did**

Follow-up to #5724. That PR relaxed validation so a KubeletConfig CR with `staticPodPath: ""` is accepted for worker and custom pools, but the empty value never reached the rendered kubelet.conf: `mergo.Merge(..., mergo.WithOverride)` in `generateKubeletIgnFiles` does not overwrite a destination field with a zero-value source, so the template default `/etc/kubernetes/manifests` survived the merge.

This change detects an explicit `staticPodPath: ""` in the raw KubeletConfig (presence check on the raw JSON, since after decoding an explicit empty value is indistinguishable from unset) and clears the template default before merging, mirroring the existing `protectKernelDefaults` workaround a few lines above.

Also adds a render-path unit test asserting that:
- an explicit `{"staticPodPath":""}` renders a kubelet.conf without `/etc/kubernetes/manifests`
- an unset `staticPodPath` keeps the template default

**- How to verify it**

1. On a cluster with this change, apply a KubeletConfig CR targeting the worker pool with `staticPodPath: ""`
2. Check the rendered MachineConfig (`oc get mc 99-worker-generated-kubelet -o yaml`) or `/etc/kubernetes/kubelet.conf` on a worker node: the `staticPodPath` entry should be absent
3. Without this change, the rendered config still contains `staticPodPath: /etc/kubernetes/manifests` even though the CR is accepted

**- Description for the changelog**

Fix `staticPodPath: ""` in a KubeletConfig CR not taking effect in the rendered kubelet configuration.

WIP: pending cluster testing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved an explicitly provided empty `staticPodPath` so it’s rendered as intended, rather than falling back to the template default.

* **Tests**
  * Added new test coverage to confirm correct `staticPodPath` behavior when the value is omitted or explicitly empty, validating handling across supported configuration input formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->