### PR TITLE
Tolerate brief kube-cloud-config absence before going Degraded

### DIFF
--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -260,13 +260,33 @@ func (optr *Operator) syncCloudConfig(spec *mcfgv1.ControllerConfigSpec, infra *
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			if isKubeCloudConfigCMRequired(infra) {
-				// Return error only if the kube-cloud-config ConfigMap is required, otherwise proceeds further.
-				return fmt.Errorf("%s/%s configmap is required on platform %s but not found: %w",
-					"openshift-config-managed", "kube-cloud-config", infra.Status.PlatformStatus.Type, err)
+				// The ConfigMap can be absent for a brief, self-healing window (e.g.
+				// another operator deletes and recreates it). Poll the live API for a
+				// short grace period before declaring failure, so we don't flip
+				// Degraded=True for a gap that resolves on its own within seconds.
+				pollErr := wait.PollUntilContextTimeout(wait.ContextForChannel(optr.stopCh), kubeCloudConfigPollInterval, kubeCloudConfigPollTimeout, true, func(ctx context.Context) (bool, error) {
+					cm, err = optr.kubeClient.CoreV1().ConfigMaps("openshift-config-managed").Get(ctx, "kube-cloud-config", metav1.GetOptions{})
+					if err != nil {
+						if apierrors.IsNotFound(err) {
+							return false, nil
+						}
+						return false, err
+					}
+					return true, nil
+				})
+				if pollErr != nil {
+					if wait.Interrupted(pollErr) {
+						return fmt.Errorf("%s/%s configmap is required on platform %s but not found: %w",
+							"openshift-config-managed", "kube-cloud-config", infra.Status.PlatformStatus.Type, err)
+					}
+					return pollErr
+				}
+			} else {
+				return nil
 			}
-			return nil
+		} else {
+			return err
 		}
-		return err
 	}
 	// Read cloud.conf from openshift-config-managed/kube-cloud-config ConfigMap.
 	cc, err := getCloudConfigFromConfigMap(cm, "cloud.conf")
@@ -1829,6 +1849,14 @@ const (
 
 	controllerConfigCompletedInterval = time.Second
 	controllerConfigCompletedTimeout  = 5 * time.Minute
+)
+
+// kubeCloudConfigPollInterval/Timeout bound how long syncCloudConfig waits on
+// the live API for a required kube-cloud-config ConfigMap before declaring it
+// missing. Declared as vars (not consts) so tests can shrink them.
+var (
+	kubeCloudConfigPollInterval = 2 * time.Second
+	kubeCloudConfigPollTimeout  = 15 * time.Second
 )
 
 //nolint:dupl

--- a/pkg/operator/sync_test.go
+++ b/pkg/operator/sync_test.go
@@ -3,6 +3,7 @@ package operator
 import (
 	"context"
 	"testing"
+	"time"
 
 	configv1 "github.com/openshift/api/config/v1"
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
@@ -10,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 
@@ -20,6 +22,12 @@ import (
 )
 
 func TestSyncCloudConfig(t *testing.T) {
+	origInterval, origTimeout := kubeCloudConfigPollInterval, kubeCloudConfigPollTimeout
+	kubeCloudConfigPollInterval, kubeCloudConfigPollTimeout = time.Millisecond, 10*time.Millisecond
+	t.Cleanup(func() {
+		kubeCloudConfigPollInterval, kubeCloudConfigPollTimeout = origInterval, origTimeout
+	})
+
 	cases := []struct {
 		name                        string
 		infra                       *configv1.Infrastructure
@@ -77,7 +85,11 @@ func TestSyncCloudConfig(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			client := fake.NewSimpleClientset()
+			objs := []runtime.Object{}
+			if tc.kubeCloudConfig != nil {
+				objs = append(objs, tc.kubeCloudConfig)
+			}
+			client := fake.NewSimpleClientset(objs...)
 			sharedInformer := informers.NewSharedInformerFactory(client, 0)
 			cmInformer := sharedInformer.Core().V1().ConfigMaps()
 			if tc.kubeCloudConfig != nil {
@@ -85,6 +97,7 @@ func TestSyncCloudConfig(t *testing.T) {
 			}
 			optr := &Operator{
 				clusterCmLister: cmInformer.Lister(),
+				kubeClient:      client,
 			}
 			spec := &mcfgv1.ControllerConfigSpec{}
 			err := optr.syncCloudConfig(spec, tc.infra)
@@ -97,6 +110,37 @@ func TestSyncCloudConfig(t *testing.T) {
 			assert.Equal(t, tc.expectedCABundle, spec.CloudProviderCAData)
 		})
 	}
+}
+
+// TestSyncCloudConfigTransientCacheMiss covers the case where the
+// clusterCmLister cache doesn't (yet, or momentarily) have the
+// kube-cloud-config ConfigMap, but it's actually present via the live API
+// (e.g. it was deleted and quickly recreated by another operator). syncCloudConfig
+// should not report an error in that case.
+func TestSyncCloudConfigTransientCacheMiss(t *testing.T) {
+	origInterval, origTimeout := kubeCloudConfigPollInterval, kubeCloudConfigPollTimeout
+	kubeCloudConfigPollInterval, kubeCloudConfigPollTimeout = time.Millisecond, time.Second
+	t.Cleanup(func() {
+		kubeCloudConfigPollInterval, kubeCloudConfigPollTimeout = origInterval, origTimeout
+	})
+
+	infra := buildInfra(withPlatformType(configv1.AzurePlatformType))
+	cm := buildKubeCloudConfig(withCloudConf("test-cloud-conf"))
+
+	// The ConfigMap exists in the live API, but is deliberately absent from the
+	// informer's cache/lister to simulate a delete/recreate race.
+	client := fake.NewSimpleClientset(cm)
+	sharedInformer := informers.NewSharedInformerFactory(client, 0)
+	cmInformer := sharedInformer.Core().V1().ConfigMaps()
+
+	optr := &Operator{
+		clusterCmLister: cmInformer.Lister(),
+		kubeClient:      client,
+	}
+	spec := &mcfgv1.ControllerConfigSpec{}
+	err := optr.syncCloudConfig(spec, infra)
+	assert.NoError(t, err)
+	assert.Equal(t, "test-cloud-conf", spec.CloudProviderConfig)
 }
 
 type infraOption func(*configv1.Infrastructure)


### PR DESCRIPTION
**- What I did**

`syncCloudConfig` failed immediately whenever the `openshift-config-managed/kube-cloud-config` ConfigMap was momentarily missing, and any `syncFunc` error immediately flips the operator to `Degraded=True`/`RenderConfigFailed`. This made MCO overly sensitive to brief, self-healing absences of that ConfigMap — e.g. a cluster-config-operator e2e test deliberately deletes and recreates it within ~5s, and MCO would transiently degrade during that window even though nothing was actually broken.

`syncCloudConfig` now gives a required-but-missing ConfigMap a short grace period: it polls the live API (2s interval, 15s timeout) before reporting it as genuinely absent. The poll is tied to `optr.stopCh` via `wait.ContextForChannel` so it's cancelled promptly on operator shutdown. A ConfigMap that reappears within the grace period no longer degrades the operator.

**- How to verify it**

- `go test ./pkg/operator/...` — includes a new `TestSyncCloudConfigTransientCacheMiss` covering the exact scenario (ConfigMap briefly unavailable, then present), plus updated `TestSyncCloudConfig` cases.
- Manually: delete `openshift-config-managed/kube-cloud-config` on a cluster where it's required (e.g. Azure/GCP/OpenStack/vSphere) and recreate it within a few seconds; MCO's `machine-config` ClusterOperator should not report `Degraded=True`/`RenderConfigFailed` during that window.

**- Description for the changelog**

Give MCO a short grace period before degrading on a missing kube-cloud-config ConfigMap, so brief self-healing deletions don't flip the operator Degraded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when cloud configuration becomes temporarily unavailable during synchronization.
  * Required platforms now retry briefly before reporting a missing cloud configuration.
  * Prevented transient cache delays from causing synchronization failures.
  * Non-required platforms continue operating without interruption when configuration is absent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->