### PR TITLE
MCO-1847: adapt tc 52373 to new AWS marketplace feature

### DIFF
--- a/test/extended-priv/mco_machineconfigpool.go
+++ b/test/extended-priv/mco_machineconfigpool.go
@@ -110,6 +110,22 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/longdurati
 		proxyValue := "http://user:pass@proxy-fake:1111"
 		noProxyValue := "test.52373.no-proxy.com"
 
+		// Disable boot images update and skew enforcement so that the boot image controller
+		// does not try to reconcile machinesets while the proxy is set to a fake value, which
+		// would cause the controller to fail and degrade the cluster operator
+		exutil.By("Disable boot images update and skew enforcement")
+		if IsBootImageUpdateSupported(oc.AsAdmin()) {
+			machineConfiguration := GetMachineConfiguration(oc.AsAdmin())
+			defer machineConfiguration.SetSpec(machineConfiguration.GetSpecOrFail())
+			DisableSkew(machineConfiguration)
+			o.Expect(
+				machineConfiguration.SetNoneManagedBootImagesConfig(MachineSetResource),
+			).To(o.Succeed(), "Error disabling managed boot images")
+		} else {
+			logger.Infof("Boot image update is not supported on this platform, skipping")
+		}
+		logger.Infof("OK!\n")
+
 		exutil.By("Get current proxy configuration")
 		proxy := NewResource(oc.AsAdmin(), "proxy", "cluster")
 		proxyInitialConfig := proxy.GetOrFail(`{.spec}`)


### PR DESCRIPTION
**- What I did**

Adapt the test case "[sig-mco][Suite:openshift/machine-config-operator/longduration][Serial][Disruptive] MCO [PolarionID:52373][OTP] Modify proxy configuration in paused pools" so that it can run with the new AWS marketplace feature.

With the new AWS marketplace feature the MCC syncs and check if the configured AMIs in the machinesets have the right value. In order to do that they have to access aws and get the AMI's information. In test 52373 we configure a fake proxy, hence the MCC cannot reach AWS to know if the configured AMIs have the right value, resulting in a degradation.

In this PR we disable the bootimages functionality when we run test case 52373, so that it doesn't collide with the new AWS marketplace functionality.

**- How to verify it**

The test passes 

**- Description for the changelog**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded coverage for modifying proxy settings in paused machine pools.
  - Added platform-aware validation for environments with and without boot image update support.
  - Improved verification that operator status transitions correctly between degraded and healthy states.
  - Added safeguards to preserve and restore existing machine configuration during the test scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->