### PR TITLE
OPNET-782: Render BGP VIP static pods instead of keepalived

### DIFF
--- a/cmd/machine-config-operator/bootstrap.go
+++ b/cmd/machine-config-operator/bootstrap.go
@@ -31,6 +31,8 @@ var (
 		infraImage                     string
 		releaseImage                   string
 		keepalivedImage                string
+		frrK8sImage                    string
+		kubeVipImage                   string
 		mcoImage                       string
 		oauthProxyImage                string
 		kubeRbacProxyImage             string
@@ -68,6 +70,8 @@ func init() {
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.dependencyFiles.DNS, "dns-config-file", "/assets/manifests/cluster-dns-02-config.yml", "File containing dns.config.openshift.io manifest.")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.dependencyFiles.AdditionalTrustBundle, "additional-trust-bundle-config-file", "/assets/manifests/user-ca-bundle-config.yaml", "File containing the additional user provided CA bundle manifest.")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.keepalivedImage, "keepalived-image", "", "Image for Keepalived.")
+	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.frrK8sImage, "frr-k8s-image", "", "Image for frr-k8s.")
+	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.kubeVipImage, "kube-vip-image", "", "Image for kube-vip.")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.corednsImage, "coredns-image", "", "Image for CoreDNS.")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.haproxyImage, "haproxy-image", "", "Image for haproxy.")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.baremetalRuntimeCfgImage, "baremetal-runtimecfg-image", "", "Image for baremetal-runtimecfg.")
@@ -78,6 +82,7 @@ func init() {
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.dockerRegistryImage, "docker-registry-image", "", "Image for docker-registry.")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.imageReferences, "image-references", "", "File containing imagestreams (from cluster-version-operator)")
 	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.dependencyFiles.CloudProviderCA, "cloud-provider-ca-file", "", "path to cloud provider CA certificate")
+	bootstrapCmd.PersistentFlags().StringVar(&bootstrapOpts.dependencyFiles.BGPVIPConfig, "bgp-vip-config-file", "/assets/manifests/bgp-vip-config.yaml", "File containing the bgp-vip-config ConfigMap manifest (optional).")
 
 }
 
@@ -142,6 +147,18 @@ func runBootstrapCmd(_ *cobra.Command, _ []string) {
 		if err != nil {
 			klog.Warningf("Base OS extensions container not found: %s", err)
 		}
+		// The frr-k8s and kube-vip images are only present in payloads that
+		// support BGP-based VIP management, so their absence is not fatal.
+		if img, err := findImage(imgstream, "metallb-frr"); err == nil {
+			bootstrapOpts.frrK8sImage = img
+		} else {
+			klog.Warningf("metallb-frr image not found in image references: %v", err)
+		}
+		if img, err := findImage(imgstream, "kube-vip"); err == nil {
+			bootstrapOpts.kubeVipImage = img
+		} else {
+			klog.Warningf("kube-vip image not found in image references: %v", err)
+		}
 	}
 
 	imgs := ctrlcommon.Images{
@@ -155,6 +172,8 @@ func runBootstrapCmd(_ *cobra.Command, _ []string) {
 			BaseOSContainerImage:           bootstrapOpts.baseOSContainerImage,
 			BaseOSExtensionsContainerImage: bootstrapOpts.baseOSExtensionsContainerImage,
 			DockerRegistryBootstrap:        bootstrapOpts.dockerRegistryImage,
+			FRRK8sBootstrap:                bootstrapOpts.frrK8sImage,
+			KubeVIPBootstrap:               bootstrapOpts.kubeVipImage,
 		},
 		ControllerConfigImages: ctrlcommon.ControllerConfigImages{
 			InfraImage:          bootstrapOpts.infraImage,
@@ -163,6 +182,8 @@ func runBootstrapCmd(_ *cobra.Command, _ []string) {
 			Haproxy:             bootstrapOpts.haproxyImage,
 			BaremetalRuntimeCfg: bootstrapOpts.baremetalRuntimeCfgImage,
 			DockerRegistry:      bootstrapOpts.dockerRegistryImage,
+			FRRK8s:              bootstrapOpts.frrK8sImage,
+			KubeVip:             bootstrapOpts.kubeVipImage,
 		},
 	}
 

--- a/cmd/machine-config-operator/bootstrap.go
+++ b/cmd/machine-config-operator/bootstrap.go
@@ -147,18 +147,10 @@ func runBootstrapCmd(_ *cobra.Command, _ []string) {
 		if err != nil {
 			klog.Warningf("Base OS extensions container not found: %s", err)
 		}
-		// Parity invariant: any image rendered into MachineConfig content
-		// must resolve identically at bootstrap and in-cluster, otherwise
-		// the bootstrap-rendered MC hash differs from the in-cluster one
-		// and every master degrades with a bootstrap MC mismatch. The
-		// in-cluster side reads the machine-config-operator-images
-		// ConfigMap (install/0000_80_machine-config_02_images.configmap.yaml,
-		// substituted by the CVO from install/image-references), so images
-		// may only be discovered here if the same tag is listed in both of
-		// those files. Both metallb-frr and kube-vip (ose-kube-vip,
-		// ART-21663 / ocp-build-data#11838) are payload members and are
-		// listed in both files, so the lookups here resolve to the same
-		// digests the CVO substitutes in-cluster.
+		// Images rendered into MachineConfig content must resolve
+		// identically at bootstrap and in-cluster (tag listed in both
+		// install/image-references and the images ConfigMap), otherwise the
+		// bootstrap-rendered MC hash differs and masters degrade.
 		bootstrapOpts.frrK8sImage = findImageOrDie(imgstream, "metallb-frr")
 		bootstrapOpts.kubeVipImage = findImageOrDie(imgstream, "kube-vip")
 	}

--- a/cmd/machine-config-operator/bootstrap.go
+++ b/cmd/machine-config-operator/bootstrap.go
@@ -147,18 +147,19 @@ func runBootstrapCmd(_ *cobra.Command, _ []string) {
 		if err != nil {
 			klog.Warningf("Base OS extensions container not found: %s", err)
 		}
-		// The frr-k8s and kube-vip images are only present in payloads that
-		// support BGP-based VIP management, so their absence is not fatal.
-		if img, err := findImage(imgstream, "metallb-frr"); err == nil {
-			bootstrapOpts.frrK8sImage = img
-		} else {
-			klog.Warningf("metallb-frr image not found in image references: %v", err)
-		}
-		if img, err := findImage(imgstream, "kube-vip"); err == nil {
-			bootstrapOpts.kubeVipImage = img
-		} else {
-			klog.Warningf("kube-vip image not found in image references: %v", err)
-		}
+		// Parity invariant: any image rendered into MachineConfig content
+		// must resolve identically at bootstrap and in-cluster, otherwise
+		// the bootstrap-rendered MC hash differs from the in-cluster one
+		// and every master degrades with a bootstrap MC mismatch. The
+		// in-cluster side reads the machine-config-operator-images
+		// ConfigMap (install/0000_80_machine-config_02_images.configmap.yaml,
+		// substituted by the CVO from install/image-references), so images
+		// may only be discovered here if the same tag is listed in both of
+		// those files. metallb-frr is; kube-vip is not in the release
+		// payload yet, so it must not be discovered here - it can only be
+		// wired through --kube-vip-image together with entries in the
+		// images ConfigMap and image-references once the payload ships it.
+		bootstrapOpts.frrK8sImage = findImageOrDie(imgstream, "metallb-frr")
 	}
 
 	imgs := ctrlcommon.Images{

--- a/cmd/machine-config-operator/bootstrap.go
+++ b/cmd/machine-config-operator/bootstrap.go
@@ -155,11 +155,12 @@ func runBootstrapCmd(_ *cobra.Command, _ []string) {
 		// ConfigMap (install/0000_80_machine-config_02_images.configmap.yaml,
 		// substituted by the CVO from install/image-references), so images
 		// may only be discovered here if the same tag is listed in both of
-		// those files. metallb-frr is; kube-vip is not in the release
-		// payload yet, so it must not be discovered here - it can only be
-		// wired through --kube-vip-image together with entries in the
-		// images ConfigMap and image-references once the payload ships it.
+		// those files. Both metallb-frr and kube-vip (ose-kube-vip,
+		// ART-21663 / ocp-build-data#11838) are payload members and are
+		// listed in both files, so the lookups here resolve to the same
+		// digests the CVO substitutes in-cluster.
 		bootstrapOpts.frrK8sImage = findImageOrDie(imgstream, "metallb-frr")
+		bootstrapOpts.kubeVipImage = findImageOrDie(imgstream, "kube-vip")
 	}
 
 	imgs := ctrlcommon.Images{

--- a/install/0000_80_machine-config_02_images.configmap.yaml
+++ b/install/0000_80_machine-config_02_images.configmap.yaml
@@ -19,5 +19,6 @@ data:
       "baremetalRuntimeCfgImage": "placeholder.url.oc.will.replace.this.org/placeholdernamespace:baremetal-runtimecfg",
       "oauthProxy": "placeholder.url.oc.will.replace.this.org/placeholdernamespace:oauth-proxy",
       "kubeRbacProxy": "placeholder.url.oc.will.replace.this.org/placeholdernamespace:kube-rbac-proxy",
-      "dockerRegistryImage": "placeholder.url.oc.will.replace.this.org/placeholdernamespace:docker-registry"
+      "dockerRegistryImage": "placeholder.url.oc.will.replace.this.org/placeholdernamespace:docker-registry",
+      "frrK8sImage": "placeholder.url.oc.will.replace.this.org/placeholdernamespace:metallb-frr"
     }

--- a/install/0000_80_machine-config_02_images.configmap.yaml
+++ b/install/0000_80_machine-config_02_images.configmap.yaml
@@ -20,5 +20,6 @@ data:
       "oauthProxy": "placeholder.url.oc.will.replace.this.org/placeholdernamespace:oauth-proxy",
       "kubeRbacProxy": "placeholder.url.oc.will.replace.this.org/placeholdernamespace:kube-rbac-proxy",
       "dockerRegistryImage": "placeholder.url.oc.will.replace.this.org/placeholdernamespace:docker-registry",
-      "frrK8sImage": "placeholder.url.oc.will.replace.this.org/placeholdernamespace:metallb-frr"
+      "frrK8sImage": "placeholder.url.oc.will.replace.this.org/placeholdernamespace:metallb-frr",
+      "kubeVipImage": "placeholder.url.oc.will.replace.this.org/placeholdernamespace:kube-vip"
     }

--- a/install/image-references
+++ b/install/image-references
@@ -56,3 +56,7 @@ spec:
     from:
       kind: DockerImage
       name: placeholder.url.oc.will.replace.this.org/placeholdernamespace:docker-registry
+  - name: metallb-frr
+    from:
+      kind: DockerImage
+      name: placeholder.url.oc.will.replace.this.org/placeholdernamespace:metallb-frr

--- a/install/image-references
+++ b/install/image-references
@@ -60,3 +60,7 @@ spec:
     from:
       kind: DockerImage
       name: placeholder.url.oc.will.replace.this.org/placeholdernamespace:metallb-frr
+  - name: kube-vip
+    from:
+      kind: DockerImage
+      name: placeholder.url.oc.will.replace.this.org/placeholdernamespace:kube-vip

--- a/manifests/on-prem/0000-frr-k8s.yaml
+++ b/manifests/on-prem/0000-frr-k8s.yaml
@@ -1,0 +1,165 @@
+---
+kind: Pod
+apiVersion: v1
+metadata:
+  name: frr-k8s
+  namespace: openshift-frr-k8s
+  labels:
+    app: frr-k8s
+spec:
+  # hostNetwork: the BGP session must originate from the node IP and the
+  # advertised VIP routes live in the host routing table (keepalived parity).
+  hostNetwork: true
+  shareProcessNamespace: true
+  priorityClassName: system-node-critical
+  # 10s (not the upstream DaemonSet's 0): a SIGTERM'd bgpd sends a Cease
+  # NOTIFICATION, which hard-resets the session; after a SIGKILL a peer in
+  # graceful-restart helper mode may retain stale VIP routes on bare TCP
+  # loss until the restart timer expires.
+  terminationGracePeriodSeconds: 10
+  tolerations:
+  - operator: Exists
+  initContainers:
+  - name: render-config-frr
+    image: {{ .Images.BaremetalRuntimeCfgBootstrap }}
+    command:
+    - /usr/bin/runtimecfg
+    - render
+    - /etc/kubernetes/kubeconfig
+    - --api-vips
+    - {{ onPremPlatformAPIServerInternalIP .ControllerConfig }}
+    - --ingress-vips
+    - {{ onPremPlatformIngressIP .ControllerConfig }}
+    - "--cluster-config"
+    - "/opt/openshift/manifests/cluster-config.yaml"
+    - /config/frr.conf.tmpl
+    - --out-dir
+    - /etc/frr
+    - --peer-file
+    - /config/frr-peers.json
+    env:
+    - name: IS_BOOTSTRAP
+      value: "yes"
+    securityContext:
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      capabilities:
+        drop:
+        - ALL
+    resources:
+      requests:
+        cpu: 10m
+        memory: 50Mi
+      limits:
+        cpu: 100m
+        memory: 128Mi
+    terminationMessagePolicy: FallbackToLogsOnError
+    volumeMounts:
+    - name: resource-dir
+      mountPath: /config
+      readOnly: true
+    - name: frr-conf
+      mountPath: /etc/frr
+    - name: kubeconfig
+      mountPath: /etc/kubernetes
+      readOnly: true
+    - name: manifests
+      mountPath: "/opt/openshift/manifests"
+      mountPropagation: HostToContainer
+      readOnly: true
+  - name: cp-frr-files
+    image: {{ .Images.FRRK8sBootstrap }}
+    command:
+    - /bin/sh
+    - -c
+    - |
+      set -eu
+      cp -f /tmp/frr/daemons /etc/frr/daemons
+      cp -f /tmp/frr/vtysh.conf /etc/frr/vtysh.conf
+    securityContext:
+      runAsUser: 100
+      runAsGroup: 101
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      capabilities:
+        drop:
+        - ALL
+    resources:
+      requests:
+        cpu: 10m
+        memory: 20Mi
+      limits:
+        cpu: 100m
+        memory: 128Mi
+    terminationMessagePolicy: FallbackToLogsOnError
+    volumeMounts:
+    - name: frr-startup
+      mountPath: /tmp/frr
+      readOnly: true
+    - name: frr-conf
+      mountPath: /etc/frr
+  containers:
+  - name: frr
+    image: {{ .Images.FRRK8sBootstrap }}
+    command:
+    - /bin/sh
+    - -c
+    - /sbin/tini -- /usr/lib/frr/docker-start
+    env:
+    - name: TINI_SUBREAPER
+      value: "true"
+    resources:
+      requests:
+        cpu: 100m
+        memory: 200Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
+    securityContext:
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      capabilities:
+        # Mirrors the frr container of the frr-k8s DaemonSet shipped by CNO
+        # (upstream metallb/frr-k8s parity). No drop ALL: FRR's
+        # privilege-separated startup (watchfrr as root spawning daemons as
+        # the frr user) additionally relies on root's implicit capabilities
+        # (SETUID/SETGID/DAC_OVERRIDE/CHOWN); dropping ALL and re-adding
+        # only the network capabilities was tested and prevents the FRR
+        # daemons from starting. SYS_ADMIN is required by docker-start/
+        # watchfrr process supervision.
+        add:
+        - NET_ADMIN
+        - NET_RAW
+        - SYS_ADMIN
+        - NET_BIND_SERVICE
+    terminationMessagePolicy: FallbackToLogsOnError
+    volumeMounts:
+    - name: frr-sockets
+      mountPath: /var/run/frr
+    - name: frr-conf
+      mountPath: /etc/frr
+    - name: frr-lib
+      mountPath: /var/lib/frr
+    - name: frr-tmp
+      mountPath: /var/tmp/frr
+  volumes:
+  - name: resource-dir
+    hostPath:
+      path: /etc/kubernetes/static-pod-resources/frr-k8s
+  - name: frr-conf
+    emptyDir: {}
+  - name: frr-sockets
+    emptyDir: {}
+  - name: frr-lib
+    emptyDir: {}
+  - name: frr-tmp
+    emptyDir: {}
+  - name: frr-startup
+    hostPath:
+      path: /etc/kubernetes/static-pod-resources/frr-k8s/startup
+  - name: kubeconfig
+    hostPath:
+      path: /etc/kubernetes
+  - name: manifests
+    hostPath:
+      path: "/opt/openshift/manifests"

--- a/manifests/on-prem/0000-frr-k8s.yaml
+++ b/manifests/on-prem/0000-frr-k8s.yaml
@@ -12,10 +12,8 @@ spec:
   hostNetwork: true
   shareProcessNamespace: true
   priorityClassName: system-node-critical
-  # 10s (not the upstream DaemonSet's 0): a SIGTERM'd bgpd sends a Cease
-  # NOTIFICATION, which hard-resets the session; after a SIGKILL a peer in
-  # graceful-restart helper mode may retain stale VIP routes on bare TCP
-  # loss until the restart timer expires.
+  # 10s, not upstream's 0: SIGTERM'd bgpd sends a Cease; after SIGKILL a
+  # graceful-restart helper peer may retain stale VIP routes.
   terminationGracePeriodSeconds: 10
   tolerations:
   - operator: Exists
@@ -119,14 +117,9 @@ spec:
       allowPrivilegeEscalation: false
       readOnlyRootFilesystem: true
       capabilities:
-        # Mirrors the frr container of the frr-k8s DaemonSet shipped by CNO
-        # (upstream metallb/frr-k8s parity). No drop ALL: FRR's
-        # privilege-separated startup (watchfrr as root spawning daemons as
-        # the frr user) additionally relies on root's implicit capabilities
-        # (SETUID/SETGID/DAC_OVERRIDE/CHOWN); dropping ALL and re-adding
-        # only the network capabilities was tested and prevents the FRR
-        # daemons from starting. SYS_ADMIN is required by docker-start/
-        # watchfrr process supervision.
+        # No drop ALL: FRR's privilege-separated startup relies on root's
+        # implicit caps beyond these four (tested: drop ALL + re-add breaks
+        # daemon startup). SYS_ADMIN for watchfrr supervision.
         add:
         - NET_ADMIN
         - NET_RAW

--- a/manifests/on-prem/0010-kube-vip-api.yaml
+++ b/manifests/on-prem/0010-kube-vip-api.yaml
@@ -1,0 +1,66 @@
+---
+kind: Pod
+apiVersion: v1
+metadata:
+  name: kube-vip-api
+  namespace: openshift-kube-vip
+  labels:
+    app: kube-vip
+    component: api
+spec:
+  hostNetwork: true
+  priorityClassName: system-node-critical
+  tolerations:
+  - operator: Exists
+  containers:
+  - name: kube-vip
+    image: {{ .Images.KubeVIPBootstrap }}
+    args:
+    - manager
+    env:
+    - name: address
+      value: "{{ onPremPlatformAPIServerInternalIP .ControllerConfig }}"
+    - name: k8s_config_file
+      value: "/etc/kubernetes/kubeconfig"
+    - name: kubernetes_addr
+      value: "https://localhost:6443"
+    - name: port
+      value: "6443"
+    - name: cp_enable
+      value: "true"
+    - name: vip_leaderelection
+      value: "true"
+    - name: vip_routingtable
+      value: "true"
+    - name: vip_cleanroutingtable
+      value: "true"
+    - name: vip_routingtableid
+      value: "198"
+    - name: vip_routingtableprotocol
+      value: "248"
+    - name: backend_health_check_interval
+      value: "5"
+    resources:
+      requests:
+        cpu: 50m
+        memory: 64Mi
+      limits:
+        cpu: 200m
+        memory: 256Mi
+    securityContext:
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      capabilities:
+        drop:
+        - ALL
+        add:
+        - NET_ADMIN
+        - NET_RAW
+    volumeMounts:
+    - name: kubeconfig
+      mountPath: /etc/kubernetes
+      readOnly: true
+  volumes:
+  - name: kubeconfig
+    hostPath:
+      path: /etc/kubernetes

--- a/manifests/on-prem/0010-kube-vip-api.yaml
+++ b/manifests/on-prem/0010-kube-vip-api.yaml
@@ -34,6 +34,10 @@ spec:
       value: "true"
     - name: vip_cleanroutingtable
       value: "true"
+    - name: vip_skipdad
+      # health-gated ECMP: every advertiser deliberately holds the VIP
+      # (anycast); DAD would blackhole the second and later advertisers
+      value: "true"
     - name: vip_routingtableid
       value: "198"
     - name: vip_routingtableprotocol

--- a/manifests/on-prem/0010-kube-vip-api.yaml
+++ b/manifests/on-prem/0010-kube-vip-api.yaml
@@ -35,8 +35,7 @@ spec:
     - name: vip_cleanroutingtable
       value: "true"
     - name: vip_skipdad
-      # health-gated ECMP: every advertiser deliberately holds the VIP
-      # (anycast); DAD would blackhole the second and later advertisers
+      # anycast ECMP: DAD would blackhole all advertisers but the first
       value: "true"
     - name: vip_routingtableid
       value: "198"

--- a/manifests/on-prem/0011-kube-vip-api-secondary.yaml
+++ b/manifests/on-prem/0011-kube-vip-api-secondary.yaml
@@ -34,6 +34,10 @@ spec:
       value: "true"
     - name: vip_cleanroutingtable
       value: "true"
+    - name: vip_skipdad
+      # health-gated ECMP: every advertiser deliberately holds the VIP
+      # (anycast); DAD would blackhole the second and later advertisers
+      value: "true"
     - name: vip_routingtableid
       value: "198"
     - name: vip_routingtableprotocol

--- a/manifests/on-prem/0011-kube-vip-api-secondary.yaml
+++ b/manifests/on-prem/0011-kube-vip-api-secondary.yaml
@@ -2,11 +2,11 @@
 kind: Pod
 apiVersion: v1
 metadata:
-  name: kube-vip-api
+  name: kube-vip-api-secondary
   namespace: openshift-kube-vip
   labels:
     app: kube-vip
-    component: api
+    component: api-secondary
 spec:
   hostNetwork: true
   priorityClassName: system-node-critical
@@ -19,7 +19,7 @@ spec:
     - manager
     env:
     - name: address
-      value: "{{ onPremPlatformAPIServerInternalIP .ControllerConfig }}"
+      value: "{{ if gt (len (onPremPlatformAPIServerInternalIPs .ControllerConfig)) 1 }}{{ index (onPremPlatformAPIServerInternalIPs .ControllerConfig) 1 }}{{ end }}"
     - name: k8s_config_file
       value: "/etc/kubernetes/kubeconfig"
     - name: kubernetes_addr

--- a/manifests/on-prem/0011-kube-vip-api-secondary.yaml
+++ b/manifests/on-prem/0011-kube-vip-api-secondary.yaml
@@ -35,8 +35,7 @@ spec:
     - name: vip_cleanroutingtable
       value: "true"
     - name: vip_skipdad
-      # health-gated ECMP: every advertiser deliberately holds the VIP
-      # (anycast); DAD would blackhole the second and later advertisers
+      # anycast ECMP: DAD would blackhole all advertisers but the first
       value: "true"
     - name: vip_routingtableid
       value: "198"

--- a/manifests/on-prem/frr-peers.json.tmpl
+++ b/manifests/on-prem/frr-peers.json.tmpl
@@ -1,0 +1,1 @@
+{{- .ControllerConfig.BGPVIPPeersJSON -}}

--- a/manifests/on-prem/frr-startup-daemons
+++ b/manifests/on-prem/frr-startup-daemons
@@ -1,0 +1,23 @@
+zebra=yes
+bgpd=yes
+ospfd=no
+ospf6d=no
+ripd=no
+ripngd=no
+isisd=no
+pimd=no
+ldpd=no
+nhrpd=no
+eigrpd=no
+babeld=no
+sharpd=no
+pbrd=no
+bfdd=yes
+fabricd=no
+vrrpd=no
+pathd=no
+
+vtysh_enable=yes
+zebra_options="  -A 127.0.0.1 -s 90000000"
+bgpd_options="   -A 127.0.0.1"
+bfdd_options="   -A 127.0.0.1"

--- a/manifests/on-prem/frr-startup-vtysh.conf
+++ b/manifests/on-prem/frr-startup-vtysh.conf
@@ -1,0 +1,1 @@
+service integrated-vtysh-config

--- a/manifests/on-prem/frr.conf.tmpl
+++ b/manifests/on-prem/frr.conf.tmpl
@@ -1,0 +1,58 @@
+frr version 9.1
+frr defaults traditional
+hostname {{`{{.Hostname}}`}}
+!
+router bgp {{`{{.LocalASN}}`}}
+ bgp router-id {{`{{.RouterID}}`}}
+ no bgp ebgp-requires-policy
+ no bgp default ipv4-unicast
+ !
+{{`{{- range .Peers}}`}}
+ neighbor {{`{{.PeerAddress}}`}} remote-as {{`{{.PeerASN}}`}}
+{{`{{- if .Password}}`}}
+ neighbor {{`{{.PeerAddress}}`}} password {{`{{.Password}}`}}
+{{`{{- end}}`}}
+{{`{{- if eq .BFDEnabled "true"}}`}}
+ neighbor {{`{{.PeerAddress}}`}} bfd
+{{`{{- end}}`}}
+{{`{{- if eq .EBGPMultiHop "true"}}`}}
+ neighbor {{`{{.PeerAddress}}`}} ebgp-multihop
+{{`{{- end}}`}}
+{{`{{- if .HoldTime}}`}}
+ neighbor {{`{{.PeerAddress}}`}} timers {{`{{.KeepaliveTime}}`}} {{`{{.HoldTime}}`}}
+{{`{{- end}}`}}
+{{`{{- end}}`}}
+ !
+ address-family ipv4 unicast
+  redistribute table-direct 198
+{{`{{- range .Peers}}`}}
+{{`{{- if isIPv4 .PeerAddress}}`}}
+  neighbor {{`{{.PeerAddress}}`}} activate
+{{`{{- if $.Communities}}`}}
+  neighbor {{`{{.PeerAddress}}`}} route-map VIP-COMMUNITY out
+{{`{{- end}}`}}
+{{`{{- end}}`}}
+{{`{{- end}}`}}
+ exit-address-family
+ !
+ address-family ipv6 unicast
+  redistribute table-direct 198
+{{`{{- range .Peers}}`}}
+{{`{{- if isIPv6 .PeerAddress}}`}}
+  neighbor {{`{{.PeerAddress}}`}} activate
+{{`{{- if $.Communities}}`}}
+  neighbor {{`{{.PeerAddress}}`}} route-map VIP-COMMUNITY out
+{{`{{- end}}`}}
+{{`{{- end}}`}}
+{{`{{- end}}`}}
+ exit-address-family
+!
+{{`{{- if .Communities}}`}}
+route-map VIP-COMMUNITY permit 10
+{{`{{- range .Communities}}`}}
+ set community {{`{{.}}`}} additive
+{{`{{- end}}`}}
+!
+{{`{{- end}}`}}
+line vty
+!

--- a/manifests/on-prem/frr.conf.tmpl
+++ b/manifests/on-prem/frr.conf.tmpl
@@ -18,7 +18,10 @@ router bgp {{`{{.LocalASN}}`}}
 {{`{{- if eq .EBGPMultiHop "true"}}`}}
  neighbor {{`{{.PeerAddress}}`}} ebgp-multihop
 {{`{{- end}}`}}
-{{`{{- if .HoldTime}}`}}
+{{`{{- if .Port}}`}}
+ neighbor {{`{{.PeerAddress}}`}} port {{`{{.Port}}`}}
+{{`{{- end}}`}}
+{{`{{- if and .HoldTime .KeepaliveTime}}`}}
  neighbor {{`{{.PeerAddress}}`}} timers {{`{{.KeepaliveTime}}`}} {{`{{.HoldTime}}`}}
 {{`{{- end}}`}}
 {{`{{- end}}`}}

--- a/pkg/controller/common/helpers.go
+++ b/pkg/controller/common/helpers.go
@@ -1605,3 +1605,23 @@ func DetectRuncInMachineConfig(mc *mcfgv1.MachineConfig) (string, error) {
 	}
 	return "", nil
 }
+
+// IsBGPVIPManagement reports whether BGP-based VIP management is active:
+// BareMetal platform, vipManagement "BGP", and VIPs present. Without VIPs
+// (user-managed load balancer) there is nothing to advertise and the
+// VIP-consuming templates would render empty values, so the keepalived
+// default applies. Shared by the template renderer, the bootstrap manifest
+// selection, and the operator's peers ingestion so they cannot disagree.
+func IsBGPVIPManagement(infra *configv1.Infrastructure) bool {
+	if infra == nil || infra.Status.PlatformStatus == nil {
+		return false
+	}
+	ps := infra.Status.PlatformStatus
+	if ps.Type != configv1.BareMetalPlatformType || ps.BareMetal == nil {
+		return false
+	}
+	if len(ps.BareMetal.APIServerInternalIPs) == 0 || len(ps.BareMetal.IngressIPs) == 0 {
+		return false
+	}
+	return ps.BareMetal.VIPManagement == configv1.VIPManagementTypeBGP
+}

--- a/pkg/controller/common/images.go
+++ b/pkg/controller/common/images.go
@@ -41,6 +41,8 @@ type RenderConfigImages struct {
 	OauthProxy                   string `json:"oauthProxy"`
 	KubeRbacProxy                string `json:"kubeRbacProxy"`
 	DockerRegistryBootstrap      string `json:"dockerRegistry"`
+	FRRK8sBootstrap              string `json:"frrK8s"`
+	KubeVIPBootstrap             string `json:"kubeVip"`
 }
 
 // ControllerConfigImages are image names used to render templates under ./templates/
@@ -51,6 +53,8 @@ type ControllerConfigImages struct {
 	Haproxy             string `json:"haproxyImage"`
 	BaremetalRuntimeCfg string `json:"baremetalRuntimeCfgImage"`
 	DockerRegistry      string `json:"dockerRegistryImage"`
+	FRRK8s              string `json:"frrK8sImage"`
+	KubeVip             string `json:"kubeVipImage"`
 }
 
 // Parses the JSON blob containing the images information into an Images struct.

--- a/pkg/controller/common/images_test.go
+++ b/pkg/controller/common/images_test.go
@@ -30,12 +30,10 @@ func TestInstallImagesConfigMapCoversControllerConfigImages(t *testing.T) {
 	var imagesJSON map[string]string
 	require.NoError(t, json.Unmarshal([]byte(cm.Data["images.json"]), &imagesJSON))
 
-	// kubeVipImage is intentionally absent: the kube-vip image is not in the
-	// release payload yet, so neither bootstrap nor the ConfigMap may carry
-	// it (both sides render it empty, preserving parity). Once the payload
-	// ships kube-vip, it must be added to the ConfigMap, image-references,
-	// and the bootstrap lookup together.
-	exceptions := map[string]bool{"kubeVipImage": true}
+	// Images consumed at bootstrap but deliberately absent from the
+	// ConfigMap go here, with rationale; the test fails if the ConfigMap
+	// gains the key while it is still listed.
+	exceptions := map[string]bool{}
 
 	typ := reflect.TypeOf(ControllerConfigImages{})
 	for i := 0; i < typ.NumField(); i++ {

--- a/pkg/controller/common/images_test.go
+++ b/pkg/controller/common/images_test.go
@@ -1,0 +1,53 @@
+package common
+
+import (
+	"encoding/json"
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
+)
+
+// The in-cluster operator reads operand images from the
+// machine-config-operator-images ConfigMap (substituted by the CVO from
+// install/image-references), while the bootstrap discovers them from the
+// release payload's image references. Any ControllerConfigImages field
+// populated at bootstrap but missing from the ConfigMap renders different
+// MachineConfig content at bootstrap vs in-cluster, which changes the
+// rendered MC hash and degrades every master with a bootstrap MC mismatch
+// (openshift/machine-config-operator#6326 e2e-openstack).
+func TestInstallImagesConfigMapCoversControllerConfigImages(t *testing.T) {
+	raw, err := os.ReadFile("../../../install/0000_80_machine-config_02_images.configmap.yaml")
+	require.NoError(t, err)
+
+	var cm struct {
+		Data map[string]string `json:"data"`
+	}
+	require.NoError(t, yaml.Unmarshal(raw, &cm))
+
+	var imagesJSON map[string]string
+	require.NoError(t, json.Unmarshal([]byte(cm.Data["images.json"]), &imagesJSON))
+
+	// kubeVipImage is intentionally absent: the kube-vip image is not in the
+	// release payload yet, so neither bootstrap nor the ConfigMap may carry
+	// it (both sides render it empty, preserving parity). Once the payload
+	// ships kube-vip, it must be added to the ConfigMap, image-references,
+	// and the bootstrap lookup together.
+	exceptions := map[string]bool{"kubeVipImage": true}
+
+	typ := reflect.TypeOf(ControllerConfigImages{})
+	for i := 0; i < typ.NumField(); i++ {
+		tag := typ.Field(i).Tag.Get("json")
+		require.NotEmpty(t, tag, "field %s has no json tag", typ.Field(i).Name)
+		if exceptions[tag] {
+			require.NotContains(t, imagesJSON, tag,
+				"%s is listed as payload-absent but present in the images ConfigMap; remove it from the exceptions", tag)
+			continue
+		}
+		require.Contains(t, imagesJSON, tag,
+			"images ConfigMap is missing %q: bootstrap and in-cluster template rendering would diverge and fail install with a bootstrap MC mismatch", tag)
+		require.NotEmpty(t, imagesJSON[tag], "images ConfigMap has an empty %q", tag)
+	}
+}

--- a/pkg/controller/template/constants.go
+++ b/pkg/controller/template/constants.go
@@ -22,6 +22,16 @@ const (
 	// BaremetalRuntimeCfgKey is the key that references the baremetal-runtimecfg image in the controller
 	BaremetalRuntimeCfgKey string = "baremetalRuntimeCfgImage"
 
+	// FRRK8sKey is the key for the frr-k8s image used by the frr-k8s static pod.
+	// A single image is used for all frr-k8s containers (controller, FRR daemon,
+	// reloader, metrics, status) in OpenShift.
+	FRRK8sKey string = "frrK8sImage"
+
+	// KubeVIPKey is the key for the kube-vip image used by the kube-vip static pods.
+	// kube-vip manages API and Ingress VIPs in Routing Table Mode for BGP-based
+	// VIP management.
+	KubeVIPKey string = "kubeVipImage"
+
 	// KubeRbacProxyKey the key that references the kubeRbacProxy image
 	KubeRbacProxyKey string = "kubeRbacProxyImage"
 

--- a/pkg/controller/template/constants.go
+++ b/pkg/controller/template/constants.go
@@ -22,14 +22,11 @@ const (
 	// BaremetalRuntimeCfgKey is the key that references the baremetal-runtimecfg image in the controller
 	BaremetalRuntimeCfgKey string = "baremetalRuntimeCfgImage"
 
-	// FRRK8sKey is the key for the frr-k8s image used by the frr-k8s static pod.
-	// A single image is used for all frr-k8s containers (controller, FRR daemon,
-	// reloader, metrics, status) in OpenShift.
+	// FRRK8sKey is the images.json key for the frr-k8s image (one image for
+	// all frr-k8s static pod containers).
 	FRRK8sKey string = "frrK8sImage"
 
-	// KubeVIPKey is the key for the kube-vip image used by the kube-vip static pods.
-	// kube-vip manages API and Ingress VIPs in Routing Table Mode for BGP-based
-	// VIP management.
+	// KubeVIPKey is the images.json key for the kube-vip image.
 	KubeVIPKey string = "kubeVipImage"
 
 	// KubeRbacProxyKey the key that references the kubeRbacProxy image

--- a/pkg/controller/template/render.go
+++ b/pkg/controller/template/render.go
@@ -386,6 +386,7 @@ func renderTemplate(config RenderConfig, path string, b []byte) ([]byte, error) 
 	funcs["urlHost"] = urlHost
 	funcs["urlPort"] = urlPort
 	funcs["isOpenShiftManagedDefaultLB"] = isOpenShiftManagedDefaultLB
+	funcs["isBGPVIPManagement"] = isBGPVIPManagement
 	funcs["dnsRecordsType"] = dnsRecordsType
 	funcs["cloudPlatformAPIIntLoadBalancerIPs"] = cloudPlatformAPIIntLoadBalancerIPs
 	funcs["cloudPlatformAPILoadBalancerIPs"] = cloudPlatformAPILoadBalancerIPs
@@ -497,10 +498,19 @@ func onPremPlatformIngressIP(cfg RenderConfig) (interface{}, error) {
 	if cfg.Infra.Status.PlatformStatus != nil {
 		switch cfg.Infra.Status.PlatformStatus.Type {
 		case configv1.BareMetalPlatformType:
+			if len(cfg.Infra.Status.PlatformStatus.BareMetal.IngressIPs) == 0 {
+				return nil, nil
+			}
 			return cfg.Infra.Status.PlatformStatus.BareMetal.IngressIPs[0], nil
 		case configv1.OvirtPlatformType:
+			if len(cfg.Infra.Status.PlatformStatus.Ovirt.IngressIPs) == 0 {
+				return nil, nil
+			}
 			return cfg.Infra.Status.PlatformStatus.Ovirt.IngressIPs[0], nil
 		case configv1.OpenStackPlatformType:
+			if len(cfg.Infra.Status.PlatformStatus.OpenStack.IngressIPs) == 0 {
+				return nil, nil
+			}
 			return cfg.Infra.Status.PlatformStatus.OpenStack.IngressIPs[0], nil
 		case configv1.VSpherePlatformType:
 			if cfg.Infra.Status.PlatformStatus.VSphere != nil {
@@ -513,6 +523,9 @@ func onPremPlatformIngressIP(cfg RenderConfig) (interface{}, error) {
 			// and there is also no data
 			return nil, nil
 		case configv1.NutanixPlatformType:
+			if len(cfg.Infra.Status.PlatformStatus.Nutanix.IngressIPs) == 0 {
+				return nil, nil
+			}
 			return cfg.Infra.Status.PlatformStatus.Nutanix.IngressIPs[0], nil
 		default:
 			return nil, fmt.Errorf("invalid platform for Ingress IP")
@@ -557,10 +570,19 @@ func onPremPlatformAPIServerInternalIP(cfg RenderConfig) (interface{}, error) {
 	if cfg.Infra.Status.PlatformStatus != nil {
 		switch cfg.Infra.Status.PlatformStatus.Type {
 		case configv1.BareMetalPlatformType:
+			if len(cfg.Infra.Status.PlatformStatus.BareMetal.APIServerInternalIPs) == 0 {
+				return nil, nil
+			}
 			return cfg.Infra.Status.PlatformStatus.BareMetal.APIServerInternalIPs[0], nil
 		case configv1.OvirtPlatformType:
+			if len(cfg.Infra.Status.PlatformStatus.Ovirt.APIServerInternalIPs) == 0 {
+				return nil, nil
+			}
 			return cfg.Infra.Status.PlatformStatus.Ovirt.APIServerInternalIPs[0], nil
 		case configv1.OpenStackPlatformType:
+			if len(cfg.Infra.Status.PlatformStatus.OpenStack.APIServerInternalIPs) == 0 {
+				return nil, nil
+			}
 			return cfg.Infra.Status.PlatformStatus.OpenStack.APIServerInternalIPs[0], nil
 		case configv1.VSpherePlatformType:
 			if cfg.Infra.Status.PlatformStatus.VSphere != nil {
@@ -573,6 +595,9 @@ func onPremPlatformAPIServerInternalIP(cfg RenderConfig) (interface{}, error) {
 			// and there is also no data
 			return nil, nil
 		case configv1.NutanixPlatformType:
+			if len(cfg.Infra.Status.PlatformStatus.Nutanix.APIServerInternalIPs) == 0 {
+				return nil, nil
+			}
 			return cfg.Infra.Status.PlatformStatus.Nutanix.APIServerInternalIPs[0], nil
 		default:
 			return nil, fmt.Errorf("invalid platform for API Server Internal IP")
@@ -721,6 +746,14 @@ func isOpenShiftManagedDefaultLB(cfg RenderConfig) bool {
 		}
 	}
 	return false
+}
+
+// isBGPVIPManagement returns true when the cluster is configured to use
+// BGP-based VIP management instead of keepalived/VRRP. This controls
+// whether MCO renders frr-k8s static pod manifests (BGP) or keepalived
+// static pod manifests (default).
+func isBGPVIPManagement(cfg RenderConfig) bool {
+	return ctrlcommon.IsBGPVIPManagement(cfg.Infra)
 }
 
 func dnsRecordsType(cfg RenderConfig) configv1.DNSRecordsType {

--- a/pkg/controller/template/render.go
+++ b/pkg/controller/template/render.go
@@ -748,10 +748,6 @@ func isOpenShiftManagedDefaultLB(cfg RenderConfig) bool {
 	return false
 }
 
-// isBGPVIPManagement returns true when the cluster is configured to use
-// BGP-based VIP management instead of keepalived/VRRP. This controls
-// whether MCO renders frr-k8s static pod manifests (BGP) or keepalived
-// static pod manifests (default).
 func isBGPVIPManagement(cfg RenderConfig) bool {
 	return ctrlcommon.IsBGPVIPManagement(cfg.Infra)
 }

--- a/pkg/controller/template/render_test.go
+++ b/pkg/controller/template/render_test.go
@@ -596,3 +596,148 @@ func verifyIgn(actual [][]byte, dir string, t *testing.T) {
 		t.Errorf("can't find expected file:\n%v", key)
 	}
 }
+
+func TestIsBGPVIPManagement(t *testing.T) {
+	dummyTemplate := []byte(`{{isBGPVIPManagement .}}`)
+
+	cases := []struct {
+		name   string
+		infra  *configv1.Infrastructure
+		result string
+	}{
+		{
+			name:   "nil infra",
+			infra:  nil,
+			result: "false",
+		},
+		{
+			name: "nil platform status",
+			infra: &configv1.Infrastructure{
+				Status: configv1.InfrastructureStatus{},
+			},
+			result: "false",
+		},
+		{
+			name: "baremetal without VIPManagement",
+			infra: &configv1.Infrastructure{
+				Status: configv1.InfrastructureStatus{
+					PlatformStatus: &configv1.PlatformStatus{
+						Type:      configv1.BareMetalPlatformType,
+						BareMetal: &configv1.BareMetalPlatformStatus{},
+					},
+				},
+			},
+			result: "false",
+		},
+		{
+			name: "baremetal with VIPManagement BGP",
+			infra: &configv1.Infrastructure{
+				Status: configv1.InfrastructureStatus{
+					PlatformStatus: &configv1.PlatformStatus{
+						Type: configv1.BareMetalPlatformType,
+						BareMetal: &configv1.BareMetalPlatformStatus{
+							VIPManagement:        "BGP",
+							APIServerInternalIPs: []string{"192.168.111.5"},
+							IngressIPs:           []string{"192.168.111.4"},
+						},
+					},
+				},
+			},
+			result: "true",
+		},
+		{
+			name: "baremetal with VIPManagement BGP but no VIPs (user-managed LB)",
+			infra: &configv1.Infrastructure{
+				Status: configv1.InfrastructureStatus{
+					PlatformStatus: &configv1.PlatformStatus{
+						Type: configv1.BareMetalPlatformType,
+						BareMetal: &configv1.BareMetalPlatformStatus{
+							VIPManagement: "BGP",
+						},
+					},
+				},
+			},
+			result: "false",
+		},
+		{
+			name: "baremetal with VIPManagement BGP but no ingress VIPs",
+			infra: &configv1.Infrastructure{
+				Status: configv1.InfrastructureStatus{
+					PlatformStatus: &configv1.PlatformStatus{
+						Type: configv1.BareMetalPlatformType,
+						BareMetal: &configv1.BareMetalPlatformStatus{
+							VIPManagement:        "BGP",
+							APIServerInternalIPs: []string{"192.168.111.5"},
+						},
+					},
+				},
+			},
+			result: "false",
+		},
+		{
+			name: "baremetal with VIPManagement Keepalived",
+			infra: &configv1.Infrastructure{
+				Status: configv1.InfrastructureStatus{
+					PlatformStatus: &configv1.PlatformStatus{
+						Type: configv1.BareMetalPlatformType,
+						BareMetal: &configv1.BareMetalPlatformStatus{
+							VIPManagement: "Keepalived",
+						},
+					},
+				},
+			},
+			result: "false",
+		},
+		{
+			name: "nil baremetal status",
+			infra: &configv1.Infrastructure{
+				Status: configv1.InfrastructureStatus{
+					PlatformStatus: &configv1.PlatformStatus{
+						Type: configv1.BareMetalPlatformType,
+					},
+				},
+			},
+			result: "false",
+		},
+		{
+			name: "vsphere platform",
+			infra: &configv1.Infrastructure{
+				Status: configv1.InfrastructureStatus{
+					PlatformStatus: &configv1.PlatformStatus{
+						Type: configv1.VSpherePlatformType,
+					},
+				},
+			},
+			result: "false",
+		},
+		{
+			name: "aws platform",
+			infra: &configv1.Infrastructure{
+				Status: configv1.InfrastructureStatus{
+					PlatformStatus: &configv1.PlatformStatus{
+						Type: configv1.AWSPlatformType,
+					},
+				},
+			},
+			result: "false",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			config := &mcfgv1.ControllerConfig{
+				Spec: mcfgv1.ControllerConfigSpec{
+					Infra: c.infra,
+				},
+			}
+
+			got, err := renderTemplate(RenderConfig{&config.Spec, `{"dummy":"dummy"}`, "dummy", nil, nil}, c.name, dummyTemplate)
+			if err != nil {
+				t.Fatalf("expected nil error, got: %v", err)
+			}
+			if string(got) != c.result {
+				t.Fatalf("mismatch: got %q, want %q", string(got), c.result)
+			}
+		})
+	}
+}

--- a/pkg/controller/template/render_test.go
+++ b/pkg/controller/template/render_test.go
@@ -741,3 +741,92 @@ func TestIsBGPVIPManagement(t *testing.T) {
 		})
 	}
 }
+
+// TestBGPVIPSecondaryFamilyRendering verifies that under BGP VIP management
+// with dual-stack VIPs, a second kube-vip instance per role is rendered for
+// the secondary address family (the VIPs slices' second entry), and that on
+// single-stack clusters the secondary manifests land in disabled-manifests.
+func TestBGPVIPSecondaryFamilyRendering(t *testing.T) {
+	cases := []struct {
+		name        string
+		apiVIPs     []string
+		ingressVIPs []string
+		wantAPIPath string
+		wantAPIAddr string
+		wantIngPath string
+		wantIngAddr string
+	}{
+		{
+			name:        "dual-stack renders secondary instances",
+			apiVIPs:     []string{"192.168.111.5", "fd2e:6f44:5dd8:c956::5"},
+			ingressVIPs: []string{"192.168.111.4", "fd2e:6f44:5dd8:c956::4"},
+			wantAPIPath: "/etc/kubernetes/manifests/0011-kube-vip-api-secondary.yaml",
+			wantAPIAddr: "fd2e:6f44:5dd8:c956::5",
+			wantIngPath: "/etc/kubernetes/manifests/0021-kube-vip-ingress-secondary.yaml",
+			wantIngAddr: "fd2e:6f44:5dd8:c956::4",
+		},
+		{
+			name:        "single-stack disables secondary instances",
+			apiVIPs:     []string{"192.168.111.5"},
+			ingressVIPs: []string{"192.168.111.4"},
+			wantAPIPath: "/etc/kubernetes/disabled-manifests/0011-kube-vip-api-secondary.yaml",
+			wantIngPath: "/etc/kubernetes/disabled-manifests/0021-kube-vip-ingress-secondary.yaml",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			controllerConfig, err := controllerConfigFromFile(configs["baremetal"])
+			if err != nil {
+				t.Fatalf("failed to get controllerconfig config: %v", err)
+			}
+			bm := controllerConfig.Spec.Infra.Status.PlatformStatus.BareMetal
+			bm.VIPManagement = "BGP"
+			bm.APIServerInternalIPs = tc.apiVIPs
+			bm.IngressIPs = tc.ingressVIPs
+
+			cfgs, err := generateTemplateMachineConfigs(&RenderConfig{&controllerConfig.Spec, `{"dummy":"dummy"}`, "dummy", nil, nil}, templateDir)
+			if err != nil {
+				t.Fatalf("failed to generate machine configs: %v", err)
+			}
+
+			checkFile := func(role, path, addr string) {
+				t.Helper()
+				found := false
+				for _, cfg := range cfgs {
+					if cfg.Labels[mcfgv1.MachineConfigRoleLabelKey] != role {
+						continue
+					}
+					ign, err := ctrlcommon.ParseAndConvertConfig(cfg.Spec.Config.Raw)
+					if err != nil {
+						t.Fatalf("failed to parse ignition config: %v", err)
+					}
+					for _, file := range ign.Storage.Files {
+						if string(file.Path) != path {
+							continue
+						}
+						found = true
+						if addr == "" {
+							continue
+						}
+						contents, err := ctrlcommon.DecodeIgnitionFileContents(file.Contents.Source, file.Contents.Compression)
+						if err != nil {
+							t.Fatalf("failed to decode %s: %v", path, err)
+						}
+						if !strings.Contains(string(contents), "value: \""+addr+"\"") {
+							t.Errorf("%s does not carry secondary VIP %q:\n%s", path, addr, string(contents))
+						}
+					}
+				}
+				if !found {
+					t.Errorf("no file %s rendered for role %s", path, role)
+				}
+			}
+
+			checkFile(masterRole, tc.wantAPIPath, tc.wantAPIAddr)
+			// the ingress instance is rendered for every role (templates/common)
+			checkFile(masterRole, tc.wantIngPath, tc.wantIngAddr)
+			checkFile(workerRole, tc.wantIngPath, tc.wantIngAddr)
+		})
+	}
+}

--- a/pkg/operator/bootstrap.go
+++ b/pkg/operator/bootstrap.go
@@ -112,6 +112,15 @@ func buildSpec(dependencies *BootstrapDependencies, imgs *ctrlcommon.Images, rel
 		return nil, err
 	}
 
+	// BGP-based VIP management renders frr-k8s and kube-vip static pods at
+	// bootstrap; without their images the manifests would carry empty image
+	// fields and the install dies much later with no useful signal.
+	if ctrlcommon.IsBGPVIPManagement(dependencies.Infrastructure) {
+		if imgs.FRRK8s == "" || imgs.KubeVip == "" {
+			return nil, fmt.Errorf("BGP-based VIP management is enabled but the frr-k8s (%q) or kube-vip (%q) image is missing from the release payload", imgs.FRRK8s, imgs.KubeVip)
+		}
+	}
+
 	if dependencies.AdditionalTrustBundle != "" {
 		spec.AdditionalTrustBundle = []byte(dependencies.AdditionalTrustBundle)
 	}
@@ -130,6 +139,7 @@ func buildSpec(dependencies *BootstrapDependencies, imgs *ctrlcommon.Images, rel
 	}
 
 	spec.RootCAData = []byte(dependencies.MCSCA)
+	spec.BGPVIPPeersJSON = dependencies.BGPVIPPeersJSON
 	spec.PullSecret = nil
 	spec.BaseOSContainerImage = imgs.BaseOSContainerImage
 	spec.BaseOSExtensionsContainerImage = imgs.BaseOSExtensionsContainerImage
@@ -145,6 +155,8 @@ func buildSpec(dependencies *BootstrapDependencies, imgs *ctrlcommon.Images, rel
 		templatectrl.BaremetalRuntimeCfgKey: imgs.BaremetalRuntimeCfg,
 		templatectrl.KubeRbacProxyKey:       imgs.KubeRbacProxy,
 		templatectrl.DockerRegistryKey:      imgs.DockerRegistry,
+		templatectrl.FRRK8sKey:              imgs.FRRK8s,
+		templatectrl.KubeVIPKey:             imgs.KubeVip,
 	}
 
 	config := getRenderConfig("", dependencies.KubeAPIServerServingCA, spec,
@@ -154,25 +166,29 @@ func buildSpec(dependencies *BootstrapDependencies, imgs *ctrlcommon.Images, rel
 
 func appendManifestsByPlatform(manifests []manifest, infra *configv1.Infrastructure) []manifest {
 	lbType := configv1.LoadBalancerTypeOpenShiftManagedDefault
+	var vipManagement configv1.VIPManagementType
 	if infra.Status.PlatformStatus.BareMetal != nil {
 		if infra.Status.PlatformStatus.BareMetal.LoadBalancer != nil {
 			lbType = infra.Status.PlatformStatus.BareMetal.LoadBalancer.Type
 		}
-		manifests = getPlatformManifests(manifests, strings.ToLower(string(configv1.BareMetalPlatformType)), lbType)
+		if ctrlcommon.IsBGPVIPManagement(infra) {
+			vipManagement = configv1.VIPManagementTypeBGP
+		}
+		manifests = getPlatformManifests(manifests, strings.ToLower(string(configv1.BareMetalPlatformType)), lbType, vipManagement)
 	}
 
 	if infra.Status.PlatformStatus.OpenStack != nil {
 		if infra.Status.PlatformStatus.OpenStack.LoadBalancer != nil {
 			lbType = infra.Status.PlatformStatus.OpenStack.LoadBalancer.Type
 		}
-		manifests = getPlatformManifests(manifests, strings.ToLower(string(configv1.OpenStackPlatformType)), lbType)
+		manifests = getPlatformManifests(manifests, strings.ToLower(string(configv1.OpenStackPlatformType)), lbType, "")
 	}
 
 	if infra.Status.PlatformStatus.Ovirt != nil {
 		if infra.Status.PlatformStatus.Ovirt.LoadBalancer != nil {
 			lbType = infra.Status.PlatformStatus.Ovirt.LoadBalancer.Type
 		}
-		manifests = getPlatformManifests(manifests, strings.ToLower(string(configv1.OvirtPlatformType)), lbType)
+		manifests = getPlatformManifests(manifests, strings.ToLower(string(configv1.OvirtPlatformType)), lbType, "")
 	}
 
 	if infra.Status.PlatformStatus.VSphere != nil {
@@ -189,14 +205,14 @@ func appendManifestsByPlatform(manifests []manifest, infra *configv1.Infrastruct
 				return manifests
 			}
 		}
-		manifests = getPlatformManifests(manifests, strings.ToLower(string(configv1.VSpherePlatformType)), lbType)
+		manifests = getPlatformManifests(manifests, strings.ToLower(string(configv1.VSpherePlatformType)), lbType, "")
 	}
 
 	if infra.Status.PlatformStatus.Nutanix != nil {
 		if infra.Status.PlatformStatus.Nutanix.LoadBalancer != nil {
 			lbType = infra.Status.PlatformStatus.Nutanix.LoadBalancer.Type
 		}
-		manifests = getPlatformManifests(manifests, strings.ToLower(string(configv1.NutanixPlatformType)), lbType)
+		manifests = getPlatformManifests(manifests, strings.ToLower(string(configv1.NutanixPlatformType)), lbType, "")
 	}
 
 	if infra.Status.PlatformStatus.GCP != nil {
@@ -205,7 +221,7 @@ func appendManifestsByPlatform(manifests []manifest, infra *configv1.Infrastruct
 			// We do not need the keepalived manifests to be generated because the cloud default Load Balancers are in use.
 			// So, setting the lbType to `UserManaged` although the default cloud LBs are not user managed.
 			lbType = configv1.LoadBalancerTypeUserManaged
-			manifests = getPlatformManifests(manifests, strings.ToLower(string(configv1.GCPPlatformType)), lbType)
+			manifests = getPlatformManifests(manifests, strings.ToLower(string(configv1.GCPPlatformType)), lbType, "")
 		}
 	}
 	if infra.Status.PlatformStatus.AWS != nil {
@@ -214,7 +230,7 @@ func appendManifestsByPlatform(manifests []manifest, infra *configv1.Infrastruct
 			// We do not need the keepalived manifests to be generated because the cloud default Load Balancers are in use.
 			// So, setting the lbType to `UserManaged` although the default cloud LBs are not user managed.
 			lbType = configv1.LoadBalancerTypeUserManaged
-			manifests = getPlatformManifests(manifests, strings.ToLower(string(configv1.AWSPlatformType)), lbType)
+			manifests = getPlatformManifests(manifests, strings.ToLower(string(configv1.AWSPlatformType)), lbType, "")
 		}
 	}
 	if infra.Status.PlatformStatus.Azure != nil {
@@ -223,14 +239,14 @@ func appendManifestsByPlatform(manifests []manifest, infra *configv1.Infrastruct
 			// We do not need the keepalived manifests to be generated because the cloud default Load Balancers are in use.
 			// So, setting the lbType to `UserManaged` although the default cloud LBs are not user managed.
 			lbType = configv1.LoadBalancerTypeUserManaged
-			manifests = getPlatformManifests(manifests, strings.ToLower(string(configv1.AzurePlatformType)), lbType)
+			manifests = getPlatformManifests(manifests, strings.ToLower(string(configv1.AzurePlatformType)), lbType, "")
 		}
 	}
 
 	return manifests
 }
 
-func getPlatformManifests(manifests []manifest, platformName string, lbType configv1.PlatformLoadBalancerType) []manifest {
+func getPlatformManifests(manifests []manifest, platformName string, lbType configv1.PlatformLoadBalancerType, vipManagement configv1.VIPManagementType) []manifest {
 	var corednsName string
 	var corefileName string
 	switch platformName {
@@ -254,16 +270,27 @@ func getPlatformManifests(manifests []manifest, platformName string, lbType conf
 	)
 
 	if lbType == configv1.LoadBalancerTypeOpenShiftManagedDefault || lbType == "" {
-		platformManifests = append(platformManifests,
-			manifest{
-				name:     "manifests/on-prem/keepalived.yaml",
-				filename: platformName + "/manifests/keepalived.yaml",
-			},
-			manifest{
-				name:     "manifests/on-prem/keepalived.conf.tmpl",
-				filename: platformName + "/static-pod-resources/keepalived/keepalived.conf.tmpl",
-			},
-		)
+		if vipManagement == "BGP" {
+			platformManifests = append(platformManifests,
+				manifest{name: "manifests/on-prem/0000-frr-k8s.yaml", filename: platformName + "/manifests/0000-frr-k8s.yaml"},
+				manifest{name: "manifests/on-prem/frr.conf.tmpl", filename: platformName + "/static-pod-resources/frr-k8s/frr.conf.tmpl"},
+				manifest{name: "manifests/on-prem/frr-peers.json.tmpl", filename: platformName + "/static-pod-resources/frr-k8s/frr-peers.json"},
+				manifest{name: "manifests/on-prem/frr-startup-daemons", filename: platformName + "/static-pod-resources/frr-k8s/startup/daemons"},
+				manifest{name: "manifests/on-prem/frr-startup-vtysh.conf", filename: platformName + "/static-pod-resources/frr-k8s/startup/vtysh.conf"},
+				manifest{name: "manifests/on-prem/0010-kube-vip-api.yaml", filename: platformName + "/manifests/0010-kube-vip-api.yaml"},
+			)
+		} else {
+			platformManifests = append(platformManifests,
+				manifest{
+					name:     "manifests/on-prem/keepalived.yaml",
+					filename: platformName + "/manifests/keepalived.yaml",
+				},
+				manifest{
+					name:     "manifests/on-prem/keepalived.conf.tmpl",
+					filename: platformName + "/static-pod-resources/keepalived/keepalived.conf.tmpl",
+				},
+			)
+		}
 	}
 
 	return append(manifests, platformManifests...)

--- a/pkg/operator/bootstrap.go
+++ b/pkg/operator/bootstrap.go
@@ -174,21 +174,24 @@ func appendManifestsByPlatform(manifests []manifest, infra *configv1.Infrastruct
 		if ctrlcommon.IsBGPVIPManagement(infra) {
 			vipManagement = configv1.VIPManagementTypeBGP
 		}
-		manifests = getPlatformManifests(manifests, strings.ToLower(string(configv1.BareMetalPlatformType)), lbType, vipManagement)
+		// dual-stack clusters carry one API VIP per address family; the
+		// bootstrap node then needs one kube-vip instance per family
+		dualStackVIPs := len(infra.Status.PlatformStatus.BareMetal.APIServerInternalIPs) > 1
+		manifests = getPlatformManifests(manifests, strings.ToLower(string(configv1.BareMetalPlatformType)), lbType, vipManagement, dualStackVIPs)
 	}
 
 	if infra.Status.PlatformStatus.OpenStack != nil {
 		if infra.Status.PlatformStatus.OpenStack.LoadBalancer != nil {
 			lbType = infra.Status.PlatformStatus.OpenStack.LoadBalancer.Type
 		}
-		manifests = getPlatformManifests(manifests, strings.ToLower(string(configv1.OpenStackPlatformType)), lbType, "")
+		manifests = getPlatformManifests(manifests, strings.ToLower(string(configv1.OpenStackPlatformType)), lbType, "", false)
 	}
 
 	if infra.Status.PlatformStatus.Ovirt != nil {
 		if infra.Status.PlatformStatus.Ovirt.LoadBalancer != nil {
 			lbType = infra.Status.PlatformStatus.Ovirt.LoadBalancer.Type
 		}
-		manifests = getPlatformManifests(manifests, strings.ToLower(string(configv1.OvirtPlatformType)), lbType, "")
+		manifests = getPlatformManifests(manifests, strings.ToLower(string(configv1.OvirtPlatformType)), lbType, "", false)
 	}
 
 	if infra.Status.PlatformStatus.VSphere != nil {
@@ -205,14 +208,14 @@ func appendManifestsByPlatform(manifests []manifest, infra *configv1.Infrastruct
 				return manifests
 			}
 		}
-		manifests = getPlatformManifests(manifests, strings.ToLower(string(configv1.VSpherePlatformType)), lbType, "")
+		manifests = getPlatformManifests(manifests, strings.ToLower(string(configv1.VSpherePlatformType)), lbType, "", false)
 	}
 
 	if infra.Status.PlatformStatus.Nutanix != nil {
 		if infra.Status.PlatformStatus.Nutanix.LoadBalancer != nil {
 			lbType = infra.Status.PlatformStatus.Nutanix.LoadBalancer.Type
 		}
-		manifests = getPlatformManifests(manifests, strings.ToLower(string(configv1.NutanixPlatformType)), lbType, "")
+		manifests = getPlatformManifests(manifests, strings.ToLower(string(configv1.NutanixPlatformType)), lbType, "", false)
 	}
 
 	if infra.Status.PlatformStatus.GCP != nil {
@@ -221,7 +224,7 @@ func appendManifestsByPlatform(manifests []manifest, infra *configv1.Infrastruct
 			// We do not need the keepalived manifests to be generated because the cloud default Load Balancers are in use.
 			// So, setting the lbType to `UserManaged` although the default cloud LBs are not user managed.
 			lbType = configv1.LoadBalancerTypeUserManaged
-			manifests = getPlatformManifests(manifests, strings.ToLower(string(configv1.GCPPlatformType)), lbType, "")
+			manifests = getPlatformManifests(manifests, strings.ToLower(string(configv1.GCPPlatformType)), lbType, "", false)
 		}
 	}
 	if infra.Status.PlatformStatus.AWS != nil {
@@ -230,7 +233,7 @@ func appendManifestsByPlatform(manifests []manifest, infra *configv1.Infrastruct
 			// We do not need the keepalived manifests to be generated because the cloud default Load Balancers are in use.
 			// So, setting the lbType to `UserManaged` although the default cloud LBs are not user managed.
 			lbType = configv1.LoadBalancerTypeUserManaged
-			manifests = getPlatformManifests(manifests, strings.ToLower(string(configv1.AWSPlatformType)), lbType, "")
+			manifests = getPlatformManifests(manifests, strings.ToLower(string(configv1.AWSPlatformType)), lbType, "", false)
 		}
 	}
 	if infra.Status.PlatformStatus.Azure != nil {
@@ -239,14 +242,14 @@ func appendManifestsByPlatform(manifests []manifest, infra *configv1.Infrastruct
 			// We do not need the keepalived manifests to be generated because the cloud default Load Balancers are in use.
 			// So, setting the lbType to `UserManaged` although the default cloud LBs are not user managed.
 			lbType = configv1.LoadBalancerTypeUserManaged
-			manifests = getPlatformManifests(manifests, strings.ToLower(string(configv1.AzurePlatformType)), lbType, "")
+			manifests = getPlatformManifests(manifests, strings.ToLower(string(configv1.AzurePlatformType)), lbType, "", false)
 		}
 	}
 
 	return manifests
 }
 
-func getPlatformManifests(manifests []manifest, platformName string, lbType configv1.PlatformLoadBalancerType, vipManagement configv1.VIPManagementType) []manifest {
+func getPlatformManifests(manifests []manifest, platformName string, lbType configv1.PlatformLoadBalancerType, vipManagement configv1.VIPManagementType, dualStackVIPs bool) []manifest {
 	var corednsName string
 	var corefileName string
 	switch platformName {
@@ -279,6 +282,11 @@ func getPlatformManifests(manifests []manifest, platformName string, lbType conf
 				manifest{name: "manifests/on-prem/frr-startup-vtysh.conf", filename: platformName + "/static-pod-resources/frr-k8s/startup/vtysh.conf"},
 				manifest{name: "manifests/on-prem/0010-kube-vip-api.yaml", filename: platformName + "/manifests/0010-kube-vip-api.yaml"},
 			)
+			if dualStackVIPs {
+				platformManifests = append(platformManifests,
+					manifest{name: "manifests/on-prem/0011-kube-vip-api-secondary.yaml", filename: platformName + "/manifests/0011-kube-vip-api-secondary.yaml"},
+				)
+			}
 		} else {
 			platformManifests = append(platformManifests,
 				manifest{

--- a/pkg/operator/bootstrap_dependencies.go
+++ b/pkg/operator/bootstrap_dependencies.go
@@ -25,6 +25,7 @@ type BootstrapDependenciesFiles struct {
 	MCSCAFile              string
 	KubeAPIServerServingCA string
 	PullSecret             string
+	BGPVIPConfig           string
 }
 
 // Validate ensures all required files are set and all provided file paths exist.
@@ -45,6 +46,7 @@ func (b BootstrapDependenciesFiles) Validate() error {
 		{"CloudProviderCA", b.CloudProviderCA, false},
 		{"AdditionalTrustBundle", b.AdditionalTrustBundle, false},
 		{"CloudConfig", b.CloudConfig, false},
+		{"BGPVIPConfig", b.BGPVIPConfig, false},
 	}
 	for _, file := range files {
 		if err := b.validateFile(file.name, file.path, file.required); err != nil {
@@ -87,6 +89,7 @@ type BootstrapDependencies struct {
 	KubeAPIServerServingCA string
 	MCSCA                  string
 	AdditionalTrustBundle  string
+	BGPVIPPeersJSON        string
 }
 
 // NewBootstrapDependencies creates a new BootstrapDependencies instance by validating and loading
@@ -129,6 +132,9 @@ func (b *BootstrapDependencies) fillDependencies() error {
 		return err
 	}
 	if err := b.fillClusterConfig(); err != nil {
+		return err
+	}
+	if err := b.fillBGPVIPConfig(b.Files.BGPVIPConfig); err != nil {
 		return err
 	}
 	if err := b.fillCloudConfigData(); err != nil {
@@ -274,5 +280,32 @@ func (b *BootstrapDependencies) fillClusterConfig() error {
 	if b.ClusterConfig, err = readString(b.Files.ClusterConfig); err != nil {
 		return fmt.Errorf("failed to read ClusterConfig file %s: %w", b.Files.ClusterConfig, err)
 	}
+	return nil
+}
+
+// fillBGPVIPConfig loads the optional bgp-vip-config ConfigMap manifest and
+// extracts its config.json payload for frr-peers.json rendering.
+func (b *BootstrapDependencies) fillBGPVIPConfig(path string) error {
+	if path == "" {
+		return nil
+	}
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return nil // optional: only present when BGP VIP management is enabled
+	}
+	cm, err := readCoreCR[*corev1.ConfigMap](path)
+	if err != nil {
+		return fmt.Errorf("failed to read bgp-vip-config ConfigMap: %w", err)
+	}
+	// Mirror the day-2 sync: a present ConfigMap without a config.json
+	// payload is a hard error, not an empty peers file.
+	raw := cm.Data["config.json"]
+	if raw == "" {
+		return fmt.Errorf("bgp-vip-config ConfigMap has no config.json payload")
+	}
+	peersJSON, err := compactBGPVIPPeersJSON(raw)
+	if err != nil {
+		return err
+	}
+	b.BGPVIPPeersJSON = peersJSON
 	return nil
 }

--- a/pkg/operator/bootstrap_test.go
+++ b/pkg/operator/bootstrap_test.go
@@ -1,0 +1,238 @@
+package operator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetPlatformManifests(t *testing.T) {
+	cases := []struct {
+		name             string
+		platformName     string
+		lbType           configv1.PlatformLoadBalancerType
+		vipManagement    configv1.VIPManagementType
+		expectKeepalived bool
+		expectFRRK8s     bool
+		expectCoredns    bool
+		expectKubeVIPAPI bool
+	}{
+		{
+			name:             "baremetal default LB, no BGP",
+			platformName:     "baremetal",
+			lbType:           configv1.LoadBalancerTypeOpenShiftManagedDefault,
+			vipManagement:    "",
+			expectKeepalived: true,
+			expectFRRK8s:     false,
+			expectCoredns:    true,
+			expectKubeVIPAPI: false,
+		},
+		{
+			name:             "baremetal default LB, BGP enabled",
+			platformName:     "baremetal",
+			lbType:           configv1.LoadBalancerTypeOpenShiftManagedDefault,
+			vipManagement:    "BGP",
+			expectKeepalived: false,
+			expectFRRK8s:     true,
+			expectCoredns:    true,
+			expectKubeVIPAPI: true,
+		},
+		{
+			name:             "baremetal user-managed LB, no BGP",
+			platformName:     "baremetal",
+			lbType:           configv1.LoadBalancerTypeUserManaged,
+			vipManagement:    "",
+			expectKeepalived: false,
+			expectFRRK8s:     false,
+			expectCoredns:    true,
+			expectKubeVIPAPI: false,
+		},
+		{
+			name:             "baremetal user-managed LB, BGP enabled",
+			platformName:     "baremetal",
+			lbType:           configv1.LoadBalancerTypeUserManaged,
+			vipManagement:    "BGP",
+			expectKeepalived: false,
+			expectFRRK8s:     false,
+			expectCoredns:    true,
+			expectKubeVIPAPI: false,
+		},
+		{
+			name:             "baremetal empty LB type, no BGP",
+			platformName:     "baremetal",
+			lbType:           "",
+			vipManagement:    "",
+			expectKeepalived: true,
+			expectFRRK8s:     false,
+			expectCoredns:    true,
+			expectKubeVIPAPI: false,
+		},
+		{
+			name:             "baremetal empty LB type, BGP enabled",
+			platformName:     "baremetal",
+			lbType:           "",
+			vipManagement:    "BGP",
+			expectKeepalived: false,
+			expectFRRK8s:     true,
+			expectCoredns:    true,
+			expectKubeVIPAPI: true,
+		},
+		{
+			name:             "openstack default LB, no BGP",
+			platformName:     "openstack",
+			lbType:           configv1.LoadBalancerTypeOpenShiftManagedDefault,
+			vipManagement:    "",
+			expectKeepalived: true,
+			expectFRRK8s:     false,
+			expectCoredns:    true,
+			expectKubeVIPAPI: false,
+		},
+		{
+			name:             "gcp cloud platform",
+			platformName:     "gcp",
+			lbType:           configv1.LoadBalancerTypeUserManaged,
+			vipManagement:    "",
+			expectKeepalived: false,
+			expectFRRK8s:     false,
+			expectCoredns:    true,
+			expectKubeVIPAPI: false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			result := getPlatformManifests(nil, c.platformName, c.lbType, c.vipManagement)
+
+			hasKeepalived := false
+			hasFRRK8s := false
+			hasCoredns := false
+			hasKubeVIPAPI := false
+			for _, m := range result {
+				if m.name == "manifests/on-prem/keepalived.yaml" {
+					hasKeepalived = true
+				}
+				if m.name == "manifests/on-prem/0000-frr-k8s.yaml" {
+					hasFRRK8s = true
+				}
+				if m.name == "manifests/on-prem/coredns.yaml" || m.name == "manifests/cloud-platform-alt-dns/coredns.yaml" {
+					hasCoredns = true
+				}
+				if m.name == "manifests/on-prem/0010-kube-vip-api.yaml" {
+					hasKubeVIPAPI = true
+				}
+			}
+
+			assert.Equal(t, c.expectKeepalived, hasKeepalived, "keepalived manifest presence")
+			assert.Equal(t, c.expectFRRK8s, hasFRRK8s, "frr-k8s manifest presence")
+			assert.Equal(t, c.expectCoredns, hasCoredns, "coredns manifest presence")
+			assert.Equal(t, c.expectKubeVIPAPI, hasKubeVIPAPI, "kube-vip-api manifest presence")
+		})
+	}
+}
+
+func TestFillBGPVIPConfig(t *testing.T) {
+	dir := t.TempDir()
+	peersJSON := `{"localASN":64512,"defaultPeers":[{"peerAddress":"192.168.111.1","peerASN":64513}],"apiVIPs":["192.168.111.5"],"ingressVIPs":["192.168.111.4"]}`
+	cmYAML := `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: bgp-vip-config
+  namespace: openshift-network-operator
+data:
+  config.json: '` + peersJSON + `'
+`
+	path := filepath.Join(dir, "bgp-vip-config.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(cmYAML), 0o644))
+
+	deps := &BootstrapDependencies{}
+	require.NoError(t, deps.fillBGPVIPConfig(path), "fillBGPVIPConfig")
+	assert.Equal(t, peersJSON, deps.BGPVIPPeersJSON, "BGPVIPPeersJSON must be the compacted config.json payload")
+
+	// Missing file is tolerated (optional dependency).
+	deps2 := &BootstrapDependencies{}
+	require.NoError(t, deps2.fillBGPVIPConfig(filepath.Join(dir, "nonexistent.yaml")), "missing file must not error")
+	assert.Empty(t, deps2.BGPVIPPeersJSON, "expected empty for missing file")
+
+	// Malformed config.json payload must be rejected.
+	badCMYAML := `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: bgp-vip-config
+  namespace: openshift-network-operator
+data:
+  config.json: '{not json'
+`
+	badPath := filepath.Join(dir, "bgp-vip-config-bad.yaml")
+	require.NoError(t, os.WriteFile(badPath, []byte(badCMYAML), 0o644))
+
+	deps3 := &BootstrapDependencies{}
+	assert.Error(t, deps3.fillBGPVIPConfig(badPath), "malformed config.json must error")
+	assert.Empty(t, deps3.BGPVIPPeersJSON, "expected empty for malformed config.json")
+
+	// A present ConfigMap without a config.json payload must be rejected
+	// (mirrors the day-2 sync behavior).
+	emptyCMYAML := `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: bgp-vip-config
+  namespace: openshift-network-operator
+data: {}
+`
+	emptyPath := filepath.Join(dir, "bgp-vip-config-empty.yaml")
+	require.NoError(t, os.WriteFile(emptyPath, []byte(emptyCMYAML), 0o644))
+
+	deps4 := &BootstrapDependencies{}
+	assert.Error(t, deps4.fillBGPVIPConfig(emptyPath), "empty config.json payload must error")
+	assert.Empty(t, deps4.BGPVIPPeersJSON, "expected empty for empty config.json")
+}
+
+// TestBuildSpecBGPImageValidation locks the bootstrap hard-fail: rendering a
+// BGP VIP management cluster without the frr-k8s/kube-vip images must error
+// at render time rather than emit static pod manifests with empty images.
+func TestBuildSpecBGPImageValidation(t *testing.T) {
+	bgpInfra := &configv1.Infrastructure{
+		Status: configv1.InfrastructureStatus{
+			PlatformStatus: &configv1.PlatformStatus{
+				Type: configv1.BareMetalPlatformType,
+				BareMetal: &configv1.BareMetalPlatformStatus{
+					VIPManagement:        configv1.VIPManagementTypeBGP,
+					APIServerInternalIPs: []string{"192.168.111.5"},
+					IngressIPs:           []string{"192.168.111.4"},
+				},
+			},
+			EtcdDiscoveryDomain: "tt.testing",
+		},
+	}
+	deps := func(infra *configv1.Infrastructure) *BootstrapDependencies {
+		return &BootstrapDependencies{
+			Infrastructure: infra,
+			Network: &configv1.Network{
+				Spec: configv1.NetworkSpec{ServiceNetwork: []string{"192.168.1.0/24"}}},
+			DNS: &configv1.DNS{
+				Spec: configv1.DNSSpec{BaseDomain: "tt.testing"}},
+		}
+	}
+	imgs := &ctrlcommon.Images{}
+
+	if _, err := buildSpec(deps(bgpInfra), imgs, ""); err == nil {
+		t.Fatal("expected an error for BGP VIP management without frr-k8s/kube-vip images")
+	}
+
+	imgs.FRRK8s = "frr-k8s-image"
+	imgs.KubeVip = "kube-vip-image"
+	if _, err := buildSpec(deps(bgpInfra), imgs, ""); err != nil {
+		t.Fatalf("unexpected error with images present: %v", err)
+	}
+
+	// VIP-less BGP falls back to keepalived; missing images must not fail.
+	noVIPs := bgpInfra.DeepCopy()
+	noVIPs.Status.PlatformStatus.BareMetal.APIServerInternalIPs = nil
+	if _, err := buildSpec(deps(noVIPs), &ctrlcommon.Images{}, ""); err != nil {
+		t.Fatalf("unexpected error for VIP-less BGP without images: %v", err)
+	}
+}

--- a/pkg/operator/bootstrap_test.go
+++ b/pkg/operator/bootstrap_test.go
@@ -21,6 +21,8 @@ func TestGetPlatformManifests(t *testing.T) {
 		expectFRRK8s     bool
 		expectCoredns    bool
 		expectKubeVIPAPI bool
+		dualStackVIPs    bool
+		expectSecondary  bool
 	}{
 		{
 			name:             "baremetal default LB, no BGP",
@@ -83,6 +85,18 @@ func TestGetPlatformManifests(t *testing.T) {
 			expectKubeVIPAPI: true,
 		},
 		{
+			name:             "baremetal BGP enabled, dual-stack VIPs",
+			platformName:     "baremetal",
+			lbType:           "",
+			vipManagement:    "BGP",
+			dualStackVIPs:    true,
+			expectKeepalived: false,
+			expectFRRK8s:     true,
+			expectCoredns:    true,
+			expectKubeVIPAPI: true,
+			expectSecondary:  true,
+		},
+		{
 			name:             "openstack default LB, no BGP",
 			platformName:     "openstack",
 			lbType:           configv1.LoadBalancerTypeOpenShiftManagedDefault,
@@ -106,12 +120,13 @@ func TestGetPlatformManifests(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			result := getPlatformManifests(nil, c.platformName, c.lbType, c.vipManagement)
+			result := getPlatformManifests(nil, c.platformName, c.lbType, c.vipManagement, c.dualStackVIPs)
 
 			hasKeepalived := false
 			hasFRRK8s := false
 			hasCoredns := false
 			hasKubeVIPAPI := false
+			hasSecondary := false
 			for _, m := range result {
 				if m.name == "manifests/on-prem/keepalived.yaml" {
 					hasKeepalived = true
@@ -125,12 +140,16 @@ func TestGetPlatformManifests(t *testing.T) {
 				if m.name == "manifests/on-prem/0010-kube-vip-api.yaml" {
 					hasKubeVIPAPI = true
 				}
+				if m.name == "manifests/on-prem/0011-kube-vip-api-secondary.yaml" {
+					hasSecondary = true
+				}
 			}
 
 			assert.Equal(t, c.expectKeepalived, hasKeepalived, "keepalived manifest presence")
 			assert.Equal(t, c.expectFRRK8s, hasFRRK8s, "frr-k8s manifest presence")
 			assert.Equal(t, c.expectCoredns, hasCoredns, "coredns manifest presence")
 			assert.Equal(t, c.expectKubeVIPAPI, hasKubeVIPAPI, "kube-vip-api manifest presence")
+			assert.Equal(t, c.expectSecondary, hasSecondary, "kube-vip-api-secondary manifest presence")
 		})
 	}
 }

--- a/pkg/operator/render.go
+++ b/pkg/operator/render.go
@@ -281,10 +281,19 @@ func onPremPlatformIngressIP(cfg mcfgv1.ControllerConfigSpec) (interface{}, erro
 	if cfg.Infra.Status.PlatformStatus != nil {
 		switch cfg.Infra.Status.PlatformStatus.Type {
 		case configv1.BareMetalPlatformType:
+			if len(cfg.Infra.Status.PlatformStatus.BareMetal.IngressIPs) == 0 {
+				return nil, nil
+			}
 			return cfg.Infra.Status.PlatformStatus.BareMetal.IngressIPs[0], nil
 		case configv1.OvirtPlatformType:
+			if len(cfg.Infra.Status.PlatformStatus.Ovirt.IngressIPs) == 0 {
+				return nil, nil
+			}
 			return cfg.Infra.Status.PlatformStatus.Ovirt.IngressIPs[0], nil
 		case configv1.OpenStackPlatformType:
+			if len(cfg.Infra.Status.PlatformStatus.OpenStack.IngressIPs) == 0 {
+				return nil, nil
+			}
 			return cfg.Infra.Status.PlatformStatus.OpenStack.IngressIPs[0], nil
 		case configv1.VSpherePlatformType:
 			if len(cfg.Infra.Status.PlatformStatus.VSphere.IngressIPs) > 0 {
@@ -292,6 +301,9 @@ func onPremPlatformIngressIP(cfg mcfgv1.ControllerConfigSpec) (interface{}, erro
 			}
 			return nil, nil
 		case configv1.NutanixPlatformType:
+			if len(cfg.Infra.Status.PlatformStatus.Nutanix.IngressIPs) == 0 {
+				return nil, nil
+			}
 			return cfg.Infra.Status.PlatformStatus.Nutanix.IngressIPs[0], nil
 		default:
 			return nil, fmt.Errorf("invalid platform for Ingress IP")
@@ -332,10 +344,19 @@ func onPremPlatformAPIServerInternalIP(cfg mcfgv1.ControllerConfigSpec) (interfa
 	if cfg.Infra.Status.PlatformStatus != nil {
 		switch cfg.Infra.Status.PlatformStatus.Type {
 		case configv1.BareMetalPlatformType:
+			if len(cfg.Infra.Status.PlatformStatus.BareMetal.APIServerInternalIPs) == 0 {
+				return nil, nil
+			}
 			return cfg.Infra.Status.PlatformStatus.BareMetal.APIServerInternalIPs[0], nil
 		case configv1.OvirtPlatformType:
+			if len(cfg.Infra.Status.PlatformStatus.Ovirt.APIServerInternalIPs) == 0 {
+				return nil, nil
+			}
 			return cfg.Infra.Status.PlatformStatus.Ovirt.APIServerInternalIPs[0], nil
 		case configv1.OpenStackPlatformType:
+			if len(cfg.Infra.Status.PlatformStatus.OpenStack.APIServerInternalIPs) == 0 {
+				return nil, nil
+			}
 			return cfg.Infra.Status.PlatformStatus.OpenStack.APIServerInternalIPs[0], nil
 		case configv1.VSpherePlatformType:
 			if len(cfg.Infra.Status.PlatformStatus.VSphere.APIServerInternalIPs) > 0 {
@@ -343,6 +364,9 @@ func onPremPlatformAPIServerInternalIP(cfg mcfgv1.ControllerConfigSpec) (interfa
 			}
 			return nil, nil
 		case configv1.NutanixPlatformType:
+			if len(cfg.Infra.Status.PlatformStatus.Nutanix.APIServerInternalIPs) == 0 {
+				return nil, nil
+			}
 			return cfg.Infra.Status.PlatformStatus.Nutanix.APIServerInternalIPs[0], nil
 		default:
 			return nil, fmt.Errorf("invalid platform for API Server Internal IP")

--- a/pkg/operator/render_test.go
+++ b/pkg/operator/render_test.go
@@ -120,6 +120,7 @@ func TestRenderAllManifests(t *testing.T) {
 				HTTPSProxy: "https://i.am.a.proxy.server",
 				NoProxy:    "*",
 			},
+			BGPVIPPeersJSON: `{"localASN":64512,"defaultPeers":[{"peerAddress":"192.168.111.1","peerASN":64513}]}`,
 			Infra: &configv1.Infrastructure{
 				Status: configv1.InfrastructureStatus{
 					PlatformStatus: &configv1.PlatformStatus{

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -374,6 +374,48 @@ func (optr *Operator) syncCloudConfig(spec *mcfgv1.ControllerConfigSpec, infra *
 	return nil
 }
 
+// compactBGPVIPPeersJSON validates and compacts the bgp-vip-config payload so
+// it is safe to embed in single-line template contexts.
+func compactBGPVIPPeersJSON(raw string) (string, error) {
+	if raw == "" {
+		return "", nil
+	}
+	var buf bytes.Buffer
+	if err := json.Compact(&buf, []byte(raw)); err != nil {
+		return "", fmt.Errorf("bgp-vip-config config.json is not valid JSON: %w", err)
+	}
+	return buf.String(), nil
+}
+
+// syncBGPVIPPeersJSON populates spec.BGPVIPPeersJSON from the
+// openshift-network-operator/bgp-vip-config ConfigMap when BGP-based VIP
+// management is enabled on a BareMetal platform.
+func (optr *Operator) syncBGPVIPPeersJSON(spec *mcfgv1.ControllerConfigSpec, infra *configv1.Infrastructure) error {
+	if !ctrlcommon.IsBGPVIPManagement(infra) {
+		return nil
+	}
+	cm, err := optr.clusterCmLister.ConfigMaps("openshift-network-operator").Get("bgp-vip-config")
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			// The spec is rebuilt from scratch on every sync, so silently
+			// tolerating absence would blank the peers file fleet-wide.
+			// Degrade instead, holding the last good ControllerConfig.
+			return fmt.Errorf("BGP VIP management is enabled but the openshift-network-operator/bgp-vip-config ConfigMap is missing")
+		}
+		return fmt.Errorf("failed to read bgp-vip-config ConfigMap: %w", err)
+	}
+	raw := cm.Data["config.json"]
+	if raw == "" {
+		return fmt.Errorf("BGP VIP management is enabled but the bgp-vip-config ConfigMap has no config.json payload")
+	}
+	peersJSON, err := compactBGPVIPPeersJSON(raw)
+	if err != nil {
+		return err
+	}
+	spec.BGPVIPPeersJSON = peersJSON
+	return nil
+}
+
 //nolint:gocyclo
 func (optr *Operator) syncRenderConfig(_ *renderConfig, _ *configv1.ClusterOperator) error {
 	if optr.inClusterBringup {
@@ -598,6 +640,10 @@ func (optr *Operator) syncRenderConfig(_ *renderConfig, _ *configv1.ClusterOpera
 		return err
 	}
 
+	if err := optr.syncBGPVIPPeersJSON(spec, infra); err != nil {
+		return err
+	}
+
 	if !osimagestream.IsFeatureEnabled(optr.fgHandler) {
 		oscontainer, osextensionscontainer, err := optr.getOSImageURLsFromConfigMap()
 		if err != nil {
@@ -625,6 +671,8 @@ func (optr *Operator) syncRenderConfig(_ *renderConfig, _ *configv1.ClusterOpera
 		templatectrl.BaremetalRuntimeCfgKey:   imgs.BaremetalRuntimeCfg,
 		templatectrl.KubeRbacProxyKey:         imgs.KubeRbacProxy,
 		templatectrl.DockerRegistryKey:        imgs.DockerRegistry,
+		templatectrl.FRRK8sKey:                imgs.FRRK8s,
+		templatectrl.KubeVIPKey:               imgs.KubeVip,
 	}
 
 	ignitionHost, err := getIgnitionHost(&infra.Status)

--- a/pkg/operator/sync_test.go
+++ b/pkg/operator/sync_test.go
@@ -10,6 +10,7 @@ import (
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
 	"github.com/openshift/machine-config-operator/test/helpers"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/informers"
@@ -176,6 +177,121 @@ func withCABundle(caBundle string) kubeCloudConfigOption {
 			kubeCloudConfig.Data = map[string]string{}
 		}
 		kubeCloudConfig.Data["ca-bundle.pem"] = caBundle
+	}
+}
+
+func withBareMetalVIPManagement(vipManagement configv1.VIPManagementType) infraOption {
+	return func(infra *configv1.Infrastructure) {
+		if infra.Status.PlatformStatus == nil {
+			infra.Status.PlatformStatus = &configv1.PlatformStatus{}
+		}
+		infra.Status.PlatformStatus.Type = configv1.BareMetalPlatformType
+		infra.Status.PlatformStatus.BareMetal = &configv1.BareMetalPlatformStatus{
+			VIPManagement:        vipManagement,
+			APIServerInternalIPs: []string{"192.168.111.5"},
+			IngressIPs:           []string{"192.168.111.4"},
+		}
+	}
+}
+
+func buildBGPVIPConfigMap(configJSON string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "openshift-network-operator",
+			Name:      "bgp-vip-config",
+		},
+		Data: map[string]string{
+			"config.json": configJSON,
+		},
+	}
+}
+
+func TestSyncBGPVIPPeersJSON(t *testing.T) {
+	compactJSON := `{"localASN":64512,"defaultPeers":[{"peerAddress":"192.168.111.1","peerASN":64513}]}`
+	prettyJSON := `{
+  "localASN": 64512,
+  "defaultPeers": [
+    {
+      "peerAddress": "192.168.111.1",
+      "peerASN": 64513
+    }
+  ]
+}`
+	cases := []struct {
+		name                    string
+		infra                   *configv1.Infrastructure
+		configMap               *corev1.ConfigMap
+		expectError             bool
+		expectedBGPVIPPeersJSON string
+	}{
+		{
+			name:  "non-BareMetal platform is a no-op",
+			infra: buildInfra(withPlatformType(configv1.AWSPlatformType)),
+		},
+		{
+			name:  "BareMetal without BGP VIP management is a no-op",
+			infra: buildInfra(withPlatformType(configv1.BareMetalPlatformType), withBareMetalVIPManagement("")),
+		},
+		{
+			// User-managed load balancer: BGP mode without VIPs renders
+			// keepalived-neither-BGP, and the peers ingestion must not
+			// degrade the operator over the (rightfully) absent ConfigMap.
+			name: "BGP without VIPs is a no-op",
+			infra: buildInfra(withPlatformType(configv1.BareMetalPlatformType), withBareMetalVIPManagement("BGP"),
+				func(infra *configv1.Infrastructure) {
+					infra.Status.PlatformStatus.BareMetal.APIServerInternalIPs = nil
+				}),
+		},
+		{
+			name:                    "BGP enabled with ConfigMap present",
+			infra:                   buildInfra(withPlatformType(configv1.BareMetalPlatformType), withBareMetalVIPManagement("BGP")),
+			configMap:               buildBGPVIPConfigMap(compactJSON),
+			expectedBGPVIPPeersJSON: compactJSON,
+		},
+		{
+			name:                    "BGP enabled with pretty-printed ConfigMap payload is compacted",
+			infra:                   buildInfra(withPlatformType(configv1.BareMetalPlatformType), withBareMetalVIPManagement("BGP")),
+			configMap:               buildBGPVIPConfigMap(prettyJSON),
+			expectedBGPVIPPeersJSON: compactJSON,
+		},
+		{
+			name:        "BGP enabled with missing ConfigMap degrades",
+			infra:       buildInfra(withPlatformType(configv1.BareMetalPlatformType), withBareMetalVIPManagement("BGP")),
+			expectError: true,
+		},
+		{
+			name:        "BGP enabled with malformed payload degrades",
+			infra:       buildInfra(withPlatformType(configv1.BareMetalPlatformType), withBareMetalVIPManagement("BGP")),
+			configMap:   buildBGPVIPConfigMap("{not json"),
+			expectError: true,
+		},
+		{
+			name:        "BGP enabled with empty config.json payload degrades",
+			infra:       buildInfra(withPlatformType(configv1.BareMetalPlatformType), withBareMetalVIPManagement("BGP")),
+			configMap:   buildBGPVIPConfigMap(""),
+			expectError: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sharedInformer := informers.NewSharedInformerFactory(fake.NewSimpleClientset(), 0)
+			cmInformer := sharedInformer.Core().V1().ConfigMaps()
+			if tc.configMap != nil {
+				require.NoError(t, cmInformer.Informer().GetIndexer().Add(tc.configMap))
+			}
+			optr := &Operator{
+				clusterCmLister: cmInformer.Lister(),
+			}
+			spec := &mcfgv1.ControllerConfigSpec{}
+			err := optr.syncBGPVIPPeersJSON(spec, tc.infra)
+			if tc.expectError {
+				assert.Error(t, err)
+				assert.Empty(t, spec.BGPVIPPeersJSON)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectedBGPVIPPeersJSON, spec.BGPVIPPeersJSON)
+		})
 	}
 }
 

--- a/pkg/operator/sync_test.go
+++ b/pkg/operator/sync_test.go
@@ -1,8 +1,13 @@
 package operator
 
 import (
+	"bytes"
 	"context"
+	"net"
+	"os"
+	"path/filepath"
 	"testing"
+	"text/template"
 
 	configv1 "github.com/openshift/api/config/v1"
 	features "github.com/openshift/api/features"
@@ -1167,4 +1172,61 @@ func buildMachineConfigurationWithBootImageDisabledAndNoSkewEnforcement() *opv1.
 			},
 		},
 	}
+}
+
+// TestFRRConfTemplateTimersAndPort guards the review findings from
+// openshift/installer#10718 (review 4919561631): FRR's
+// "timers <keepalive> <hold>" takes bare seconds (the peer data carries
+// whole-second decimal strings, converted from install-config durations by
+// the producers), the line must only render when BOTH timers are set, and
+// the peer port must be rendered (it was dead code before).
+func TestFRRConfTemplateTimersAndPort(t *testing.T) {
+	// Outer pass: the MCO asset render only unwraps the {{` ... `}} escapes.
+	outer, err := renderAsset(&renderConfig{}, "manifests/on-prem/frr.conf.tmpl")
+	require.NoError(t, err)
+
+	// Inner pass: emulate runtimecfg rendering the on-disk tmpl.
+	type peer struct {
+		PeerAddress, PeerASN, Password, BFDEnabled, EBGPMultiHop, HoldTime, KeepaliveTime string
+		Port                                                                              int32
+	}
+	render := func(p peer) string {
+		data := struct {
+			Hostname, LocalASN, RouterID string
+			Peers                        []peer
+			Communities                  []string
+		}{
+			Hostname: "master-0", LocalASN: "64512", RouterID: "192.168.111.20",
+			Peers: []peer{p},
+		}
+		tmpl, err := template.New("frr").Funcs(template.FuncMap{
+			"isIPv4": func(s string) bool { ip := net.ParseIP(s); return ip != nil && ip.To4() != nil },
+			"isIPv6": func(s string) bool { ip := net.ParseIP(s); return ip != nil && ip.To4() == nil },
+		}).Parse(string(outer))
+		require.NoError(t, err)
+		var rendered bytes.Buffer
+		require.NoError(t, tmpl.Execute(&rendered, data))
+		return rendered.String()
+	}
+
+	// Both timers set (bare seconds): rendered in FRR's keepalive-first order.
+	out := render(peer{PeerAddress: "192.168.111.1", PeerASN: "64513", HoldTime: "90", KeepaliveTime: "30"})
+	assert.Contains(t, out, " neighbor 192.168.111.1 timers 30 90\n")
+
+	// Only one timer set: no timers line at all (FRR requires both).
+	out = render(peer{PeerAddress: "192.168.111.1", PeerASN: "64513", HoldTime: "90"})
+	assert.NotContains(t, out, " timers ")
+
+	// Port set: rendered; omitted: absent.
+	out = render(peer{PeerAddress: "192.168.111.1", PeerASN: "64513", Port: 1790})
+	assert.Contains(t, out, " neighbor 192.168.111.1 port 1790\n")
+	out = render(peer{PeerAddress: "192.168.111.1", PeerASN: "64513"})
+	assert.NotContains(t, out, " port ")
+
+	// The day-2 MachineConfig template must stay in sync with the bootstrap
+	// asset for both constructs.
+	day2, err := os.ReadFile(filepath.Join("..", "..", "templates", "master", "00-master", "on-prem", "files", "frr-k8s-conf.yaml"))
+	require.NoError(t, err)
+	assert.Contains(t, string(day2), "{{`{{- if and .HoldTime .KeepaliveTime}}`}}")
+	assert.Contains(t, string(day2), "port {{`{{.Port}}`}}")
 }

--- a/templates/common/on-prem/files/0020-kube-vip-ingress.yaml
+++ b/templates/common/on-prem/files/0020-kube-vip-ingress.yaml
@@ -1,0 +1,74 @@
+mode: 0644
+path: {{ if isBGPVIPManagement . }}"/etc/kubernetes/manifests/0020-kube-vip-ingress.yaml"{{ else }}"/etc/kubernetes/disabled-manifests/0020-kube-vip-ingress.yaml"{{ end }}
+contents:
+  inline: |
+    ---
+    kind: Pod
+    apiVersion: v1
+    metadata:
+      name: kube-vip-ingress
+      namespace: openshift-kube-vip
+      labels:
+        app: kube-vip
+        component: ingress
+    spec:
+      hostNetwork: true
+      priorityClassName: system-node-critical
+      tolerations:
+      - operator: Exists
+      containers:
+      - name: kube-vip
+        image: {{.Images.kubeVipImage}}
+        args:
+        - manager
+        env:
+        - name: address
+          value: "{{ onPremPlatformIngressIP . }}"
+        - name: k8s_config_file
+          value: "/etc/kubernetes/kubeconfig"
+        - name: kubernetes_addr
+          value: "https://localhost:6443"
+        - name: port
+          value: "443"
+        - name: cp_enable
+          value: "true"
+        - name: vip_leaderelection
+          value: "true"
+        - name: vip_routingtable
+          value: "true"
+        - name: vip_cleanroutingtable
+          value: "true"
+        - name: vip_routingtableid
+          value: "198"
+        - name: vip_routingtableprotocol
+          value: "248"
+        - name: backend_health_check_interval
+          value: "5"
+        - name: control_plane_health_check_address
+          value: "http://localhost:1936/healthz"
+        - name: control_plane_health_check_timeout_seconds
+          value: "3"
+        resources:
+          requests:
+            cpu: 50m
+            memory: 64Mi
+          limits:
+            cpu: 200m
+            memory: 256Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
+            add:
+            - NET_ADMIN
+            - NET_RAW
+        volumeMounts:
+        - name: kubeconfig
+          mountPath: /etc/kubernetes
+          readOnly: true
+      volumes:
+      - name: kubeconfig
+        hostPath:
+          path: /etc/kubernetes

--- a/templates/common/on-prem/files/0020-kube-vip-ingress.yaml
+++ b/templates/common/on-prem/files/0020-kube-vip-ingress.yaml
@@ -39,8 +39,7 @@ contents:
         - name: vip_cleanroutingtable
           value: "true"
         - name: vip_skipdad
-          # health-gated ECMP: every advertiser deliberately holds the VIP
-          # (anycast); DAD would blackhole the second and later advertisers
+          # anycast ECMP: DAD would blackhole all advertisers but the first
           value: "true"
         - name: vip_routingtableid
           value: "198"

--- a/templates/common/on-prem/files/0020-kube-vip-ingress.yaml
+++ b/templates/common/on-prem/files/0020-kube-vip-ingress.yaml
@@ -38,6 +38,10 @@ contents:
           value: "true"
         - name: vip_cleanroutingtable
           value: "true"
+        - name: vip_skipdad
+          # health-gated ECMP: every advertiser deliberately holds the VIP
+          # (anycast); DAD would blackhole the second and later advertisers
+          value: "true"
         - name: vip_routingtableid
           value: "198"
         - name: vip_routingtableprotocol

--- a/templates/common/on-prem/files/0021-kube-vip-ingress-secondary.yaml
+++ b/templates/common/on-prem/files/0021-kube-vip-ingress-secondary.yaml
@@ -39,8 +39,7 @@ contents:
         - name: vip_cleanroutingtable
           value: "true"
         - name: vip_skipdad
-          # health-gated ECMP: every advertiser deliberately holds the VIP
-          # (anycast); DAD would blackhole the second and later advertisers
+          # anycast ECMP: DAD would blackhole all advertisers but the first
           value: "true"
         - name: vip_routingtableid
           value: "198"

--- a/templates/common/on-prem/files/0021-kube-vip-ingress-secondary.yaml
+++ b/templates/common/on-prem/files/0021-kube-vip-ingress-secondary.yaml
@@ -38,6 +38,10 @@ contents:
           value: "true"
         - name: vip_cleanroutingtable
           value: "true"
+        - name: vip_skipdad
+          # health-gated ECMP: every advertiser deliberately holds the VIP
+          # (anycast); DAD would blackhole the second and later advertisers
+          value: "true"
         - name: vip_routingtableid
           value: "198"
         - name: vip_routingtableprotocol

--- a/templates/common/on-prem/files/0021-kube-vip-ingress-secondary.yaml
+++ b/templates/common/on-prem/files/0021-kube-vip-ingress-secondary.yaml
@@ -1,16 +1,16 @@
 mode: 0644
-path: {{ if isBGPVIPManagement . }}"/etc/kubernetes/manifests/0020-kube-vip-ingress.yaml"{{ else }}"/etc/kubernetes/disabled-manifests/0020-kube-vip-ingress.yaml"{{ end }}
+path: {{ if and (isBGPVIPManagement .) (gt (len (onPremPlatformIngressIPs .)) 1) }}"/etc/kubernetes/manifests/0021-kube-vip-ingress-secondary.yaml"{{ else }}"/etc/kubernetes/disabled-manifests/0021-kube-vip-ingress-secondary.yaml"{{ end }}
 contents:
   inline: |
     ---
     kind: Pod
     apiVersion: v1
     metadata:
-      name: kube-vip-ingress
+      name: kube-vip-ingress-secondary
       namespace: openshift-kube-vip
       labels:
         app: kube-vip
-        component: ingress
+        component: ingress-secondary
     spec:
       hostNetwork: true
       priorityClassName: system-node-critical
@@ -23,7 +23,7 @@ contents:
         - manager
         env:
         - name: address
-          value: "{{ onPremPlatformIngressIP . }}"
+          value: "{{ if gt (len (onPremPlatformIngressIPs .)) 1 }}{{ index (onPremPlatformIngressIPs .) 1 }}{{ end }}"
         - name: k8s_config_file
           value: "/etc/kubernetes/kubeconfig"
         - name: kubernetes_addr

--- a/templates/common/on-prem/files/keepalived.yaml
+++ b/templates/common/on-prem/files/keepalived.yaml
@@ -1,5 +1,5 @@
 mode: 0644
-path: {{ if isOpenShiftManagedDefaultLB . }} "/etc/kubernetes/manifests/keepalived.yaml" {{ else }} "/etc/kubernetes/disabled-manifests/keepalived.yaml" {{ end }}
+path: {{ if and (isOpenShiftManagedDefaultLB .) (not (isBGPVIPManagement .)) }} "/etc/kubernetes/manifests/keepalived.yaml" {{ else }} "/etc/kubernetes/disabled-manifests/keepalived.yaml" {{ end }}
 contents:
   inline: |
     kind: Pod

--- a/templates/master/00-master/on-prem/files/0000-frr-k8s.yaml
+++ b/templates/master/00-master/on-prem/files/0000-frr-k8s.yaml
@@ -1,0 +1,340 @@
+mode: 0644
+path: {{ if isBGPVIPManagement . }}"/etc/kubernetes/manifests/0000-frr-k8s.yaml"{{ else }}"/etc/kubernetes/disabled-manifests/0000-frr-k8s.yaml"{{ end }}
+contents:
+  inline: |
+    ---
+    kind: Pod
+    apiVersion: v1
+    metadata:
+      name: frr-k8s
+      namespace: openshift-frr-k8s
+      labels:
+        app: frr-k8s
+    spec:
+      # hostNetwork: the BGP session must originate from the node IP and the
+      # advertised VIP routes live in the host routing table (keepalived parity).
+      hostNetwork: true
+      shareProcessNamespace: true
+      priorityClassName: system-node-critical
+      # 10s (not the upstream DaemonSet's 0): a SIGTERM'd bgpd sends a Cease
+      # NOTIFICATION, which hard-resets the session; after a SIGKILL a peer
+      # in graceful-restart helper mode may retain stale VIP routes on bare
+      # TCP loss until the restart timer expires.
+      terminationGracePeriodSeconds: 10
+      tolerations:
+      - operator: Exists
+      initContainers:
+      - name: render-config-frr
+        image: {{.Images.baremetalRuntimeCfgImage}}
+        command:
+        - /usr/bin/runtimecfg
+        - render
+        - /etc/kubernetes/kubeconfig
+        - --api-vips
+        - {{ onPremPlatformAPIServerInternalIP . }}
+        - --ingress-vips
+        - {{ onPremPlatformIngressIP . }}
+        - /config/frr.conf.tmpl
+        - --out-dir
+        - /etc/frr
+        - --peer-file
+        - /config/frr-peers.json
+        env:
+        - name: IS_BOOTSTRAP
+          value: "no"
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
+        resources:
+          requests:
+            cpu: 10m
+            memory: 50Mi
+          limits:
+            cpu: 100m
+            memory: 128Mi
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - name: resource-dir
+          mountPath: /config
+          readOnly: true
+        - name: frr-conf
+          mountPath: /etc/frr
+        - name: kubeconfig
+          mountPath: /etc/kubernetes
+          readOnly: true
+      - name: cp-frr-files
+        image: {{.Images.frrK8sImage}}
+        command:
+        - /bin/sh
+        - -c
+        - |
+          set -eu
+          cp -f /tmp/frr/daemons /etc/frr/daemons
+          cp -f /tmp/frr/vtysh.conf /etc/frr/vtysh.conf
+        securityContext:
+          runAsUser: 100
+          runAsGroup: 101
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
+        resources:
+          requests:
+            cpu: 10m
+            memory: 20Mi
+          limits:
+            cpu: 100m
+            memory: 128Mi
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - name: frr-startup
+          mountPath: /tmp/frr
+          readOnly: true
+        - name: frr-conf
+          mountPath: /etc/frr
+      - name: cp-reloader
+        image: {{.Images.frrK8sImage}}
+        command:
+        - /bin/sh
+        - -c
+        - cp -f /frr-reloader.sh /etc/frr_reloader/
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
+        resources:
+          requests:
+            cpu: 10m
+            memory: 20Mi
+          limits:
+            cpu: 100m
+            memory: 128Mi
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - name: reloader
+          mountPath: /etc/frr_reloader
+      - name: cp-frr-status
+        image: {{.Images.frrK8sImage}}
+        command:
+        - /bin/sh
+        - -c
+        - cp -f /frr-status /etc/frr_status/
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
+        resources:
+          requests:
+            cpu: 10m
+            memory: 20Mi
+          limits:
+            cpu: 100m
+            memory: 128Mi
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - name: frr-status
+          mountPath: /etc/frr_status
+      containers:
+      - name: controller
+        image: {{.Images.frrK8sImage}}
+        command:
+        - /frr-k8s
+        args:
+        - --node-name=$(NODE_NAME)
+        - --namespace=openshift-frr-k8s
+        env:
+        - name: FRR_CONFIG_FILE
+          value: /etc/frr_reloader/frr.conf
+        - name: FRR_RELOADER_PID_FILE
+          value: /etc/frr_reloader/reloader.pid
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig
+        resources:
+          requests:
+            cpu: 100m
+            memory: 200Mi
+          limits:
+            cpu: 500m
+            memory: 512Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
+            add:
+            - NET_RAW
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 7572
+            host: 127.0.0.1
+          initialDelaySeconds: 10
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 7572
+            host: 127.0.0.1
+          initialDelaySeconds: 10
+          periodSeconds: 10
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - name: reloader
+          mountPath: /etc/frr_reloader
+        - name: kubeconfig
+          mountPath: /etc/kubernetes
+          readOnly: true
+      - name: frr
+        image: {{.Images.frrK8sImage}}
+        command:
+        - /bin/sh
+        - -c
+        - /sbin/tini -- /usr/lib/frr/docker-start
+        env:
+        - name: TINI_SUBREAPER
+          value: "true"
+        resources:
+          requests:
+            cpu: 100m
+            memory: 200Mi
+          limits:
+            cpu: 500m
+            memory: 512Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            # Mirrors the frr container of the frr-k8s DaemonSet shipped by
+            # CNO (upstream metallb/frr-k8s parity). No drop ALL: FRR's
+            # privilege-separated startup (watchfrr as root spawning daemons
+            # as the frr user) additionally relies on root's implicit
+            # capabilities (SETUID/SETGID/DAC_OVERRIDE/CHOWN); dropping ALL
+            # and re-adding only the network capabilities was tested and
+            # prevents the FRR daemons from starting. SYS_ADMIN is required
+            # by docker-start/watchfrr process supervision.
+            add:
+            - NET_ADMIN
+            - NET_RAW
+            - SYS_ADMIN
+            - NET_BIND_SERVICE
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - name: frr-sockets
+          mountPath: /var/run/frr
+        - name: frr-conf
+          mountPath: /etc/frr
+        - name: frr-lib
+          mountPath: /var/lib/frr
+        - name: frr-tmp
+          mountPath: /var/tmp/frr
+      - name: reloader
+        image: {{.Images.frrK8sImage}}
+        command:
+        - /etc/frr_reloader/frr-reloader.sh
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
+            # vtysh as root against the frr-user-owned vty sockets.
+            add:
+            - DAC_OVERRIDE
+        resources:
+          requests:
+            cpu: 10m
+            memory: 20Mi
+          limits:
+            cpu: 500m
+            memory: 128Mi
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - name: frr-sockets
+          mountPath: /var/run/frr
+        - name: frr-conf
+          mountPath: /etc/frr
+        - name: reloader
+          mountPath: /etc/frr_reloader
+      - name: frr-status
+        image: {{.Images.frrK8sImage}}
+        command:
+        - /etc/frr_status/frr-status
+        args:
+        - --node-name=$(NODE_NAME)
+        - --namespace=openshift-frr-k8s
+        - --pod-name=frr-k8s-$(NODE_NAME)
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
+            # vtysh as root against the frr-user-owned vty sockets.
+            add:
+            - DAC_OVERRIDE
+        resources:
+          requests:
+            cpu: 10m
+            memory: 20Mi
+          limits:
+            cpu: 500m
+            memory: 128Mi
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - name: frr-sockets
+          mountPath: /var/run/frr
+        - name: frr-conf
+          mountPath: /etc/frr
+        - name: frr-status
+          mountPath: /etc/frr_status
+        - name: kubeconfig
+          mountPath: /etc/kubernetes
+          readOnly: true
+      volumes:
+      - name: resource-dir
+        hostPath:
+          path: /etc/kubernetes/static-pod-resources/frr-k8s
+      # hostPath (not emptyDir) so the CNO-managed metrics companion
+      # DaemonSet can reach the FRR sockets; perms via tmpfiles.d.
+      - name: frr-conf
+        hostPath:
+          path: /run/frr-k8s/conf
+          type: DirectoryOrCreate
+      - name: frr-sockets
+        hostPath:
+          path: /run/frr-k8s/sockets
+          type: DirectoryOrCreate
+      - name: reloader
+        emptyDir: {}
+      - name: frr-status
+        emptyDir: {}
+      - name: frr-lib
+        emptyDir: {}
+      - name: frr-tmp
+        emptyDir: {}
+      - name: frr-startup
+        hostPath:
+          path: /etc/kubernetes/static-pod-resources/frr-k8s/startup
+      - name: kubeconfig
+        hostPath:
+          path: /etc/kubernetes

--- a/templates/master/00-master/on-prem/files/0000-frr-k8s.yaml
+++ b/templates/master/00-master/on-prem/files/0000-frr-k8s.yaml
@@ -16,10 +16,8 @@ contents:
       hostNetwork: true
       shareProcessNamespace: true
       priorityClassName: system-node-critical
-      # 10s (not the upstream DaemonSet's 0): a SIGTERM'd bgpd sends a Cease
-      # NOTIFICATION, which hard-resets the session; after a SIGKILL a peer
-      # in graceful-restart helper mode may retain stale VIP routes on bare
-      # TCP loss until the restart timer expires.
+      # 10s, not upstream's 0: SIGTERM'd bgpd sends a Cease; after SIGKILL
+      # a graceful-restart helper peer may retain stale VIP routes.
       terminationGracePeriodSeconds: 10
       tolerations:
       - operator: Exists
@@ -217,14 +215,10 @@ contents:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
           capabilities:
-            # Mirrors the frr container of the frr-k8s DaemonSet shipped by
-            # CNO (upstream metallb/frr-k8s parity). No drop ALL: FRR's
-            # privilege-separated startup (watchfrr as root spawning daemons
-            # as the frr user) additionally relies on root's implicit
-            # capabilities (SETUID/SETGID/DAC_OVERRIDE/CHOWN); dropping ALL
-            # and re-adding only the network capabilities was tested and
-            # prevents the FRR daemons from starting. SYS_ADMIN is required
-            # by docker-start/watchfrr process supervision.
+            # No drop ALL: FRR's privilege-separated startup relies on
+            # root's implicit caps beyond these four (tested: drop ALL +
+            # re-add breaks daemon startup). SYS_ADMIN for watchfrr
+            # supervision. Matches CNO's frr-k8s DaemonSet frr container.
             add:
             - NET_ADMIN
             - NET_RAW

--- a/templates/master/00-master/on-prem/files/0010-kube-vip-api.yaml
+++ b/templates/master/00-master/on-prem/files/0010-kube-vip-api.yaml
@@ -1,0 +1,70 @@
+mode: 0644
+path: {{ if isBGPVIPManagement . }}"/etc/kubernetes/manifests/0010-kube-vip-api.yaml"{{ else }}"/etc/kubernetes/disabled-manifests/0010-kube-vip-api.yaml"{{ end }}
+contents:
+  inline: |
+    ---
+    kind: Pod
+    apiVersion: v1
+    metadata:
+      name: kube-vip-api
+      namespace: openshift-kube-vip
+      labels:
+        app: kube-vip
+        component: api
+    spec:
+      hostNetwork: true
+      priorityClassName: system-node-critical
+      tolerations:
+      - operator: Exists
+      containers:
+      - name: kube-vip
+        image: {{.Images.kubeVipImage}}
+        args:
+        - manager
+        env:
+        - name: address
+          value: "{{ onPremPlatformAPIServerInternalIP . }}"
+        - name: k8s_config_file
+          value: "/etc/kubernetes/kubeconfig"
+        - name: kubernetes_addr
+          value: "https://localhost:6443"
+        - name: port
+          value: "6443"
+        - name: cp_enable
+          value: "true"
+        - name: vip_leaderelection
+          value: "true"
+        - name: vip_routingtable
+          value: "true"
+        - name: vip_cleanroutingtable
+          value: "true"
+        - name: vip_routingtableid
+          value: "198"
+        - name: vip_routingtableprotocol
+          value: "248"
+        - name: backend_health_check_interval
+          value: "5"
+        resources:
+          requests:
+            cpu: 50m
+            memory: 64Mi
+          limits:
+            cpu: 200m
+            memory: 256Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
+            add:
+            - NET_ADMIN
+            - NET_RAW
+        volumeMounts:
+        - name: kubeconfig
+          mountPath: /etc/kubernetes
+          readOnly: true
+      volumes:
+      - name: kubeconfig
+        hostPath:
+          path: /etc/kubernetes

--- a/templates/master/00-master/on-prem/files/0010-kube-vip-api.yaml
+++ b/templates/master/00-master/on-prem/files/0010-kube-vip-api.yaml
@@ -27,7 +27,7 @@ contents:
         - name: k8s_config_file
           value: "/etc/kubernetes/kubeconfig"
         - name: kubernetes_addr
-          value: "https://localhost:6443"
+          value: "https://127.0.0.1:6443"
         - name: port
           value: "6443"
         - name: cp_enable

--- a/templates/master/00-master/on-prem/files/0010-kube-vip-api.yaml
+++ b/templates/master/00-master/on-prem/files/0010-kube-vip-api.yaml
@@ -39,8 +39,7 @@ contents:
         - name: vip_cleanroutingtable
           value: "true"
         - name: vip_skipdad
-          # health-gated ECMP: every advertiser deliberately holds the VIP
-          # (anycast); DAD would blackhole the second and later advertisers
+          # anycast ECMP: DAD would blackhole all advertisers but the first
           value: "true"
         - name: vip_routingtableid
           value: "198"

--- a/templates/master/00-master/on-prem/files/0010-kube-vip-api.yaml
+++ b/templates/master/00-master/on-prem/files/0010-kube-vip-api.yaml
@@ -38,6 +38,10 @@ contents:
           value: "true"
         - name: vip_cleanroutingtable
           value: "true"
+        - name: vip_skipdad
+          # health-gated ECMP: every advertiser deliberately holds the VIP
+          # (anycast); DAD would blackhole the second and later advertisers
+          value: "true"
         - name: vip_routingtableid
           value: "198"
         - name: vip_routingtableprotocol

--- a/templates/master/00-master/on-prem/files/0011-kube-vip-api-secondary.yaml
+++ b/templates/master/00-master/on-prem/files/0011-kube-vip-api-secondary.yaml
@@ -1,16 +1,16 @@
 mode: 0644
-path: {{ if isBGPVIPManagement . }}"/etc/kubernetes/manifests/0020-kube-vip-ingress.yaml"{{ else }}"/etc/kubernetes/disabled-manifests/0020-kube-vip-ingress.yaml"{{ end }}
+path: {{ if and (isBGPVIPManagement .) (gt (len (onPremPlatformAPIServerInternalIPs .)) 1) }}"/etc/kubernetes/manifests/0011-kube-vip-api-secondary.yaml"{{ else }}"/etc/kubernetes/disabled-manifests/0011-kube-vip-api-secondary.yaml"{{ end }}
 contents:
   inline: |
     ---
     kind: Pod
     apiVersion: v1
     metadata:
-      name: kube-vip-ingress
+      name: kube-vip-api-secondary
       namespace: openshift-kube-vip
       labels:
         app: kube-vip
-        component: ingress
+        component: api-secondary
     spec:
       hostNetwork: true
       priorityClassName: system-node-critical
@@ -23,13 +23,13 @@ contents:
         - manager
         env:
         - name: address
-          value: "{{ onPremPlatformIngressIP . }}"
+          value: "{{ if gt (len (onPremPlatformAPIServerInternalIPs .)) 1 }}{{ index (onPremPlatformAPIServerInternalIPs .) 1 }}{{ end }}"
         - name: k8s_config_file
           value: "/etc/kubernetes/kubeconfig"
         - name: kubernetes_addr
           value: "https://127.0.0.1:6443"
         - name: port
-          value: "443"
+          value: "6443"
         - name: cp_enable
           value: "true"
         - name: vip_leaderelection
@@ -44,10 +44,6 @@ contents:
           value: "248"
         - name: backend_health_check_interval
           value: "5"
-        - name: control_plane_health_check_address
-          value: "http://localhost:1936/healthz"
-        - name: control_plane_health_check_timeout_seconds
-          value: "3"
         resources:
           requests:
             cpu: 50m

--- a/templates/master/00-master/on-prem/files/0011-kube-vip-api-secondary.yaml
+++ b/templates/master/00-master/on-prem/files/0011-kube-vip-api-secondary.yaml
@@ -39,8 +39,7 @@ contents:
         - name: vip_cleanroutingtable
           value: "true"
         - name: vip_skipdad
-          # health-gated ECMP: every advertiser deliberately holds the VIP
-          # (anycast); DAD would blackhole the second and later advertisers
+          # anycast ECMP: DAD would blackhole all advertisers but the first
           value: "true"
         - name: vip_routingtableid
           value: "198"

--- a/templates/master/00-master/on-prem/files/0011-kube-vip-api-secondary.yaml
+++ b/templates/master/00-master/on-prem/files/0011-kube-vip-api-secondary.yaml
@@ -38,6 +38,10 @@ contents:
           value: "true"
         - name: vip_cleanroutingtable
           value: "true"
+        - name: vip_skipdad
+          # health-gated ECMP: every advertiser deliberately holds the VIP
+          # (anycast); DAD would blackhole the second and later advertisers
+          value: "true"
         - name: vip_routingtableid
           value: "198"
         - name: vip_routingtableprotocol

--- a/templates/master/00-master/on-prem/files/frr-k8s-conf.yaml
+++ b/templates/master/00-master/on-prem/files/frr-k8s-conf.yaml
@@ -1,0 +1,62 @@
+mode: 0644
+path: "/etc/kubernetes/static-pod-resources/frr-k8s/frr.conf.tmpl"
+contents:
+  inline: |
+    frr version 9.1
+    frr defaults traditional
+    hostname {{`{{.Hostname}}`}}
+    !
+    router bgp {{`{{.LocalASN}}`}}
+     bgp router-id {{`{{.RouterID}}`}}
+     no bgp ebgp-requires-policy
+     no bgp default ipv4-unicast
+     !
+    {{`{{- range .Peers}}`}}
+     neighbor {{`{{.PeerAddress}}`}} remote-as {{`{{.PeerASN}}`}}
+    {{`{{- if .Password}}`}}
+     neighbor {{`{{.PeerAddress}}`}} password {{`{{.Password}}`}}
+    {{`{{- end}}`}}
+    {{`{{- if eq .BFDEnabled "true"}}`}}
+     neighbor {{`{{.PeerAddress}}`}} bfd
+    {{`{{- end}}`}}
+    {{`{{- if eq .EBGPMultiHop "true"}}`}}
+     neighbor {{`{{.PeerAddress}}`}} ebgp-multihop
+    {{`{{- end}}`}}
+    {{`{{- if .HoldTime}}`}}
+     neighbor {{`{{.PeerAddress}}`}} timers {{`{{.KeepaliveTime}}`}} {{`{{.HoldTime}}`}}
+    {{`{{- end}}`}}
+    {{`{{- end}}`}}
+     !
+     address-family ipv4 unicast
+      redistribute table-direct 198
+    {{`{{- range .Peers}}`}}
+    {{`{{- if isIPv4 .PeerAddress}}`}}
+      neighbor {{`{{.PeerAddress}}`}} activate
+    {{`{{- if $.Communities}}`}}
+      neighbor {{`{{.PeerAddress}}`}} route-map VIP-COMMUNITY out
+    {{`{{- end}}`}}
+    {{`{{- end}}`}}
+    {{`{{- end}}`}}
+     exit-address-family
+     !
+     address-family ipv6 unicast
+      redistribute table-direct 198
+    {{`{{- range .Peers}}`}}
+    {{`{{- if isIPv6 .PeerAddress}}`}}
+      neighbor {{`{{.PeerAddress}}`}} activate
+    {{`{{- if $.Communities}}`}}
+      neighbor {{`{{.PeerAddress}}`}} route-map VIP-COMMUNITY out
+    {{`{{- end}}`}}
+    {{`{{- end}}`}}
+    {{`{{- end}}`}}
+     exit-address-family
+    !
+    {{`{{- if .Communities}}`}}
+    route-map VIP-COMMUNITY permit 10
+    {{`{{- range .Communities}}`}}
+     set community {{`{{.}}`}} additive
+    {{`{{- end}}`}}
+    !
+    {{`{{- end}}`}}
+    line vty
+    !

--- a/templates/master/00-master/on-prem/files/frr-k8s-conf.yaml
+++ b/templates/master/00-master/on-prem/files/frr-k8s-conf.yaml
@@ -22,7 +22,10 @@ contents:
     {{`{{- if eq .EBGPMultiHop "true"}}`}}
      neighbor {{`{{.PeerAddress}}`}} ebgp-multihop
     {{`{{- end}}`}}
-    {{`{{- if .HoldTime}}`}}
+    {{`{{- if .Port}}`}}
+     neighbor {{`{{.PeerAddress}}`}} port {{`{{.Port}}`}}
+    {{`{{- end}}`}}
+    {{`{{- if and .HoldTime .KeepaliveTime}}`}}
      neighbor {{`{{.PeerAddress}}`}} timers {{`{{.KeepaliveTime}}`}} {{`{{.HoldTime}}`}}
     {{`{{- end}}`}}
     {{`{{- end}}`}}

--- a/templates/master/00-master/on-prem/files/frr-k8s-peers.yaml
+++ b/templates/master/00-master/on-prem/files/frr-k8s-peers.yaml
@@ -1,0 +1,5 @@
+mode: 0600
+path: "/etc/kubernetes/static-pod-resources/frr-k8s/frr-peers.json"
+contents:
+  inline: |-
+    {{.BGPVIPPeersJSON}}

--- a/templates/master/00-master/on-prem/files/frr-k8s-startup-daemons.yaml
+++ b/templates/master/00-master/on-prem/files/frr-k8s-startup-daemons.yaml
@@ -1,0 +1,27 @@
+mode: 0644
+path: "/etc/kubernetes/static-pod-resources/frr-k8s/startup/daemons"
+contents:
+  inline: |
+    zebra=yes
+    bgpd=yes
+    ospfd=no
+    ospf6d=no
+    ripd=no
+    ripngd=no
+    isisd=no
+    pimd=no
+    ldpd=no
+    nhrpd=no
+    eigrpd=no
+    babeld=no
+    sharpd=no
+    pbrd=no
+    bfdd=yes
+    fabricd=no
+    vrrpd=no
+    pathd=no
+
+    vtysh_enable=yes
+    zebra_options="  -A 127.0.0.1 -s 90000000"
+    bgpd_options="   -A 127.0.0.1"
+    bfdd_options="   -A 127.0.0.1"

--- a/templates/master/00-master/on-prem/files/frr-k8s-startup-vtysh.yaml
+++ b/templates/master/00-master/on-prem/files/frr-k8s-startup-vtysh.yaml
@@ -1,0 +1,5 @@
+mode: 0644
+path: "/etc/kubernetes/static-pod-resources/frr-k8s/startup/vtysh.conf"
+contents:
+  inline: |
+    service integrated-vtysh-config

--- a/templates/master/00-master/on-prem/units/frr-k8s-hostpath.service.yaml
+++ b/templates/master/00-master/on-prem/units/frr-k8s-hostpath.service.yaml
@@ -1,0 +1,21 @@
+name: frr-k8s-hostpath.service
+enabled: {{if isBGPVIPManagement .}}true{{else}}false{{end}}
+contents: |
+  [Unit]
+  Description=Prepare the frr-k8s static pod hostPath directories
+  # /run/frr-k8s is shared between the frr-k8s static pod and the
+  # CNO-managed metrics companion DaemonSet. 0777 mirrors emptyDir
+  # semantics: FRR daemons run as uid 100 while watchfrr runs as root
+  # without CAP_DAC_OVERRIDE. container_file_t because the companion runs
+  # as plain container_t (MCS-confined): the static pod itself is spc_t
+  # (host network) and unconstrained, but its files inherit the directory
+  # type and must stay accessible to the companion.
+  Before=kubelet-dependencies.target
+
+  [Service]
+  Type=oneshot
+  RemainAfterExit=yes
+  ExecStart=/bin/bash -c 'mkdir -p /run/frr-k8s/sockets /run/frr-k8s/conf && chmod 0777 /run/frr-k8s/sockets /run/frr-k8s/conf && chcon -R -t container_file_t /run/frr-k8s'
+
+  [Install]
+  WantedBy=kubelet-dependencies.target

--- a/templates/master/00-master/on-prem/units/frr-k8s-hostpath.service.yaml
+++ b/templates/master/00-master/on-prem/units/frr-k8s-hostpath.service.yaml
@@ -3,13 +3,10 @@ enabled: {{if isBGPVIPManagement .}}true{{else}}false{{end}}
 contents: |
   [Unit]
   Description=Prepare the frr-k8s static pod hostPath directories
-  # /run/frr-k8s is shared between the frr-k8s static pod and the
-  # CNO-managed metrics companion DaemonSet. 0777 mirrors emptyDir
-  # semantics: FRR daemons run as uid 100 while watchfrr runs as root
-  # without CAP_DAC_OVERRIDE. container_file_t because the companion runs
-  # as plain container_t (MCS-confined): the static pod itself is spc_t
-  # (host network) and unconstrained, but its files inherit the directory
-  # type and must stay accessible to the companion.
+  # Shared with the CNO metrics companion. 0777 mirrors emptyDir (FRR
+  # daemons uid 100, watchfrr root without DAC_OVERRIDE); container_file_t
+  # so the MCS-confined companion can reach files created by the spc_t
+  # static pod.
   Before=kubelet-dependencies.target
 
   [Service]

--- a/test/e2e-bootstrap/openstack_parity_test.go
+++ b/test/e2e-bootstrap/openstack_parity_test.go
@@ -1,0 +1,130 @@
+package e2e_bootstrap_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ghodss/yaml"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+
+	configv1 "github.com/openshift/api/config/v1"
+	configv1alpha1 "github.com/openshift/api/config/v1alpha1"
+	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
+	mcfgv1alpha1 "github.com/openshift/api/machineconfiguration/v1alpha1"
+	apioperatorsv1alpha1 "github.com/openshift/api/operator/v1alpha1"
+
+	"github.com/openshift/machine-config-operator/pkg/controller/bootstrap"
+	"github.com/openshift/machine-config-operator/test/framework"
+	"github.com/openshift/machine-config-operator/test/helpers"
+)
+
+// Debug test for openshift/machine-config-operator#6326 e2e-openstack:
+// the bootstrap-rendered MC and the in-cluster rendered MC must match on
+// an on-prem (OpenStack) platform, where the on-prem templates
+// (keepalived, frr-k8s, kube-vip) render real content.
+func TestE2EBootstrapOpenStackParity(t *testing.T) {
+	ctx := context.Background()
+
+	testEnv := framework.NewTestEnv(t)
+
+	configv1.Install(scheme.Scheme)
+	configv1alpha1.Install(scheme.Scheme)
+	mcfgv1.Install(scheme.Scheme)
+	mcfgv1alpha1.Install(scheme.Scheme)
+	apioperatorsv1alpha1.Install(scheme.Scheme)
+
+	baseTestManifests := loadBaseTestManifests(t)
+
+	// Mutate the ControllerConfig's infra to OpenStack with VIPs, mirroring
+	// the CI cluster where the mismatch was observed.
+	found := false
+	for _, obj := range baseTestManifests {
+		if cc, ok := obj.(*mcfgv1.ControllerConfig); ok {
+			cc.Spec.Infra.Status.PlatformStatus = &configv1.PlatformStatus{
+				Type: configv1.OpenStackPlatformType,
+				OpenStack: &configv1.OpenStackPlatformStatus{
+					APIServerInternalIPs: []string{"10.0.0.5"},
+					IngressIPs:           []string{"10.0.0.7"},
+					APIServerInternalIP:  "10.0.0.5",
+					IngressIP:            "10.0.0.7",
+				},
+			}
+			cc.Spec.DNS = &configv1.DNS{
+				TypeMeta:   metav1.TypeMeta{APIVersion: "config.openshift.io/v1", Kind: "DNS"},
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Spec:       configv1.DNSSpec{BaseDomain: "domain.example.com"},
+			}
+			found = true
+		}
+	}
+	require.True(t, found, "no ControllerConfig in base manifests")
+
+	cfg, err := testEnv.Start()
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, testEnv.Stop())
+	}()
+
+	clientSet := framework.NewClientSetFromConfig(cfg)
+
+	for _, ns := range []string{framework.OpenshiftConfigNamespace, bootstrapTestName} {
+		_, err = clientSet.Namespaces().Create(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: ns},
+		}, metav1.CreateOptions{})
+		require.NoError(t, err)
+	}
+
+	objs := append([]runtime.Object{}, baseTestManifests...)
+	objs = append(objs, loadRawManifests(t, [][]byte{
+		[]byte(`apiVersion: config.openshift.io/v1
+kind: Node
+metadata:
+  name: cluster`),
+	})...)
+
+	fixture := newTestFixture(t, cfg, objs)
+	defer framework.CleanEnvironment(t, clientSet)
+	defer fixture.stop()
+
+	controllerRenderedMasterConfigName, err := helpers.WaitForRenderedConfigs(t, clientSet, "master", "99-master-ssh", "99-master-generated-registries")
+	require.NoError(t, err)
+	t.Logf("Controller rendered master config as %q", controllerRenderedMasterConfigName)
+
+	destDir, err := os.MkdirTemp("", "controller-bootstrap")
+	require.NoError(t, err)
+	defer os.RemoveAll(destDir)
+
+	srcDir, err := os.MkdirTemp("", "controller-bootstrap-source")
+	require.NoError(t, err)
+	defer os.RemoveAll(srcDir)
+
+	for id, obj := range objs {
+		manifest, err := yaml.Marshal(obj)
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(filepath.Join(srcDir, fmt.Sprintf("manifest-%d.yaml", id)), manifest, 0o644))
+	}
+
+	bootstrapper := bootstrap.New(templatesDir, srcDir, filepath.Join(bootstrapTestDataDir, "/machineconfigcontroller-pull-secret"), nil)
+	require.NoError(t, bootstrapper.Run(destDir))
+
+	compareRenderedConfigPool(t, clientSet, destDir, "master", controllerRenderedMasterConfigName)
+
+	// Sanity: the bootstrap-rendered MC must contain the on-prem static pod
+	// files (path-gated to disabled-manifests on non-BGP clusters) and the
+	// ssh passwd section - exactly what the CI bootstrap MC was missing.
+	paths, err := filepath.Glob(filepath.Join(destDir, "machine-configs", "rendered-master-*.yaml"))
+	require.NoError(t, err)
+	require.Len(t, paths, 1)
+	mcBytes, err := os.ReadFile(paths[0])
+	require.NoError(t, err)
+	assert.Contains(t, string(mcBytes), "disabled-manifests/0000-frr-k8s.yaml")
+	assert.Contains(t, string(mcBytes), "sshAuthorizedKeys")
+}


### PR DESCRIPTION
## What

MCO side of BGP-based VIP management for on-premise platforms
([enhancement #1982](https://github.com/openshift/enhancements/pull/1982), [OPNET-773](https://redhat.atlassian.net/browse/OPNET-773)). When the BareMetal
Infrastructure CR requests `vipManagement: BGP` (behind the `BGPBasedVIPManagement` feature gate,
DevPreviewNoUpgrade) and both VIP sets are present, render frr-k8s + kube-vip static pods on control
plane nodes instead of the keepalived manifests. kube-vip runs in routing-table mode: it installs the
VIP route into kernel table 198 only while the local health check passes, and FRR advertises that
table — per-node health-gated ECMP from the ToR.

Three commits, each builds on its own:

1. **template: render BGP VIP static pods instead of keepalived** — frr-k8s static pod (masters),
   kube-vip API/ingress static pods (keepalived parity), hostPath sockets prepared by a boot unit
   (0777 emptyDir-parity for the mixed-uid FRR daemons, `container_file_t` for the MCS-confined
   metrics companion that CNO deploys against them). Requires non-empty VIPs — with a user-managed
   LB the keepalived default applies, via the shared `IsBGPVIPManagement` predicate. Containers are
   hardened (drop ALL + minimal re-adds, no-escalation, read-only rootfs, CPU/memory limits,
   read-only input mounts); the frr container keeps upstream metallb/frr-k8s capability parity —
   `drop: ALL` was tested and breaks FRR's privilege-separated startup (documented in-manifest).
   `terminationGracePeriodSeconds: 10` so a stopping bgpd sends a Cease NOTIFICATION rather than
   leaving graceful-restart helper peers retaining stale VIP routes. `frr-peers.json` is 0600.
2. **operator: bootstrap and day-2 support** — RenderBootstrap ingests the installer-generated
   `bgp-vip-config` ConfigMap (`--bgp-vip-config-file`) into `ControllerConfigSpec.BGPVIPPeersJSON`;
   the bootstrap node runs an FRR-only static pod so the API VIP is advertised while the control
   plane forms; missing images or an empty config.json fail the bootstrap render early. Day-2 the
   operator reads the ConfigMap through the cluster-wide ConfigMap lister (cached; same informer
   that backs `syncCloudConfig`, so no additional RBAC) — absence degrades instead of blanking
   peers fleet-wide.

A third commit (payload image-references for frr-k8s/kube-vip) is withheld until the kube-vip
payload tag exists — [ART-21663](https://redhat.atlassian.net/browse/ART-21663) / openshift/release#81957 — since the CI `images` job fails on an
image-references entry whose tag is missing from the payload.

## Dependencies / ordering

- openshift/api#2923 — **merged**; the vendored API landed via #6334, this PR carries no vendoring
- CNO counterpart: openshift/cluster-network-operator#3047 (FRRConfiguration handover, DaemonSet
  anti-affinity, static pod RBAC, metrics companion)
- The withheld image-references commit additionally needs [ART-21663](https://redhat.atlassian.net/browse/ART-21663) / openshift/release#81957

## Privileged settings justification

The new static pod manifests intentionally use the following privileged
settings (also documented as comments in the manifests themselves):

- **`hostNetwork: true`** (frr-k8s and kube-vip pods): required by function.
  The BGP session must originate from the node IP so the ToR peers with the
  node itself, and the health-gated VIP routes are installed into the host
  routing table (kernel table 198) that FRR redistributes. This is exact
  parity with both the keepalived/haproxy static pods being replaced and the
  frr-k8s DaemonSet shipped by CNO.
- **`SYS_ADMIN` on the `frr` container only**: required by FRR's
  `docker-start`/`watchfrr` process supervision. Same capability set as the
  `frr` container of the CNO-shipped frr-k8s DaemonSet (upstream
  metallb/frr-k8s parity). Note this container deliberately does NOT use
  `drop: ALL`: it was tested live and FRR's privilege-separated startup
  (watchfrr as root spawning daemons as the frr user) fails without
  root-implicit SETUID/SETGID/DAC_OVERRIDE/CHOWN.
- Every other container in these pods drops ALL capabilities with minimal
  re-adds (kube-vip: NET_ADMIN/NET_RAW for netlink route management;
  reloader/frr-status: DAC_OVERRIDE for root vtysh against frr-user-owned
  vty sockets), sets `allowPrivilegeEscalation: false` and
  `readOnlyRootFilesystem: true`, and has CPU/memory limits.

## Testing

Validated end-to-end on dev-scripts baremetal IPI clusters (3 masters + 2 workers, dual VIP), most
recently on a 5.0.0-0.nightly-2026-07-20-081439 base: API VIP ECMP from all masters, ingress VIP
ECMP from router-bearing workers, health-gated withdrawal on node failure, console served over the
BGP-routed path, full frr metrics coverage in Prometheus (static pods via the CNO metrics companion).
Bootstrap-to-CRD handover exercised on every install. The securityContext hardening and the
termination-grace change were additionally validated live on a running cluster (hot-edited static
pod manifests, BGP/VIP behavior watched through each change).

---
This PR description was prepared with AI assistance. Please verify before acting on it.

