### PR TITLE
NO-ISSUE: Add reusable utilities for image inspection

### DIFF
--- a/pkg/controller/bootstrap/bootstrap.go
+++ b/pkg/controller/bootstrap/bootstrap.go
@@ -502,21 +502,7 @@ func (b *Bootstrap) fetchOSImageStream(
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
-	sysCtxFactory := func() (*imageutils.SysContext, error) {
-		sysCtxBuilder := imageutils.NewSysContextBuilder().
-			WithControllerConfig(cconfig).
-			WithSecret(pullSecret)
-
-		registriesConfig, err := imageutils.GenerateRegistriesConfig(imgCfg, icspRules, idmsRules, itmsRules)
-		if err != nil {
-			return nil, fmt.Errorf("failed to generate registries config for OSImageStreams fetching: %w", err)
-		}
-		if registriesConfig != nil {
-			sysCtxBuilder.WithRegistriesConfig(registriesConfig)
-		}
-
-		return sysCtxBuilder.Build()
-	}
+	sysCtxFactory := buildSysContextFactory(pullSecret, cconfig, imgCfg, icspRules, idmsRules, itmsRules)
 
 	factory := b.getImageStreamFactory()
 	osImageStream, err := factory.Create(ctx, sysCtxFactory, osimagestream.CreateOptions{
@@ -540,6 +526,31 @@ func (b *Bootstrap) getImageStreamFactory() osimagestream.ImageStreamFactory {
 	}
 
 	return osimagestream.NewDefaultStreamSourceFactory(&osimagestream.DefaultImagesInspectorFactory{})
+}
+
+func buildSysContextFactory(
+	pullSecret *corev1.Secret,
+	cconfig *mcfgv1.ControllerConfig,
+	imgCfg *apicfgv1.Image,
+	icspRules []*apioperatorsv1alpha1.ImageContentSourcePolicy,
+	idmsRules []*apicfgv1.ImageDigestMirrorSet,
+	itmsRules []*apicfgv1.ImageTagMirrorSet,
+) imageutils.SysContextFactory {
+	return func() (*imageutils.SysContext, error) {
+		builder := imageutils.NewSysContextBuilder().
+			WithControllerConfig(cconfig).
+			WithSecret(pullSecret)
+
+		registriesConfig, err := imageutils.GenerateRegistriesConfig(imgCfg, icspRules, idmsRules, itmsRules)
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate registries config: %w", err)
+		}
+		if registriesConfig != nil {
+			builder.WithRegistriesConfig(registriesConfig)
+		}
+
+		return builder.Build()
+	}
 }
 
 func getValidPullSecretFromBytes(sData []byte) (*corev1.Secret, error) {

--- a/pkg/controller/common/sys_context.go
+++ b/pkg/controller/common/sys_context.go
@@ -1,0 +1,66 @@
+package common
+
+import (
+	"fmt"
+
+	configlistersv1 "github.com/openshift/client-go/config/listers/config/v1"
+	mcfglistersv1 "github.com/openshift/client-go/machineconfiguration/listers/machineconfiguration/v1"
+	operatorlistersv1alpha1 "github.com/openshift/client-go/operator/listers/operator/v1alpha1"
+	"github.com/openshift/machine-config-operator/pkg/imageutils"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
+	corelistersv1 "k8s.io/client-go/listers/core/v1"
+)
+
+// NewSysContextFactory builds a SysContextFactory that resolves pull secrets,
+// ControllerConfig, and registry mirror rules from informer-backed listers.
+func NewSysContextFactory(
+	ccLister mcfglistersv1.ControllerConfigLister,
+	secretLister corelistersv1.SecretLister,
+	imgLister configlistersv1.ImageLister,
+	icspLister operatorlistersv1alpha1.ImageContentSourcePolicyLister,
+	idmsLister configlistersv1.ImageDigestMirrorSetLister,
+	itmsLister configlistersv1.ImageTagMirrorSetLister,
+) imageutils.SysContextFactory {
+	return func() (*imageutils.SysContext, error) {
+		cc, err := ccLister.Get(ControllerConfigName)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get controller config: %w", err)
+		}
+		secret, err := secretLister.Secrets(OpenshiftConfigNamespace).Get(GlobalPullSecretName)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get pull secret: %w", err)
+		}
+
+		builder := imageutils.NewSysContextBuilder().
+			WithSecret(secret).
+			WithControllerConfig(cc)
+
+		imgCfg, err := imgLister.Get("cluster")
+		if err != nil && !apierrors.IsNotFound(err) {
+			return nil, fmt.Errorf("failed to get cluster image config: %w", err)
+		}
+		icspRules, err := icspLister.List(labels.Everything())
+		if err != nil && !apierrors.IsNotFound(err) {
+			return nil, fmt.Errorf("failed to list ICSP rules: %w", err)
+		}
+		idmsRules, err := idmsLister.List(labels.Everything())
+		if err != nil && !apierrors.IsNotFound(err) {
+			return nil, fmt.Errorf("failed to list IDMS rules: %w", err)
+		}
+		itmsRules, err := itmsLister.List(labels.Everything())
+		if err != nil && !apierrors.IsNotFound(err) {
+			return nil, fmt.Errorf("failed to list ITMS rules: %w", err)
+		}
+
+		if imgCfg != nil || len(icspRules) != 0 || len(idmsRules) != 0 || len(itmsRules) != 0 {
+			registriesConf, err := imageutils.GenerateRegistriesConfig(imgCfg, icspRules, idmsRules, itmsRules)
+			if err != nil {
+				return nil, fmt.Errorf("failed to generate registries config: %w", err)
+			}
+			builder.WithRegistriesConfig(registriesConf)
+		}
+
+		return builder.Build()
+	}
+}

--- a/pkg/controller/osimagestream/osimagestream_controller.go
+++ b/pkg/controller/osimagestream/osimagestream_controller.go
@@ -9,9 +9,7 @@ import (
 	"sync"
 	"time"
 
-	configv1 "github.com/openshift/api/config/v1"
 	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
-	apioperatorsv1alpha1 "github.com/openshift/api/operator/v1alpha1"
 	configinformersv1 "github.com/openshift/client-go/config/informers/externalversions/config/v1"
 	configlistersv1 "github.com/openshift/client-go/config/listers/config/v1"
 	mcfgclientset "github.com/openshift/client-go/machineconfiguration/clientset/versioned"
@@ -19,14 +17,12 @@ import (
 	mcfginformersv1 "github.com/openshift/client-go/machineconfiguration/informers/externalversions/machineconfiguration/v1"
 	mcfglistersv1 "github.com/openshift/client-go/machineconfiguration/listers/machineconfiguration/v1"
 	operatorinformersv1alpha1 "github.com/openshift/client-go/operator/informers/externalversions/operator/v1alpha1"
-	operatorlistersv1alpha1 "github.com/openshift/client-go/operator/listers/operator/v1alpha1"
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
 	"github.com/openshift/machine-config-operator/pkg/imageutils"
 	"github.com/openshift/machine-config-operator/pkg/osimagestream"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -62,24 +58,17 @@ type Controller struct {
 	clusterVersionLister       configlistersv1.ClusterVersionLister
 	clusterVersionListerSynced cache.InformerSynced
 
-	secretLister       corelistersv1.SecretLister
 	secretListerSynced cache.InformerSynced
 
 	mcoCmLister       corelistersv1.ConfigMapLister
 	mcoCmListerSynced cache.InformerSynced
 
-	icspLister       operatorlistersv1alpha1.ImageContentSourcePolicyLister
 	icspListerSynced cache.InformerSynced
-
-	idmsLister       configlistersv1.ImageDigestMirrorSetLister
 	idmsListerSynced cache.InformerSynced
-
-	itmsLister       configlistersv1.ImageTagMirrorSetLister
 	itmsListerSynced cache.InformerSynced
+	imgListerSynced  cache.InformerSynced
 
-	imgLister       configlistersv1.ImageLister
-	imgListerSynced cache.InformerSynced
-
+	sysCtxFactory    imageutils.SysContextFactory
 	inspectorFactory osimagestream.ImagesInspectorFactory
 
 	queue workqueue.TypedRateLimitingInterface[string]
@@ -136,23 +125,20 @@ func New(
 	ctrl.clusterVersionLister = clusterVersionInformer.Lister()
 	ctrl.clusterVersionListerSynced = clusterVersionInformer.Informer().HasSynced
 
-	ctrl.secretLister = secretInformer.Lister()
 	ctrl.secretListerSynced = secretInformer.Informer().HasSynced
 
 	ctrl.mcoCmLister = cmInformer.Lister()
 	ctrl.mcoCmListerSynced = cmInformer.Informer().HasSynced
 
-	ctrl.icspLister = icspInformer.Lister()
 	ctrl.icspListerSynced = icspInformer.Informer().HasSynced
-
-	ctrl.idmsLister = idmsInformer.Lister()
 	ctrl.idmsListerSynced = idmsInformer.Informer().HasSynced
-
-	ctrl.itmsLister = itmsInformer.Lister()
 	ctrl.itmsListerSynced = itmsInformer.Informer().HasSynced
-
-	ctrl.imgLister = imgInformer.Lister()
 	ctrl.imgListerSynced = imgInformer.Informer().HasSynced
+
+	ctrl.sysCtxFactory = ctrlcommon.NewSysContextFactory(
+		ccInformer.Lister(), secretInformer.Lister(), imgInformer.Lister(),
+		icspInformer.Lister(), idmsInformer.Lister(), itmsInformer.Lister(),
+	)
 
 	return ctrl
 }
@@ -370,11 +356,6 @@ func (ctrl *Controller) getExistingOSImageStream() (*mcfgv1.OSImageStream, error
 func (ctrl *Controller) buildOSImageStream(ctx context.Context, existing *mcfgv1.OSImageStream) error {
 	klog.Info("Starting building of the OSImageStream instance")
 
-	cc, err := ctrl.ccLister.Get(ctrlcommon.ControllerConfigName)
-	if err != nil {
-		return fmt.Errorf("getting ControllerConfig for OSImageStream build: %w", err)
-	}
-
 	clusterVersion, err := osimagestream.GetClusterVersion(ctrl.clusterVersionLister)
 	if err != nil {
 		return fmt.Errorf("getting cluster version for OSImageStream inspection: %w", err)
@@ -389,26 +370,13 @@ func (ctrl *Controller) buildOSImageStream(ctx context.Context, existing *mcfgv1
 		klog.Warningf("Unable to get install version for OSImageStream build: %s", err)
 	}
 
-	clusterPullSecret, err := ctrl.secretLister.Secrets(ctrlcommon.OpenshiftConfigNamespace).Get("pull-secret")
-	if err != nil {
-		return fmt.Errorf("could not get the cluster PullSecret for OSImageStream sync: %w", err)
-	}
-
-	sysCtxFactory := func() (*imageutils.SysContext, error) {
-		builder, err := ctrl.getSysContextBuilder(clusterPullSecret, cc)
-		if err != nil {
-			return nil, fmt.Errorf("could not build SysContext for OSImageStream build: %w", err)
-		}
-		return builder.Build()
-	}
-
 	buildCtx, buildCancel := context.WithTimeout(ctx, 5*time.Minute)
 	defer buildCancel()
 
 	factory := osimagestream.NewDefaultStreamSourceFactory(ctrl.inspectorFactory)
 	osImageStream, err := factory.Create(
 		buildCtx,
-		sysCtxFactory,
+		ctrl.sysCtxFactory,
 		osimagestream.CreateOptions{
 			ReleaseImage:          image,
 			ConfigMapLister:       ctrl.mcoCmLister,
@@ -498,50 +466,6 @@ func osImageStreamRequiresRebuild(osImageStream *mcfgv1.OSImageStream, releaseIm
 	return !ok || storedVersion != version.Hash
 }
 
-func (ctrl *Controller) getSysContextBuilder(clusterPullSecret *corev1.Secret, cc *mcfgv1.ControllerConfig) (*imageutils.SysContextBuilder, error) {
-	sysCtxBuilder := imageutils.NewSysContextBuilder().
-		WithSecret(clusterPullSecret).
-		WithControllerConfig(cc)
-
-	imageConfig, err := ctrl.imgLister.Get("cluster")
-	if err != nil && !apierrors.IsNotFound(err) {
-		return nil, fmt.Errorf("could not get image configuration: %w", err)
-	}
-
-	icspRules, err := ctrl.icspLister.List(labels.Everything())
-	if err != nil {
-		if !apierrors.IsNotFound(err) {
-			return nil, fmt.Errorf("could not get ICSP rules: %w", err)
-		}
-		icspRules = []*apioperatorsv1alpha1.ImageContentSourcePolicy{}
-	}
-
-	idmsRules, err := ctrl.idmsLister.List(labels.Everything())
-	if err != nil {
-		if !apierrors.IsNotFound(err) {
-			return nil, fmt.Errorf("could not get IDMS rules: %w", err)
-		}
-		idmsRules = []*configv1.ImageDigestMirrorSet{}
-	}
-
-	itmsRules, err := ctrl.itmsLister.List(labels.Everything())
-	if err != nil {
-		if !apierrors.IsNotFound(err) {
-			return nil, fmt.Errorf("could not get ITMS rules: %w", err)
-		}
-		itmsRules = []*configv1.ImageTagMirrorSet{}
-	}
-
-	if imageConfig != nil || len(icspRules) != 0 || len(idmsRules) != 0 || len(itmsRules) != 0 {
-		registriesConf, err := imageutils.GenerateRegistriesConfig(imageConfig, icspRules, idmsRules, itmsRules)
-		if err != nil {
-			return nil, fmt.Errorf("could not build registries configuration: %w", err)
-		}
-		sysCtxBuilder.WithRegistriesConfig(registriesConf)
-	}
-
-	return sysCtxBuilder, nil
-}
 
 // Retain implements CacheEvicter — it keeps cached digests referenced by the
 // OSImage and OSExtensionsImage of each available stream in the OSImageStream.

--- a/pkg/osimagestream/stream_class_inspector.go
+++ b/pkg/osimagestream/stream_class_inspector.go
@@ -1,0 +1,60 @@
+package osimagestream
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/openshift/machine-config-operator/pkg/imageutils"
+)
+
+// StreamClassInspector inspects a container image URL and returns its OS Image
+// Stream name.
+type StreamClassInspector interface {
+	InspectStreamClass(imageURL string) (string, error)
+}
+
+type streamClassInspector struct {
+	inspectorFactory ImagesInspectorFactory
+	sysCtxFactory    imageutils.SysContextFactory
+}
+
+// NewStreamClassInspector creates a StreamClassInspector that resolves the OS
+// Image Stream name by inspecting image labels via the given factory.
+func NewStreamClassInspector(inspectorFactory ImagesInspectorFactory, sysCtxFactory imageutils.SysContextFactory) StreamClassInspector {
+	return &streamClassInspector{
+		inspectorFactory: inspectorFactory,
+		sysCtxFactory:    sysCtxFactory,
+	}
+}
+
+func (s *streamClassInspector) InspectStreamClass(imageURL string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	inspector := s.inspectorFactory.ForContext(s.sysCtxFactory)
+	return inspectStreamClass(ctx, inspector, imageURL)
+}
+
+func inspectStreamClass(ctx context.Context, inspector ImagesInspector, imageURL string) (string, error) {
+	results, err := inspector.Inspect(ctx, imageURL)
+	if err != nil {
+		return "", fmt.Errorf("failed to inspect OS image: %w", err)
+	}
+	if len(results) == 0 {
+		return "", fmt.Errorf("no inspection result for OS image")
+	}
+	if results[0].Error != nil {
+		return "", fmt.Errorf("failed to inspect OS image: %w", results[0].Error)
+	}
+	if results[0].InspectInfo == nil {
+		return "", nil
+	}
+
+	extractor := NewImageStreamExtractor()
+	imageData := extractor.GetImageData(imageURL, results[0].InspectInfo.Labels)
+	if imageData == nil {
+		return "", nil
+	}
+	return imageData.Stream, nil
+}

--- a/pkg/osimagestream/stream_class_inspector_test.go
+++ b/pkg/osimagestream/stream_class_inspector_test.go
@@ -1,0 +1,127 @@
+package osimagestream
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/containers/image/v5/types"
+	"github.com/openshift/machine-config-operator/pkg/imageutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func noopSysCtxFactory() (*imageutils.SysContext, error) {
+	return &imageutils.SysContext{}, nil
+}
+
+func TestInspectStreamClass(t *testing.T) {
+	const testImage = "quay.io/openshift/rhcos@sha256:abc123"
+
+	tests := []struct {
+		name      string
+		inspector ImagesInspector
+		wantClass string
+		wantErr   bool
+	}{
+		{
+			name: "RHEL 10",
+			inspector: &mockImagesInspector{
+				inspectData: map[string]*types.ImageInspectInfo{
+					testImage: {Labels: map[string]string{
+						"io.openshift.os.streamclass": "rhel-10",
+						"containers.bootc":            "1",
+					}},
+				},
+			},
+			wantClass: "rhel-10",
+		},
+		{
+			name: "RHEL 9",
+			inspector: &mockImagesInspector{
+				inspectData: map[string]*types.ImageInspectInfo{
+					testImage: {Labels: map[string]string{
+						"io.openshift.os.streamclass": "rhel-9",
+						"containers.bootc":            "true",
+					}},
+				},
+			},
+			wantClass: "rhel-9",
+		},
+		{
+			name: "CentOS 10",
+			inspector: &mockImagesInspector{
+				inspectData: map[string]*types.ImageInspectInfo{
+					testImage: {Labels: map[string]string{
+						"io.openshift.os.streamclass": "centos-10",
+						"containers.bootc":            "1",
+					}},
+				},
+			},
+			wantClass: "centos-10",
+		},
+		{
+			name: "no stream class label",
+			inspector: &mockImagesInspector{
+				inspectData: map[string]*types.ImageInspectInfo{
+					testImage: {Labels: map[string]string{
+						"containers.bootc": "true",
+					}},
+				},
+			},
+			wantClass: "",
+		},
+		{
+			name: "empty labels",
+			inspector: &mockImagesInspector{
+				inspectData: map[string]*types.ImageInspectInfo{
+					testImage: {Labels: map[string]string{}},
+				},
+			},
+			wantClass: "",
+		},
+		{
+			name: "nil InspectInfo",
+			inspector: &mockImagesInspector{
+				results: []imageutils.BulkInspectResult{
+					{Image: testImage, InspectInfo: nil},
+				},
+			},
+			wantClass: "",
+		},
+		{
+			name:      "inspector returns error",
+			inspector: &mockImagesInspector{err: errors.New("connection refused")},
+			wantErr:   true,
+		},
+		{
+			name: "result contains error",
+			inspector: &mockImagesInspector{
+				results: []imageutils.BulkInspectResult{
+					{Image: testImage, Error: errors.New("manifest unknown")},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty results",
+			inspector: &mockImagesInspector{
+				results: []imageutils.BulkInspectResult{},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			factory := &mockImagesInspectorFactory{inspector: tt.inspector}
+			sci := NewStreamClassInspector(factory, noopSysCtxFactory)
+			sc, err := sci.InspectStreamClass(testImage)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantClass, sc)
+		})
+	}
+}


### PR DESCRIPTION
**- What I did**

This change adds a few reusable pieces of logic for future usage in image inspection for runc or PIS checks.

**- How to verify it**

Regular PR e2es are enough to test this change.

**- Description for the changelog**

This change adds a few reusable pieces of logic for future usage in image inspection for runc or PIS checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved image stream processing by consistently applying cluster image settings and registry mirror rules.
  - Added automatic detection of an image stream’s classification metadata during image inspection.
  - Improved handling of missing metadata and inspection results without unnecessary failures.

- **Bug Fixes**
  - Improved error reporting for image inspection and registry configuration failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->