### PR TITLE
MCO-2468: Cache backed OSImageStreams for PIS

### DIFF
--- a/cmd/machine-config-controller/start.go
+++ b/cmd/machine-config-controller/start.go
@@ -105,6 +105,7 @@ func runStartCmd(_ *cobra.Command, _ []string) {
 		// EnsureOSImageStream call guarantees the CR exists before any other
 		// controller starts, since render, node, and template depend on it
 		// for OS image URLs.
+		var cacheWarmer *pinnedimageset.CacheWarmer
 		if osimagestream.IsFeatureEnabled(ctrlctx.FeatureGatesHandler) {
 			if inspectionCache != nil {
 				inspectorFactory = osimagestream.NewCachedImagesInspectorFactory(
@@ -145,6 +146,20 @@ func runStartCmd(_ *cobra.Command, _ []string) {
 
 			if inspectionCache != nil {
 				inspectionCache.RegisterEvicter(osImageStreamCtrl)
+
+				cacheWarmer = pinnedimageset.NewCacheWarmer(
+					ctrlctx.InformerFactory.Machineconfiguration().V1().PinnedImageSets().Lister(),
+					inspectorFactory,
+					ctrlcommon.NewSysContextFactory(
+						ctrlctx.InformerFactory.Machineconfiguration().V1().ControllerConfigs().Lister(),
+						ctrlctx.OpenShiftConfigKubeNamespacedInformerFactory.Core().V1().Secrets().Lister(),
+						ctrlctx.ConfigInformerFactory.Config().V1().Images().Lister(),
+						ctrlctx.OperatorInformerFactory.Operator().V1alpha1().ImageContentSourcePolicies().Lister(),
+						ctrlctx.ConfigInformerFactory.Config().V1().ImageDigestMirrorSets().Lister(),
+						ctrlctx.ConfigInformerFactory.Config().V1().ImageTagMirrorSets().Lister(),
+					),
+				)
+				inspectionCache.RegisterEvicter(cacheWarmer)
 			}
 		}
 
@@ -182,6 +197,7 @@ func runStartCmd(_ *cobra.Command, _ []string) {
 			ctrlctx.InformerFactory.Machineconfiguration().V1().MachineConfigPools(),
 			ctrlctx.ClientBuilder.KubeClientOrDie("pinned-image-set-controller"),
 			ctrlctx.ClientBuilder.MachineConfigClientOrDie("pinned-image-set-controller"),
+			cacheWarmer,
 		)
 		go pinnedImageSet.Run(ctx, 2)
 

--- a/pkg/controller/osimagestream/osimagestream_controller.go
+++ b/pkg/controller/osimagestream/osimagestream_controller.go
@@ -370,7 +370,7 @@ func (ctrl *Controller) buildOSImageStream(ctx context.Context, existing *mcfgv1
 		klog.Warningf("Unable to get install version for OSImageStream build: %s", err)
 	}
 
-	buildCtx, buildCancel := context.WithTimeout(ctx, 5*time.Minute)
+	buildCtx, buildCancel := context.WithTimeout(ctx, osimagestream.ImageInspectionTimeout)
 	defer buildCancel()
 
 	factory := osimagestream.NewDefaultStreamSourceFactory(ctrl.inspectorFactory)

--- a/pkg/controller/pinnedimageset/cache_warmer.go
+++ b/pkg/controller/pinnedimageset/cache_warmer.go
@@ -1,0 +1,143 @@
+package pinnedimageset
+
+import (
+	"context"
+	"fmt"
+
+	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
+	mcfglistersv1 "github.com/openshift/client-go/machineconfiguration/listers/machineconfiguration/v1"
+	"github.com/openshift/machine-config-operator/pkg/imageutils"
+	"github.com/openshift/machine-config-operator/pkg/osimagestream"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/klog/v2"
+)
+
+const releaseImageStreamPath = "/release-manifests/image-references"
+
+// CacheWarmer proactively warms the inspection cache for images referenced by
+// PinnedImageSets. It inspects labels of all PIS images and fetches the
+// ImageStream file from release payload images. It also implements CacheEvicter
+// to retain PIS-referenced digests.
+type CacheWarmer struct {
+	pisLister        mcfglistersv1.PinnedImageSetLister
+	inspectorFactory osimagestream.ImagesInspectorFactory
+	sysCtxFactory    imageutils.SysContextFactory
+	signal           chan struct{}
+}
+
+// NewCacheWarmer creates a CacheWarmer that will inspect images from PinnedImageSets.
+func NewCacheWarmer(
+	pisLister mcfglistersv1.PinnedImageSetLister,
+	inspectorFactory osimagestream.ImagesInspectorFactory,
+	sysCtxFactory imageutils.SysContextFactory,
+) *CacheWarmer {
+	return &CacheWarmer{
+		pisLister:        pisLister,
+		inspectorFactory: inspectorFactory,
+		sysCtxFactory:    sysCtxFactory,
+		signal:           make(chan struct{}, 1),
+	}
+}
+
+// Retain implements CacheEvicter — it retains all digests referenced by any PinnedImageSet.
+func (w *CacheWarmer) Retain(digests []string) []string {
+	pisList, err := w.pisLister.List(labels.Everything())
+	if err != nil {
+		return digests
+	}
+
+	active := sets.New[string]()
+	for _, pis := range pisList {
+		for _, ref := range pis.Spec.PinnedImages {
+			if d := imageutils.DigestFromPullspec(string(ref.Name)); d != "" {
+				active.Insert(d)
+			}
+		}
+	}
+
+	return sets.New(digests...).Intersection(active).UnsortedList()
+}
+
+// Start runs the warming loop, consuming coalesced signals from requestWarm.
+// It blocks until stopCh is closed.
+func (w *CacheWarmer) Start(ctx context.Context) {
+	w.requestWarm()
+
+	klog.Info("Starting PinnedImageSet cache warmer")
+	defer klog.Info("Shutting down PinnedImageSet cache warmer")
+
+	for {
+		select {
+		case <-w.signal:
+			if err := w.Warm(ctx); err != nil {
+				klog.Warningf("PinnedImageSet cache warming failed: %v", err)
+			}
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (w *CacheWarmer) requestWarm() {
+	select {
+	case w.signal <- struct{}{}:
+	default:
+	}
+}
+
+// Warm performs a single cache warming cycle. It inspects all PIS image labels
+// and fetches the ImageStream file from any release payload images found.
+func (w *CacheWarmer) Warm(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, osimagestream.ImageInspectionTimeout)
+	defer cancel()
+
+	pisList, err := w.pisLister.List(labels.Everything())
+	if err != nil {
+		return fmt.Errorf("listing PinnedImageSets: %w", err)
+	}
+
+	images := collectPISImages(pisList)
+	if len(images) == 0 {
+		return nil
+	}
+
+	inspector := w.inspectorFactory.ForContext(w.sysCtxFactory)
+
+	results, err := inspector.Inspect(ctx, images...)
+	if err != nil {
+		return fmt.Errorf("inspecting PIS images: %w", err)
+	}
+
+	klog.V(4).Infof("PIS cache warmer: inspected %d images", len(results))
+
+	for _, r := range results {
+		if r.Error != nil || r.InspectInfo == nil || !osimagestream.IsReleasePayload(r.InspectInfo.Labels) {
+			continue
+		}
+		// Release payload images contain the ImageStream manifest at a well-known
+		// path. Fetching it here warms the file in the inspection cache so that
+		// later consumers (e.g. the osimagestream controller) get a cache hit.
+		if _, err := inspector.FetchImageFile(ctx, r.Image, releaseImageStreamPath); err != nil {
+			klog.Warningf("PIS cache warmer: failed to fetch image-references from %s: %v", r.Image, err)
+		}
+	}
+
+	return nil
+}
+
+func collectPISImages(pisList []*mcfgv1.PinnedImageSet) []string {
+	seen := sets.New[string]()
+	var images []string
+	for _, pis := range pisList {
+		for _, ref := range pis.Spec.PinnedImages {
+			img := string(ref.Name)
+			if seen.Has(img) {
+				continue
+			}
+			seen.Insert(img)
+			images = append(images, img)
+		}
+	}
+	return images
+}

--- a/pkg/controller/pinnedimageset/cache_warmer_test.go
+++ b/pkg/controller/pinnedimageset/cache_warmer_test.go
@@ -1,0 +1,174 @@
+package pinnedimageset
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/containers/image/v5/types"
+	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
+	fakemco "github.com/openshift/client-go/machineconfiguration/clientset/versioned/fake"
+	mcfginformers "github.com/openshift/client-go/machineconfiguration/informers/externalversions"
+	"github.com/openshift/machine-config-operator/pkg/imageutils"
+	"github.com/openshift/machine-config-operator/pkg/osimagestream"
+	"github.com/openshift/machine-config-operator/test/helpers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+const (
+	testOSImage       = "registry.example.com/os@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	testReleaseImage  = "registry.example.com/release@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	testOperatorImage = "registry.example.com/operator@sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+)
+
+type fakeInspector struct {
+	inspectData map[string]*types.ImageInspectInfo
+	fileData    map[string][]byte
+}
+
+func (f *fakeInspector) Inspect(_ context.Context, images ...string) ([]imageutils.BulkInspectResult, error) {
+	var results []imageutils.BulkInspectResult
+	for _, img := range images {
+		r := imageutils.BulkInspectResult{Image: img}
+		if info, ok := f.inspectData[img]; ok {
+			r.InspectInfo = info
+		}
+		results = append(results, r)
+	}
+	return results, nil
+}
+
+func (f *fakeInspector) FetchImageFile(_ context.Context, image, path string) ([]byte, error) {
+	if data, ok := f.fileData[image+":"+path]; ok {
+		return data, nil
+	}
+	return nil, nil
+}
+
+type fakeInspectorFactory struct {
+	inspector osimagestream.ImagesInspector
+}
+
+func (f *fakeInspectorFactory) ForContext(_ imageutils.SysContextFactory) osimagestream.ImagesInspector {
+	return f.inspector
+}
+
+func noopSysCtxFactory() (*imageutils.SysContext, error) {
+	return &imageutils.SysContext{}, nil
+}
+
+// TestCacheWarmerWarmsOnPISChange verifies that the cache warmer, running inside
+// the PIS controller, reacts to PinnedImageSet create and update events by
+// inspecting all referenced images and caching their labels. For images
+// identified as release payloads (io.openshift.release label), it also fetches
+// and caches the ImageStream file at /release-manifests/image-references.
+func TestCacheWarmerWarmsOnPISChange(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cache := imageutils.NewFileInspectionCache(
+		filepath.Join(t.TempDir(), "cache.json"), 48*time.Hour)
+
+	inspector := &fakeInspector{
+		inspectData: map[string]*types.ImageInspectInfo{
+			testOSImage: {Labels: map[string]string{
+				"io.openshift.os.streamclass": "rhel-9",
+				"containers.bootc":            "true",
+			}},
+			testReleaseImage: {Labels: map[string]string{
+				"io.openshift.release": "5.0.0",
+			}},
+			testOperatorImage: {Labels: map[string]string{
+				"io.openshift.release.operator": "true",
+			}},
+		},
+		fileData: map[string][]byte{
+			testReleaseImage + ":" + releaseImageStreamPath: []byte("fake-imagestream"),
+		},
+	}
+
+	cachedFactory := osimagestream.NewCachedImagesInspectorFactory(
+		&fakeInspectorFactory{inspector: inspector},
+		cache,
+	)
+
+	pool := helpers.NewMachineConfigPool("master", masterPoolSelector, helpers.MasterSelector, "")
+	fakeMCOClient := fakemco.NewSimpleClientset(pool)
+	fakeClient := fake.NewSimpleClientset()
+
+	sharedInformers := mcfginformers.NewSharedInformerFactory(fakeMCOClient, 0)
+	pisInformer := sharedInformers.Machineconfiguration().V1().PinnedImageSets()
+	mcpInformer := sharedInformers.Machineconfiguration().V1().MachineConfigPools()
+
+	warmer := NewCacheWarmer(pisInformer.Lister(), cachedFactory, noopSysCtxFactory)
+	ctrl := New(pisInformer, mcpInformer, fakeClient, fakeMCOClient, warmer)
+
+	sharedInformers.Start(ctx.Done())
+	sharedInformers.WaitForCacheSync(ctx.Done())
+
+	go ctrl.Run(ctx, 2)
+
+	pis := &mcfgv1.PinnedImageSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "test-pis",
+			Labels: map[string]string{"machineconfiguration.openshift.io/role": "master"},
+		},
+		Spec: mcfgv1.PinnedImageSetSpec{
+			PinnedImages: []mcfgv1.PinnedImageRef{
+				{Name: mcfgv1.ImageDigestFormat(testOSImage)},
+				{Name: mcfgv1.ImageDigestFormat(testReleaseImage)},
+				{Name: mcfgv1.ImageDigestFormat(testOperatorImage)},
+			},
+		},
+	}
+	_, err := fakeMCOClient.MachineconfigurationV1().PinnedImageSets().Create(ctx, pis, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	osDigest := imageutils.DigestFromPullspec(testOSImage)
+	releaseDigest := imageutils.DigestFromPullspec(testReleaseImage)
+	operatorDigest := imageutils.DigestFromPullspec(testOperatorImage)
+
+	require.Eventually(t, func() bool {
+		releaseEntry := cache.Get(releaseDigest)
+		return releaseEntry != nil &&
+			releaseEntry.Files != nil &&
+			len(releaseEntry.Files[releaseImageStreamPath]) > 0
+	}, 5*time.Second, 100*time.Millisecond)
+
+	osEntry := cache.Get(osDigest)
+	require.NotNil(t, osEntry)
+	assert.Equal(t, "rhel-9", osEntry.Labels["io.openshift.os.streamclass"])
+
+	releaseEntry := cache.Get(releaseDigest)
+	require.NotNil(t, releaseEntry)
+	assert.Equal(t, "5.0.0", releaseEntry.Labels["io.openshift.release"])
+	assert.Equal(t, []byte("fake-imagestream"), releaseEntry.Files[releaseImageStreamPath])
+
+	operatorEntry := cache.Get(operatorDigest)
+	require.NotNil(t, operatorEntry)
+	assert.Equal(t, "true", operatorEntry.Labels["io.openshift.release.operator"])
+
+	// Update the PIS adding a new image and verify it gets warmed too
+	newImage := "registry.example.com/new@sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+	inspector.inspectData[newImage] = &types.ImageInspectInfo{
+		Labels: map[string]string{"some-label": "some-value"},
+	}
+
+	pis.Spec.PinnedImages = append(pis.Spec.PinnedImages, mcfgv1.PinnedImageRef{
+		Name: mcfgv1.ImageDigestFormat(newImage),
+	})
+	_, err = fakeMCOClient.MachineconfigurationV1().PinnedImageSets().Update(ctx, pis, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	newDigest := imageutils.DigestFromPullspec(newImage)
+	require.Eventually(t, func() bool {
+		return cache.Get(newDigest) != nil
+	}, 5*time.Second, 100*time.Millisecond)
+
+	newEntry := cache.Get(newDigest)
+	assert.Equal(t, "some-value", newEntry.Labels["some-label"])
+}

--- a/pkg/controller/pinnedimageset/pinned_image_set.go
+++ b/pkg/controller/pinnedimageset/pinned_image_set.go
@@ -56,6 +56,8 @@ type Controller struct {
 	imageSetSynced cache.InformerSynced
 
 	queue workqueue.TypedRateLimitingInterface[string]
+
+	cacheWarmer *CacheWarmer
 }
 
 // New returns a new pinned image set controller.
@@ -64,6 +66,7 @@ func New(
 	mcpInformer mcfginformersv1.MachineConfigPoolInformer,
 	kubeClient clientset.Interface,
 	mcfgClient mcfgclientset.Interface,
+	cacheWarmer *CacheWarmer,
 ) *Controller {
 	eventBroadcaster := record.NewBroadcaster()
 	eventBroadcaster.StartLogging(klog.Infof)
@@ -100,6 +103,8 @@ func New(
 	ctrl.imageSetLister = imageSetInformer.Lister()
 	ctrl.imageSetSynced = imageSetInformer.Informer().HasSynced
 
+	ctrl.cacheWarmer = cacheWarmer
+
 	return ctrl
 }
 
@@ -114,6 +119,10 @@ func (ctrl *Controller) Run(ctx context.Context, workers int) {
 
 	klog.Info("Starting MachineConfigController-PinnedImageSetController")
 	defer klog.Info("Shutting down MachineConfigController-PinnedImageSetController")
+
+	if ctrl.cacheWarmer != nil {
+		go ctrl.cacheWarmer.Start(ctx)
+	}
 
 	for i := 0; i < workers; i++ {
 		go wait.Until(ctrl.worker, time.Second, ctx.Done())
@@ -169,6 +178,9 @@ func (ctrl *Controller) addPinnedImageSet(obj interface{}) {
 	for _, p := range pools {
 		ctrl.enqueueMachineConfigPool(p)
 	}
+	if ctrl.cacheWarmer != nil {
+		ctrl.cacheWarmer.requestWarm()
+	}
 }
 
 func (ctrl *Controller) updatePinnedImageSet(old, cur interface{}) {
@@ -185,6 +197,9 @@ func (ctrl *Controller) updatePinnedImageSet(old, cur interface{}) {
 	if triggerPinnedImageSetChange(oldImageSet, newImageSet) {
 		for _, p := range pools {
 			ctrl.enqueueMachineConfigPool(p)
+		}
+		if ctrl.cacheWarmer != nil {
+			ctrl.cacheWarmer.requestWarm()
 		}
 	}
 }

--- a/pkg/controller/pinnedimageset/pinned_image_set_test.go
+++ b/pkg/controller/pinnedimageset/pinned_image_set_test.go
@@ -78,7 +78,7 @@ func TestSyncHandler(t *testing.T) {
 				require.NoError(err)
 			}
 
-			c := New(imageSetInformer, mcpInformer, fakeClient, fakeMCOClient)
+			c := New(imageSetInformer, mcpInformer, fakeClient, fakeMCOClient, nil)
 			mcp, ok := tt.machineConfigPool.(*mcfgv1.MachineConfigPool)
 			require.True(ok)
 

--- a/pkg/osimagestream/image_data.go
+++ b/pkg/osimagestream/image_data.go
@@ -17,6 +17,10 @@ const (
 	coreOSLabelExtension      = "io.openshift.os.extensions"
 	coreOSLabelExtensionValue = "true"
 
+	// releasePayloadLabel is the container image label that identifies a release payload image.
+	// Its value is the release version string (e.g. "5.0.0-0.ci-2026-07-21-191603").
+	releasePayloadLabel = "io.openshift.release"
+
 	// coreOSLabelBootc is the container image label present on bootc-based OS images.
 	coreOSLabelBootc             = "containers.bootc"
 	coreOSLabelBootcValueBool    = "true"
@@ -170,6 +174,12 @@ func NewOSImageStreamURLSetFromImageMetadata(imageMetadata *ImageData) *mcfgv1.O
 		urlSet.OSExtensionsImage = imageName
 	}
 	return urlSet
+}
+
+// IsReleasePayload returns true if the given labels indicate a release payload image.
+func IsReleasePayload(labels map[string]string) bool {
+	_, ok := labels[releasePayloadLabel]
+	return ok
 }
 
 // labelEquals returns a matcher that checks whether a label has the expected value (case-insensitive).

--- a/pkg/osimagestream/osimagestream.go
+++ b/pkg/osimagestream/osimagestream.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"maps"
 	"slices"
+	"time"
 
 	imagev1 "github.com/openshift/api/image/v1"
 	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
@@ -18,6 +19,9 @@ import (
 	corelisterv1 "k8s.io/client-go/listers/core/v1"
 	"k8s.io/klog/v2"
 )
+
+// ImageInspectionTimeout is the timeout for operations that inspect images over the network.
+const ImageInspectionTimeout = 5 * time.Minute
 
 var (
 	ErrorNoOSImageStreamAvailable = errors.New("unable to retrieve any OSImageStream from the configured sources")


### PR DESCRIPTION
**- What I did**

This change leverages the recently added inspection cache to allow disconnected environments using PIS to be able to discover streams.

**- How to verify it**

TBD

**- Description for the changelog**

This change leverages the recently added inspection cache to allow disconnected environments using PIS to be able to discover streams.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optionally warms the inspection cache for images referenced by pinned image sets when stream caching is enabled.
  * Adds a background cache warmer that preloads release payload manifest references.
  * Cache warming is triggered on pinned image set create and update events.
* **Enhancements**
  * Release payload images are detected via a dedicated helper for consistent identification.
* **Testing**
  * Added coverage to verify cache warming reacts to pinned image set changes.
* **Chores**
  * Standardized OS image inspection context timeout to a shared 5-minute value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->