### PR TITLE
OCPBUGS-87962: Add OCP-89593 test for boot image skew reset on reconcile-skip

### DIFF
--- a/test/extended-priv/mco_bootimages_skew.go
+++ b/test/extended-priv/mco_bootimages_skew.go
@@ -2,6 +2,7 @@ package extended
 
 import (
 	"context"
+	"fmt"
 
 	g "github.com/onsi/ginkgo/v2"
 	o "github.com/onsi/gomega"
@@ -295,5 +296,66 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/disruptive
 
 		// Check machine-config CO upgradeable status, should be set to true
 		o.Eventually(mcoCO, "1m", "10s").Should(BeUpgradeable(), "co/machine-config should be upgradeable when skew enforcement is disabled (None mode)")
+	})
+
+	// https://issues.redhat.com/browse/OCPBUGS-87962
+	g.It("[PolarionID:89593][OTP] Boot image skew check correctly reflects actual boot image version when MachineSets are reconcile-skipped [Disruptive]", g.Label("Platform:aws", "Platform:gce", "Platform:azure", "Platform:vsphere"), func() {
+		skipTestIfSupportedPlatformNotMatched(oc, GCPPlatform, AWSPlatform, AzurePlatform, VspherePlatform)
+
+		automaticOCPVersionPath := `{.status.bootImageSkewEnforcementStatus.automatic.ocpVersion}`
+
+		exutil.By("Ensure Automatic mode is active")
+		o.Expect(machineConfiguration.RemoveSkew()).To(o.Succeed())
+		machineConfiguration.WaitForBootImageSkewEnforcementStatusMode(SkewEnforcementAutomaticMode)
+		machineConfiguration.WaitForBootImageControllerComplete()
+		logger.Infof("OK!\n")
+
+		exutil.By("Get the automatic.ocpVersion before patch")
+		originalOCPVersion, err := machineConfiguration.Get(automaticOCPVersionPath)
+		o.Expect(err).NotTo(o.HaveOccurred(), "Error getting automatic.ocpVersion from %s", machineConfiguration)
+		o.Expect(originalOCPVersion).NotTo(o.BeEmpty(), "automatic.ocpVersion should not be empty in Automatic mode")
+		logger.Infof("automatic.ocpVersion before patch: %s", originalOCPVersion)
+		logger.Infof("OK!\n")
+
+		exutil.By("Pick a MachineSet and add an OwnerReference to trigger reconcile-skip")
+		machineSetUnderTest := NewMachineSetList(oc.AsAdmin(), MachineAPINamespace).GetAllOrFail()[0]
+		logger.Infof("MachineSet under test: %s", machineSetUnderTest.name)
+
+		infraUID, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(
+			"infrastructure", "cluster", "-o", "jsonpath={.metadata.uid}",
+		).Output()
+		o.Expect(err).NotTo(o.HaveOccurred(), "Failed to get Infrastructure UID")
+
+		ownerRefPatch := fmt.Sprintf(
+			`{"metadata":{"ownerReferences":[{"apiVersion":"config.openshift.io/v1","kind":"Infrastructure","name":"cluster","uid":"%s"}]}}`,
+			infraUID)
+		o.Expect(machineSetUnderTest.Patch("merge", ownerRefPatch)).To(o.Succeed())
+		logger.Infof("Added OwnerReference to MachineSet %s to trigger reconcile-skip", machineSetUnderTest.name)
+
+		defer func() {
+			exutil.By("Restoring MachineSet by removing OwnerReference")
+			o.Expect(machineSetUnderTest.Patch("json", `[{"op":"remove","path":"/metadata/ownerReferences"}]`)).To(o.Succeed())
+			machineConfiguration.WaitForBootImageControllerComplete()
+		}()
+		logger.Infof("OK!\n")
+
+		exutil.By("Wait for boot image controller to process and get automatic.ocpVersion after patch")
+		machineConfiguration.WaitForBootImageControllerComplete()
+		patchedOCPVersion, err := machineConfiguration.Get(automaticOCPVersionPath)
+		o.Expect(err).NotTo(o.HaveOccurred(), "Error getting automatic.ocpVersion after patch")
+		o.Expect(patchedOCPVersion).NotTo(o.BeEmpty(), "automatic.ocpVersion should not be empty after reconcile-skip")
+		logger.Infof("automatic.ocpVersion after patch: %s", patchedOCPVersion)
+		logger.Infof("OK!\n")
+
+		exutil.By("Remove OwnerReference and verify automatic.ocpVersion is restored")
+		o.Expect(machineSetUnderTest.Patch("json", `[{"op":"remove","path":"/metadata/ownerReferences"}]`)).To(o.Succeed())
+		machineConfiguration.WaitForBootImageControllerComplete()
+		o.Eventually(func() string {
+			v, _ := machineConfiguration.Get(automaticOCPVersionPath)
+			return v
+		}, "2m", "10s").Should(o.Equal(originalOCPVersion),
+			"automatic.ocpVersion should be restored to %s after removing OwnerReference", originalOCPVersion)
+		logger.Infof("automatic.ocpVersion restored to: %s", originalOCPVersion)
+		logger.Infof("OK!\n")
 	})
 })


### PR DESCRIPTION
###Upgrade Test-case

Summary

  - Adds e2e test OCP-89593 to validate the fix in PR #6162 (resetClusterBootImage)
  - Verifies automatic.ocpVersion before/after triggering reconcile-skip on a MachineSet, and that it restores after cleanup

  Approach

  - Uses an OwnerReference on a MachineSet to trigger reconcileSkipped=true in syncMAPIMachineSet (line 150-152 of ms_helpers.go)
  - This check happens before the OS stream check, so it works on both rhel-9 (4.x) and rhel-10 (5.0) clusters
  - No SkipIfUnsupportedOSStreamLabel needed
  - defer removes the OwnerReference for cleanup



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage to verify boot image skew reporting remains accurate when MachineSet reconciliation is skipped.
  * Confirmed the reported automatic OpenShift version is preserved during the skipped reconciliation and restored correctly after reconciliation resumes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->