### PR TITLE
OCPBUGS-99696: Add extension verification failure test cases OCP-89090 and OCP-89095

### DIFF
--- a/test/extended-priv/mco_extensions.go
+++ b/test/extended-priv/mco_extensions.go
@@ -144,4 +144,110 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/longdurati
 
 		validateMcpRenderDegraded(mc, mcp, expectedRDMessage, expectedRDReason)
 	})
+
+	g.It("[PolarionID:89090][OTP] verifyExtensionsStaged detects missing staged deployment after applying extensions [Disruptive]", func() {
+		var (
+			testID            = GetCurrentTestPolarionIDNumber()
+			expectedNDMessage = "no staged deployment found after applying extensions"
+		)
+
+		exutil.By("Get a pool for testing")
+		mcp, cleanup, err := GetCompactCompatibleOrCustomPool(oc.AsAdmin(), 1)
+		defer cleanup()
+		o.Expect(err).NotTo(o.HaveOccurred(), "Error getting pool for testing")
+		node := mcp.GetSortedNodesOrFail()[0]
+		logger.Infof("MCP: %s, node: %s", mcp.GetName(), node.GetName())
+		logger.Infof("OK!\n")
+
+		exutil.By("Replace rpm-ostree with fake script that silently succeeds on install/override")
+		o.Expect(ReplaceRpmOstree(node, generateTemplateAbsolutePath("rpm-ostree-fake-install-noop.sh"))).To(o.Succeed(),
+			"Failed to replace rpm-ostree on node %s", node.GetName())
+		logger.Infof("OK!\n")
+
+		exutil.By("Apply MachineConfig with usbguard extension")
+		mc := NewMachineConfig(oc.AsAdmin(), fmt.Sprintf("test-%s-ext", testID), mcp.GetName()).
+			SetMCOTemplate("change-worker-extension-usbguard.yaml")
+		mc.skipWaitForMcp = true
+		defer func() {
+			exutil.By("Restore rpm-ostree, delete MC, and recover MCP")
+			o.Expect(RestoreRpmOstree(node)).To(o.Succeed(), "Failed to restore rpm-ostree on node %s", node.GetName())
+			o.Eventually(mc.Delete).Should(o.Succeed(), "Could not delete the extension MC")
+			o.Expect(mcp.RecoverFromDegraded()).To(o.Succeed(), "The MCP could not be recovered from Degraded status")
+		}()
+		mc.create()
+		logger.Infof("OK!\n")
+
+		exutil.By("Restart MCD pod on the node to pick up fake rpm-ostree")
+		mcdPod := node.GetMachineConfigDaemon()
+		err = NewNamespacedResource(oc.AsAdmin(), "pod", MachineConfigNamespace, mcdPod).Delete()
+		o.Expect(err).NotTo(o.HaveOccurred(), "Failed to delete MCD pod %s", mcdPod)
+		logger.Infof("Deleted MCD pod %s to trigger re-sync with fake rpm-ostree", mcdPod)
+		logger.Infof("OK!\n")
+
+		exutil.By("Wait for MCP to degrade with missing staged deployment error")
+		o.Eventually(mcp, mcp.estimateWaitDuration().String(), "30s").Should(BeDegraded(),
+			"The '%s' MCP should become degraded when no staged deployment is found after applying extensions", mcp.GetName())
+		o.Expect(mcp).To(HaveNodeDegradedMessage(o.ContainSubstring(expectedNDMessage)),
+			"The '%s' MCP should report the staged deployment error in the NodeDegraded condition", mcp.GetName())
+		logger.Infof("OK!\n")
+	})
+
+	g.It("[PolarionID:89095][OTP] verifyExtensionPackages detects extension missing from RPM database after reboot [Disruptive]", func() {
+		var (
+			testID            = GetCurrentTestPolarionIDNumber()
+			expectedNDMessage = "extension package verification failed"
+			fakeRpmLocalPath  = generateTemplateAbsolutePath("rpm-fake-usbguard-missing.sh")
+		)
+
+		exutil.By("Get a pool for testing")
+		mcp, cleanup, err := GetCompactCompatibleOrCustomPool(oc.AsAdmin(), 1)
+		defer cleanup()
+		o.Expect(err).NotTo(o.HaveOccurred(), "Error getting pool for testing")
+		node := mcp.GetSortedNodesOrFail()[0]
+		logger.Infof("MCP: %s, node: %s", mcp.GetName(), node.GetName())
+		logger.Infof("OK!\n")
+
+		exutil.By("Apply MachineConfig with usbguard extension")
+		mc := NewMachineConfig(oc.AsAdmin(), fmt.Sprintf("test-%s-ext", testID), mcp.GetName()).
+			SetMCOTemplate("change-worker-extension-usbguard.yaml")
+		mc.skipWaitForMcp = true
+		defer func() {
+			exutil.By("Restore rpm, delete MC, and recover MCP")
+			o.Expect(RestoreRpm(node)).To(o.Succeed(), "Failed to restore rpm on node %s", node.GetName())
+			o.Eventually(mc.Delete).Should(o.Succeed(), "Could not delete the extension MC")
+			o.Expect(mcp.RecoverFromDegraded()).To(o.Succeed(), "The MCP could not be recovered from Degraded status")
+		}()
+		mc.create()
+		logger.Infof("OK!\n")
+
+		exutil.By("Wait for node to reboot and MCP to finish updating")
+		o.Expect(mcp.WaitForUpdatedStatus()).To(o.Succeed(),
+			"The MCP should complete the update after installing usbguard extension")
+		logger.Infof("OK!\n")
+
+		exutil.By("Re-apply fake rpm after reboot (bind mount is lost on reboot)")
+		o.Expect(ReplaceRpm(node, fakeRpmLocalPath)).To(o.Succeed(),
+			"Failed to re-apply fake rpm on node %s", node.GetName())
+		logger.Infof("OK!\n")
+
+		exutil.By("Restart MCD pod on the node to pick up fake rpm")
+		mcdPod := node.GetMachineConfigDaemon()
+		err = NewNamespacedResource(oc.AsAdmin(), "pod", MachineConfigNamespace, mcdPod).Delete()
+		o.Expect(err).NotTo(o.HaveOccurred(), "Failed to delete MCD pod %s", mcdPod)
+		logger.Infof("Deleted MCD pod %s to trigger re-sync", mcdPod)
+		logger.Infof("OK!\n")
+
+		exutil.By("Wait for MCP to degrade with extension verification error")
+		o.Eventually(mcp, mcp.estimateWaitDuration().String(), "30s").Should(BeDegraded(),
+			"The '%s' MCP should become degraded when extension packages are missing from the RPM database", mcp.GetName())
+		o.Expect(mcp).To(HaveNodeDegradedMessage(o.ContainSubstring(expectedNDMessage)),
+			"The '%s' MCP should report the extension verification error in the NodeDegraded condition", mcp.GetName())
+		logger.Infof("OK!\n")
+
+		exutil.By("Check MCD logs for extension verification error")
+		o.Eventually(node.GetMCDaemonLogs, "2m", "10s").WithArguments("").Should(
+			o.ContainSubstring(expectedNDMessage),
+			"MCD logs should contain the extension verification error")
+		logger.Infof("OK!\n")
+	})
 })

--- a/test/extended-priv/node.go
+++ b/test/extended-priv/node.go
@@ -1457,24 +1457,12 @@ func FixRebootInNode(node *Node) error {
 // BreakRebaseInNode breaks the rpm-ostree rebase process in a node
 func BreakRebaseInNode(node *Node) error {
 	logger.Infof("Breaking rpm-ostree rebase process in node %s", node.GetName())
-	brokenRpmOstree := generateTemplateAbsolutePath("rpm-ostree-force-pivot-error.sh")
-	if err := node.CopyFromLocal(brokenRpmOstree, "/tmp/rpm-ostree.broken"); err != nil {
-		return fmt.Errorf("error copying %s to node %s: %w", brokenRpmOstree, node, err)
-	}
-	_, err := node.DebugNodeWithChroot("sh", "-c",
-		"chmod +x /tmp/rpm-ostree.broken; "+
-			"cp /usr/bin/rpm-ostree /tmp/rpm-ostree; "+
-			"nsenter --mount=/proc/1/ns/mnt mount --bind /tmp/rpm-ostree.broken /usr/bin/rpm-ostree; "+
-			"restorecon -v /usr/bin/rpm-ostree")
-	return err
+	return ReplaceRpmOstree(node, generateTemplateAbsolutePath("rpm-ostree-force-pivot-error.sh"))
 }
 
 // FixRebaseInNode fixes the rpm-ostree rebase process in a node
 func FixRebaseInNode(node *Node) error {
-	logger.Infof("Fixing rpm-ostree rebase process in node %s", node.GetName())
-
-	_, err := node.DebugNodeWithChroot("sh", "-c", "pkill -9 -x rpm-ostree; nsenter --mount=/proc/1/ns/mnt umount /usr/bin/rpm-ostree")
-	return err
+	return RestoreRpmOstree(node)
 }
 
 // GetOperatorNode returns the node running the MCO operator pod
@@ -1614,4 +1602,58 @@ func FilterSchedulableNodesOrFail(nodes []*Node) []*Node {
 		}
 	}
 	return returnNodes
+}
+
+const (
+	fakeRpmOstreeRemotePath = "/var/tmp/rpm-ostree-fake.sh"
+	fakeRpmRemotePath       = "/var/tmp/rpm-fake.sh"
+)
+
+// ReplaceRpmOstree copies a local script to the node and bind-mounts it over /usr/bin/rpm-ostree.
+// The original binary is backed up to /var/tmp/rpm-ostree.
+func ReplaceRpmOstree(node *Node, localScriptPath string) error {
+	logger.Infof("Replacing rpm-ostree with %s on node %s", localScriptPath, node.GetName())
+	if err := node.CopyFromLocal(localScriptPath, fakeRpmOstreeRemotePath); err != nil {
+		return fmt.Errorf("error copying %s to node %s: %w", localScriptPath, node, err)
+	}
+	_, err := node.DebugNodeWithChroot("sh", "-c",
+		"chmod +x "+fakeRpmOstreeRemotePath+" && "+
+			"cp /usr/bin/rpm-ostree /var/tmp/rpm-ostree && "+
+			"nsenter --mount=/proc/1/ns/mnt mount --bind "+fakeRpmOstreeRemotePath+" /usr/bin/rpm-ostree && "+
+			"restorecon -v /usr/bin/rpm-ostree")
+	return err
+}
+
+// RestoreRpmOstree unmounts the bind-mounted rpm-ostree and removes backup and fake script files.
+func RestoreRpmOstree(node *Node) error {
+	logger.Infof("Restoring rpm-ostree on node %s", node.GetName())
+	_, err := node.DebugNodeWithChroot("sh", "-c",
+		"pkill -9 -x rpm-ostree; "+
+			"nsenter --mount=/proc/1/ns/mnt umount -l /usr/bin/rpm-ostree 2>/dev/null; "+
+			"rm -f /var/tmp/rpm-ostree "+fakeRpmOstreeRemotePath)
+	return err
+}
+
+// ReplaceRpm copies a local script to the node and bind-mounts it over /usr/bin/rpm.
+// The original binary is backed up to /var/tmp/rpm-real.
+func ReplaceRpm(node *Node, localScriptPath string) error {
+	logger.Infof("Replacing rpm with %s on node %s", localScriptPath, node.GetName())
+	if err := node.CopyFromLocal(localScriptPath, fakeRpmRemotePath); err != nil {
+		return fmt.Errorf("error copying %s to node %s: %w", localScriptPath, node, err)
+	}
+	_, err := node.DebugNodeWithChroot("sh", "-c",
+		"chmod +x "+fakeRpmRemotePath+" && "+
+			"cp /usr/bin/rpm /var/tmp/rpm-real && "+
+			"nsenter --mount=/proc/1/ns/mnt mount --bind "+fakeRpmRemotePath+" /usr/bin/rpm && "+
+			"restorecon -v /usr/bin/rpm")
+	return err
+}
+
+// RestoreRpm unmounts the bind-mounted rpm and removes backup and fake script files.
+func RestoreRpm(node *Node) error {
+	logger.Infof("Restoring rpm on node %s", node.GetName())
+	_, err := node.DebugNodeWithChroot("sh", "-c",
+		"nsenter --mount=/proc/1/ns/mnt umount -l /usr/bin/rpm 2>/dev/null; "+
+			"rm -f /var/tmp/rpm-real "+fakeRpmRemotePath)
+	return err
 }

--- a/test/extended-priv/testdata/files/rpm-fake-usbguard-missing.sh
+++ b/test/extended-priv/testdata/files/rpm-fake-usbguard-missing.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Fake rpm that reports usbguard as not installed.
+# All other queries are forwarded to the real rpm backup.
+if [ "$1" = "-q" ] && [ "$2" = "usbguard" ]; then
+  exit 1
+fi
+/var/tmp/rpm-real "$@"

--- a/test/extended-priv/testdata/files/rpm-ostree-fake-install-noop.sh
+++ b/test/extended-priv/testdata/files/rpm-ostree-fake-install-noop.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Fake rpm-ostree that silently succeeds on install/override commands.
+# All other commands are forwarded to the real rpm-ostree backup.
+if [[ "$@" == *"install"* ]] || [[ "$@" == *"override"* ]]; then
+  echo "Installing package (fake)"
+  exit 0
+fi
+exec /var/tmp/rpm-ostree "$@"


### PR DESCRIPTION
  Summary

  - OCP-89090: Tests that MCD detects missing staged deployment when rpm-ostree silently succeeds on extension install (fake binary via bind mount). Verifies MCP degrades with "no staged 
  deployment found after applying extensions" error.
  - OCP-89095: Tests that MCD detects extension packages missing from RPM database after reboot. Uses fake rpm binary that reports usbguard as not installed. Verifies MCP degrades with
  "extension package verification failed" error.

  Both tests use a custom MCP with 1 node, bind-mount fake binaries via nsenter, and validate degradation via checkDegraded. Cleanup restores original binaries, deletes MC, recovers MCP, and
  deletes custom MCP — all in defer.

  Test plan

  - [x] Run OCP-89090 on a cluster and verify MCP degrades with staged deployment error
  - [x] Run OCP-89095 on a cluster and verify MCP degrades with extension verification error
  - [x] Verify cleanup restores cluster to healthy state after each test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for machine configuration extensions, including degraded states caused by missing staged deployments and failed package verification.
  * Improved validation of node-reported failure messages and recovery to a healthy state after disruptive scenarios.
  * Added realistic simulations for package queries and installation or override operations.
* **Chores**
  * Standardized temporary system command replacement and restoration to improve consistency across node operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->