### PR TITLE
OCPBUGS-99650: Delete stale auto-sizing MachineConfigs for non-default (custom) pools 4.20

### DIFF
--- a/pkg/controller/kubelet-config/kubelet_config_autosizing.go
+++ b/pkg/controller/kubelet-config/kubelet_config_autosizing.go
@@ -8,6 +8,7 @@ import (
 	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
 
@@ -26,18 +27,25 @@ SYSTEM_RESERVED_ES=1Gi
 `
 )
 
-// ensureAutoSizingMachineConfigs ensures auto-sizing MachineConfigs exist for the master and worker MachineConfigPools
+// ensureAutoSizingMachineConfigs ensures auto-sizing MachineConfigs exist only for the master and worker pools,
+// and deletes any stale auto-sizing MachineConfigs left on non-default pools by older MCO versions.
 func (ctrl *Controller) ensureAutoSizingMachineConfigs(ctx context.Context) error {
-	for _, poolName := range []string{ctrlcommon.MachineConfigPoolMaster, ctrlcommon.MachineConfigPoolWorker} {
-		pool, err := ctrl.mcpLister.Get(poolName)
-		if err != nil {
-			return fmt.Errorf("could not get MachineConfigPool %v: %w", poolName, err)
+	pools, err := ctrl.mcpLister.List(labels.Everything())
+	if err != nil {
+		return fmt.Errorf("could not list MachineConfigPools: %w", err)
+	}
+	for _, pool := range pools {
+		mcName := fmt.Sprintf(AutoSizingMachineConfigNamePrefix, pool.Name)
+		if pool.Name == ctrlcommon.MachineConfigPoolMaster || pool.Name == ctrlcommon.MachineConfigPoolWorker {
+			if err := ctrl.createAutoSizingMCIfNeeded(ctx, pool); err != nil {
+				return fmt.Errorf("could not ensure auto-sizing MachineConfig for pool %v: %w", pool.Name, err)
+			}
+			continue
 		}
-		if err := ctrl.createAutoSizingMCIfNeeded(ctx, pool); err != nil {
-			return fmt.Errorf("could not ensure auto-sizing MachineConfig for pool %v: %w", poolName, err)
+		if err := ctrl.client.MachineconfigurationV1().MachineConfigs().Delete(ctx, mcName, metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
+			return fmt.Errorf("error deleting stale auto-sizing MachineConfig %s: %w", mcName, err)
 		}
 	}
-
 	return nil
 }
 

--- a/pkg/controller/kubelet-config/kubelet_config_autosizing_test.go
+++ b/pkg/controller/kubelet-config/kubelet_config_autosizing_test.go
@@ -212,6 +212,62 @@ func TestEnsureAutoSizingMachineConfigs(t *testing.T) {
 	})
 }
 
+// TestEnsureAutoSizingMachineConfigsDeletesStale verifies that the controller deletes
+// stale auto-sizing MachineConfigs for non-default pools created by older MCO versions.
+func TestEnsureAutoSizingMachineConfigsDeletesStale(t *testing.T) {
+	t.Run("deletes stale auto-sizing MC for custom pool", func(t *testing.T) {
+		f := newFixture(t)
+		f.skipActionsValidation = true
+
+		workerPool := helpers.NewMachineConfigPool("worker", nil, helpers.WorkerSelector, "v0")
+		masterPool := helpers.NewMachineConfigPool("master", nil, helpers.MasterSelector, "v0")
+		customPool := helpers.NewMachineConfigPool("custom", nil, helpers.WorkerSelector, "v0")
+		f.mcpLister = append(f.mcpLister, workerPool, masterPool, customPool)
+
+		ctrl := f.newController(nil)
+		ctx := context.Background()
+
+		// Pre-create stale auto-sizing MC for custom pool
+		staleMC := helpers.NewMachineConfig("50-custom-auto-sizing-disabled", map[string]string{"node-role/custom": ""}, "dummy://", []ign3types.File{{}})
+		_, err := ctrl.client.MachineconfigurationV1().MachineConfigs().Create(ctx, staleMC, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		err = ctrl.ensureAutoSizingMachineConfigs(ctx)
+		require.NoError(t, err)
+
+		mcList, err := ctrl.client.MachineconfigurationV1().MachineConfigs().List(ctx, metav1.ListOptions{})
+		require.NoError(t, err)
+
+		mcNames := make(map[string]bool)
+		for _, mc := range mcList.Items {
+			mcNames[mc.Name] = true
+		}
+		require.True(t, mcNames["50-worker-auto-sizing-disabled"], "should keep worker MC")
+		require.True(t, mcNames["50-master-auto-sizing-disabled"], "should keep master MC")
+		require.False(t, mcNames["50-custom-auto-sizing-disabled"], "should delete stale custom MC")
+	})
+
+	t.Run("no error when custom pool has no stale MC", func(t *testing.T) {
+		f := newFixture(t)
+		f.skipActionsValidation = true
+
+		workerPool := helpers.NewMachineConfigPool("worker", nil, helpers.WorkerSelector, "v0")
+		masterPool := helpers.NewMachineConfigPool("master", nil, helpers.MasterSelector, "v0")
+		customPool := helpers.NewMachineConfigPool("custom", nil, helpers.WorkerSelector, "v0")
+		f.mcpLister = append(f.mcpLister, workerPool, masterPool, customPool)
+
+		ctrl := f.newController(nil)
+		ctx := context.Background()
+
+		err := ctrl.ensureAutoSizingMachineConfigs(ctx)
+		require.NoError(t, err)
+
+		mcList, err := ctrl.client.MachineconfigurationV1().MachineConfigs().List(ctx, metav1.ListOptions{})
+		require.NoError(t, err)
+		require.Len(t, mcList.Items, 2, "should have only master and worker MCs")
+	})
+}
+
 // TestRunAutoSizingBootstrap validates the bootstrap function that generates auto-sizing MachineConfigs
 // for cluster initialization. This function is used during cluster bootstrap to ensure all pools
 // have auto-sizing configurations from the start.

--- a/pkg/controller/kubelet-config/kubelet_config_controller.go
+++ b/pkg/controller/kubelet-config/kubelet_config_controller.go
@@ -200,7 +200,8 @@ func (ctrl *Controller) Run(workers int, stopCh <-chan struct{}) {
 	klog.Info("Starting MachineConfigController-KubeletConfigController")
 	defer klog.Info("Shutting down MachineConfigController-KubeletConfigController")
 
-	// Ensure auto-sizing MachineConfigs exist only for master and worker pools
+	// Ensure auto-sizing MachineConfigs exist only for master and worker pools,
+	// and delete any stale auto-sizing MachineConfigs for non-default pools.
 	if err := ctrl.ensureAutoSizingMachineConfigs(context.TODO()); err != nil {
 		klog.Errorf("Error ensuring auto-sizing MachineConfigs: %v", err)
 		// Don't return - we want the controller to continue even if this fails


### PR DESCRIPTION

Fixes: [OCPBUGS-99650](https://redhat.atlassian.net/browse/OCPBUGS-99650)

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

Fixed stale 50-{pool}-auto-sizing-disabled MachineConfigs persisting on non-default pools after upgrade from 4.20.24 or earlier. Restarting machine-config-controller creating 50-{pool}-auto-sizing-disabled MachineConfigs  for custom pools.

[OCPBUGS-83862 ](https://redhat.atlassian.net/browse/OCPBUGS-83862)(shipped in 4.20.25) stopped creating auto-sizing MachineConfigs for non-default pools, but never cleaned up ones already created by older MCO versions. These stale MachineConfigs mask autoscaling configuration in KubeletConfigs for custom pool nodes.

Modified ensureAutoSizingMachineConfigs to iterate all MachineConfigPools on controller startup:
  - Master/worker pools: create auto-sizing MC if missing (existing behavior)
  - Non-default pools: delete the auto-sizing MC if it exists


**- How to verify it**

  1. Launch a cluster on 4.20.24
  2. oc apply -f mcp.yaml to add a custom MachineConfigPool
  3. oc -n openshift-machine-config-operator delete pods -l k8s-app=machine-config-controller
  4. Verify 50-custom-auto-sizing-disabled gets created
  5. Upgrade to a version containing this fix
  6. oc get machineconfigs | grep auto-sizing — only 50-master-auto-sizing-disabled and 50-worker-auto-sizing-disabled should remain



**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Delete stale auto-sizing-disabled MachineConfigs for non-default pools on controller startup to fix custom pool nodes affected after upgrade  clusters.

