### PR TITLE
NO-ISSUE: extended tests, restore initial maxUnavailable when modified

### DIFF
--- a/test/extended-priv/mco_drain.go
+++ b/test/extended-priv/mco_drain.go
@@ -281,8 +281,8 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/longdurati
 
 		exutil.By("Set maxUnavailable value")
 		maxUnavailable := 2
+		defer mcp.SetSpec(mcp.GetSpecOrFail())
 		mcp.SetMaxUnavailable(maxUnavailable)
-		defer mcp.RemoveMaxUnavailable()
 
 		exutil.By("Create a MC to deploy a config file")
 		filePath := "/etc/TC-49672-mco-test-file-order"

--- a/test/extended-priv/mco_machineconfigpool.go
+++ b/test/extended-priv/mco_machineconfigpool.go
@@ -339,8 +339,8 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/longdurati
 		}
 
 		exutil.By("Set the maxUnavailable value to 2")
+		defer mcp.SetSpec(mcp.GetSpecOrFail())
 		mcp.SetMaxUnavailable(2)
-		defer mcp.RemoveMaxUnavailable()
 		logger.Infof("OK!\n")
 
 		exutil.By("Manually cordon one of the nodes")


### PR DESCRIPTION
**- What I did**

One of the possibilities being discussed to speed the extended tests execution is to parallelise the tests using custom worker pools.

The number of possible parallel tests should be `num_workers - 1` in the cluster. 

The problem is that the serial test cases should run in a N worker clusters, the more parallel test cases the more workers the serial tests will have to handle. The solution for that is to configure maxUnavailble = num_workers-1.

The problem is that there are 3 test cases that manipulate the maxUnavailable value, and they don't restore the original value.

In order to make the parallel option viable we modify those tests so that they restore the initial maxUnavailable value.


**- How to verify it**

All tests should pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test cleanup to restore MachineConfigPool settings to their original state after execution.
  * Increased reliability of scenarios covering node update ordering and manually cordoned nodes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->