### PR TITLE
NO-ISSUE: Use context instead of discrete signal

### DIFF
--- a/cmd/machine-config-controller/start.go
+++ b/cmd/machine-config-controller/start.go
@@ -87,7 +87,7 @@ func runStartCmd(_ *cobra.Command, _ []string) {
 		ctrlctx := ctrlcommon.CreateControllerContext(ctx, cb)
 
 		// Early start the config informer because feature gate depends on it
-		ctrlctx.ConfigInformerFactory.Start(ctrlctx.Stop)
+		ctrlctx.ConfigInformerFactory.Start(ctx.Done())
 		if fgErr := ctrlctx.FeatureGatesHandler.Connect(ctx); fgErr != nil {
 			klog.Error(fmt.Errorf("failed to connect to feature gates %w", fgErr))
 			runCancel()
@@ -131,13 +131,13 @@ func runStartCmd(_ *cobra.Command, _ []string) {
 				inspectorFactory,
 			)
 
-			ctrlctx.InformerFactory.Start(ctrlctx.Stop)
-			ctrlctx.ConfigInformerFactory.Start(ctrlctx.Stop)
-			ctrlctx.OpenShiftConfigKubeNamespacedInformerFactory.Start(ctrlctx.Stop)
-			ctrlctx.KubeNamespacedInformerFactory.Start(ctrlctx.Stop)
-			ctrlctx.OperatorInformerFactory.Start(ctrlctx.Stop)
+			ctrlctx.InformerFactory.Start(ctx.Done())
+			ctrlctx.ConfigInformerFactory.Start(ctx.Done())
+			ctrlctx.OpenShiftConfigKubeNamespacedInformerFactory.Start(ctx.Done())
+			ctrlctx.KubeNamespacedInformerFactory.Start(ctx.Done())
+			ctrlctx.OperatorInformerFactory.Start(ctx.Done())
 
-			go osImageStreamCtrl.Run(1, ctrlctx.Stop)
+			go osImageStreamCtrl.Run(ctx, 1)
 
 			if err := osImageStreamCtrl.EnsureOSImageStream(ctx); err != nil {
 				klog.Fatalf("Failed to ensure OSImageStream: %v", err)
@@ -148,7 +148,7 @@ func runStartCmd(_ *cobra.Command, _ []string) {
 			}
 		}
 
-		go ctrlcommon.StartMetricsListener(startOpts.promMetricsListenAddress, ctrlctx.Stop, ctrlcommon.RegisterMCCMetrics, startOpts.tlsMinVersion, startOpts.tlsCipherSuites)
+		go ctrlcommon.StartMetricsListener(startOpts.promMetricsListenAddress, ctx.Done(), ctrlcommon.RegisterMCCMetrics, startOpts.tlsMinVersion, startOpts.tlsCipherSuites)
 
 		controllers := createControllers(ctrlctx, inspectionCache, inspectorFactory)
 		draincontroller := drain.New(
@@ -183,17 +183,17 @@ func runStartCmd(_ *cobra.Command, _ []string) {
 			ctrlctx.ClientBuilder.KubeClientOrDie("pinned-image-set-controller"),
 			ctrlctx.ClientBuilder.MachineConfigClientOrDie("pinned-image-set-controller"),
 		)
-		go pinnedImageSet.Run(2, ctrlctx.Stop)
+		go pinnedImageSet.Run(ctx, 2)
 
 		// Start the shared factory informers that you need to use in your controller
-		ctrlctx.InformerFactory.Start(ctrlctx.Stop)
-		ctrlctx.KubeInformerFactory.Start(ctrlctx.Stop)
-		ctrlctx.OpenShiftConfigKubeNamespacedInformerFactory.Start(ctrlctx.Stop)
-		ctrlctx.OperatorInformerFactory.Start(ctrlctx.Stop)
-		ctrlctx.ConfigInformerFactory.Start(ctrlctx.Stop)
-		ctrlctx.KubeNamespacedInformerFactory.Start(ctrlctx.Stop)
-		ctrlctx.KubeMAOSharedInformer.Start(ctrlctx.Stop)
-		ctrlctx.OCLInformerFactory.Start(ctrlctx.Stop)
+		ctrlctx.InformerFactory.Start(ctx.Done())
+		ctrlctx.KubeInformerFactory.Start(ctx.Done())
+		ctrlctx.OpenShiftConfigKubeNamespacedInformerFactory.Start(ctx.Done())
+		ctrlctx.OperatorInformerFactory.Start(ctx.Done())
+		ctrlctx.ConfigInformerFactory.Start(ctx.Done())
+		ctrlctx.KubeNamespacedInformerFactory.Start(ctx.Done())
+		ctrlctx.KubeMAOSharedInformer.Start(ctx.Done())
+		ctrlctx.OCLInformerFactory.Start(ctx.Done())
 
 		close(ctrlctx.InformersStarted)
 
@@ -210,11 +210,11 @@ func runStartCmd(_ *cobra.Command, _ []string) {
 				ctrlctx.ClientBuilder.KubeClientOrDie("internalreleaseimage-controller"),
 				ctrlctx.ClientBuilder.MachineConfigClientOrDie("internalreleaseimage-controller"))
 
-			go iriController.Run(2, ctrlctx.Stop)
+			go iriController.Run(ctx, 2)
 			// start the informers again to enable feature gated types.
 			// see comments in SharedInformerFactory interface.
-			ctrlctx.InformerFactory.Start(ctrlctx.Stop)
-			ctrlctx.KubeInformerFactory.Start(ctrlctx.Stop)
+			ctrlctx.InformerFactory.Start(ctx.Done())
+			ctrlctx.KubeInformerFactory.Start(ctx.Done())
 		}
 
 		if ctrlcommon.IsBootImageControllerRequired(ctrlctx) {
@@ -230,19 +230,19 @@ func runStartCmd(_ *cobra.Command, _ []string) {
 				ctrlctx.ConfigInformerFactory.Config().V1().ClusterVersions(),
 				ctrlctx.FeatureGatesHandler,
 			)
-			go bootImageController.Run(ctrlctx.Stop)
+			go bootImageController.Run(ctx)
 			// start the informers again to enable feature gated types.
 			// see comments in SharedInformerFactory interface.
-			ctrlctx.KubeNamespacedInformerFactory.Start(ctrlctx.Stop)
-			ctrlctx.MachineInformerFactory.Start(ctrlctx.Stop)
-			ctrlctx.ConfigInformerFactory.Start(ctrlctx.Stop)
-			ctrlctx.OperatorInformerFactory.Start(ctrlctx.Stop)
+			ctrlctx.KubeNamespacedInformerFactory.Start(ctx.Done())
+			ctrlctx.MachineInformerFactory.Start(ctx.Done())
+			ctrlctx.ConfigInformerFactory.Start(ctx.Done())
+			ctrlctx.OperatorInformerFactory.Start(ctx.Done())
 		}
 
 		for _, c := range controllers {
-			go c.Run(2, ctrlctx.Stop)
+			go c.Run(ctx, 2)
 		}
-		go draincontroller.Run(5, ctrlctx.Stop)
+		go draincontroller.Run(ctx, 5)
 		go certrotationcontroller.Run(ctx, 1)
 
 		if inspectionCache != nil {

--- a/cmd/machine-config-operator/start.go
+++ b/cmd/machine-config-operator/start.go
@@ -62,7 +62,7 @@ func runStartCmd(_ *cobra.Command, _ []string) {
 		ctrlctx := ctrlcommon.CreateControllerContext(ctx, cb)
 
 		// Early start the config informer because feature gate depends on it
-		ctrlctx.ConfigInformerFactory.Start(ctrlctx.Stop)
+		ctrlctx.ConfigInformerFactory.Start(ctx.Done())
 		if fgErr := ctrlctx.FeatureGatesHandler.Connect(ctx); fgErr != nil {
 			klog.Fatal(fmt.Errorf("failed to connect to feature gates %w", fgErr))
 		}
@@ -121,21 +121,21 @@ func runStartCmd(_ *cobra.Command, _ []string) {
 			ctrlctx,
 		)
 
-		ctrlctx.InformerFactory.Start(ctrlctx.Stop)
-		ctrlctx.ConfigInformerFactory.Start(ctrlctx.Stop)
-		ctrlctx.NamespacedInformerFactory.Start(ctrlctx.Stop)
-		ctrlctx.KubeInformerFactory.Start(ctrlctx.Stop)
-		ctrlctx.KubeNamespacedInformerFactory.Start(ctrlctx.Stop)
-		ctrlctx.APIExtInformerFactory.Start(ctrlctx.Stop)
-		ctrlctx.OpenShiftKubeAPIServerKubeNamespacedInformerFactory.Start(ctrlctx.Stop)
-		ctrlctx.OpenShiftConfigKubeNamespacedInformerFactory.Start(ctrlctx.Stop)
-		ctrlctx.OpenShiftConfigManagedKubeNamespacedInformerFactory.Start(ctrlctx.Stop)
-		ctrlctx.OperatorInformerFactory.Start(ctrlctx.Stop)
-		ctrlctx.KubeMAOSharedInformer.Start(ctrlctx.Stop)
+		ctrlctx.InformerFactory.Start(ctx.Done())
+		ctrlctx.ConfigInformerFactory.Start(ctx.Done())
+		ctrlctx.NamespacedInformerFactory.Start(ctx.Done())
+		ctrlctx.KubeInformerFactory.Start(ctx.Done())
+		ctrlctx.KubeNamespacedInformerFactory.Start(ctx.Done())
+		ctrlctx.APIExtInformerFactory.Start(ctx.Done())
+		ctrlctx.OpenShiftKubeAPIServerKubeNamespacedInformerFactory.Start(ctx.Done())
+		ctrlctx.OpenShiftConfigKubeNamespacedInformerFactory.Start(ctx.Done())
+		ctrlctx.OpenShiftConfigManagedKubeNamespacedInformerFactory.Start(ctx.Done())
+		ctrlctx.OperatorInformerFactory.Start(ctx.Done())
+		ctrlctx.KubeMAOSharedInformer.Start(ctx.Done())
 
 		close(ctrlctx.InformersStarted)
 
-		go controller.Run(2, ctrlctx.Stop)
+		go controller.Run(ctx, 2)
 
 		// wait here in this function until the context gets cancelled (which tells us whe were being shut down)
 		<-ctx.Done()

--- a/pkg/controller/bootimage/boot_image_controller.go
+++ b/pkg/controller/bootimage/boot_image_controller.go
@@ -219,11 +219,11 @@ func New(
 }
 
 // Run executes the machine-set-boot-image controller.
-func (ctrl *Controller) Run(stopCh <-chan struct{}) {
+func (ctrl *Controller) Run(ctx context.Context) {
 	defer utilruntime.HandleCrash()
 	defer ctrl.queue.ShutDown()
 
-	if !cache.WaitForCacheSync(stopCh, ctrl.mcoCmListerSynced, ctrl.mapiMachineSetListerSynced, ctrl.infraListerSynced, ctrl.mcopListerSynced, ctrl.clusterVersionListerSynced) {
+	if !cache.WaitForCacheSync(ctx.Done(), ctrl.mcoCmListerSynced, ctrl.mapiMachineSetListerSynced, ctrl.infraListerSynced, ctrl.mcopListerSynced, ctrl.clusterVersionListerSynced) {
 		return
 	}
 
@@ -232,9 +232,9 @@ func (ctrl *Controller) Run(stopCh <-chan struct{}) {
 
 	// This controller needs to run in single thread mode, as the work unit per sync are
 	// the same and shouldn't overlap each other.
-	go wait.Until(ctrl.worker, time.Second, stopCh)
+	go wait.Until(ctrl.worker, time.Second, ctx.Done())
 
-	<-stopCh
+	<-ctx.Done()
 }
 
 // enqueueEvent adds a event to the work queue.

--- a/pkg/controller/common/controller.go
+++ b/pkg/controller/common/controller.go
@@ -1,6 +1,8 @@
 package common
 
+import "context"
+
 // Controller is the common interface all controllers implement
 type Controller interface {
-	Run(workers int, stopCh <-chan struct{})
+	Run(ctx context.Context, workers int)
 }

--- a/pkg/controller/container-runtime-config/container_runtime_config_controller.go
+++ b/pkg/controller/container-runtime-config/container_runtime_config_controller.go
@@ -234,7 +234,7 @@ func New(
 }
 
 // Run executes the container runtime config controller.
-func (ctrl *Controller) Run(workers int, stopCh <-chan struct{}) {
+func (ctrl *Controller) Run(ctx context.Context, workers int) {
 	defer utilruntime.HandleCrash()
 	defer ctrl.queue.ShutDown()
 	defer ctrl.imgQueue.ShutDown()
@@ -253,7 +253,7 @@ func (ctrl *Controller) Run(workers int, stopCh <-chan struct{}) {
 	}
 
 	if ctrl.addedPolicyObservers || ctrl.addedCRIOCPObservers {
-		ctrl.configInformerFactory.Start(stopCh)
+		ctrl.configInformerFactory.Start(ctx.Done())
 	}
 
 	if ctrl.addedPolicyObservers {
@@ -264,7 +264,7 @@ func (ctrl *Controller) Run(workers int, stopCh <-chan struct{}) {
 		listerCaches = append(listerCaches, ctrl.criocpListerSynced)
 	}
 
-	if !cache.WaitForCacheSync(stopCh, listerCaches...) {
+	if !cache.WaitForCacheSync(ctx.Done(), listerCaches...) {
 		return
 	}
 
@@ -272,16 +272,16 @@ func (ctrl *Controller) Run(workers int, stopCh <-chan struct{}) {
 	defer klog.Info("Shutting down MachineConfigController-ContainerRuntimeConfigController")
 
 	for i := 0; i < workers; i++ {
-		go wait.Until(ctrl.worker, time.Second, stopCh)
+		go wait.Until(ctrl.worker, time.Second, ctx.Done())
 	}
 
 	// Just need one worker for the image config
-	go wait.Until(ctrl.imgWorker, time.Second, stopCh)
+	go wait.Until(ctrl.imgWorker, time.Second, ctx.Done())
 
 	// Just need one worker for the CRIOCredentialProviderConfig
-	go wait.Until(ctrl.criocpWorker, time.Second, stopCh)
+	go wait.Until(ctrl.criocpWorker, time.Second, ctx.Done())
 
-	<-stopCh
+	<-ctx.Done()
 }
 
 func ctrConfigTriggerObjectChange(old, newCRC *mcfgv1.ContainerRuntimeConfig) bool {

--- a/pkg/controller/drain/drain_controller.go
+++ b/pkg/controller/drain/drain_controller.go
@@ -164,11 +164,11 @@ func (w writer) Write(p []byte) (n int, err error) {
 }
 
 // Run executes the drain controller.
-func (ctrl *Controller) Run(workers int, stopCh <-chan struct{}) {
+func (ctrl *Controller) Run(ctx context.Context, workers int) {
 	defer utilruntime.HandleCrash()
 	defer ctrl.queue.ShutDown()
 
-	if !cache.WaitForCacheSync(stopCh, ctrl.nodeListerSynced, ctrl.mcpListerSynced) {
+	if !cache.WaitForCacheSync(ctx.Done(), ctrl.nodeListerSynced, ctrl.mcpListerSynced) {
 		return
 	}
 
@@ -179,11 +179,11 @@ func (ctrl *Controller) Run(workers int, stopCh <-chan struct{}) {
 	defer klog.Info("Shutting down MachineConfigController-DrainController")
 
 	for i := 0; i < workers; i++ {
-		go wait.Until(ctrl.worker, ctrl.cfg.WaitUntil, stopCh)
+		go wait.Until(ctrl.worker, ctrl.cfg.WaitUntil, ctx.Done())
 
 	}
 
-	<-stopCh
+	<-ctx.Done()
 }
 
 // logNode emits a log message at informational level, prefixed with the node name in a consistent fashion.

--- a/pkg/controller/internalreleaseimage/internalreleaseimage_controller.go
+++ b/pkg/controller/internalreleaseimage/internalreleaseimage_controller.go
@@ -172,11 +172,11 @@ func New(
 }
 
 // Run executes the InternalReleaseImage controller.
-func (ctrl *Controller) Run(workers int, stopCh <-chan struct{}) {
+func (ctrl *Controller) Run(ctx context.Context, workers int) {
 	defer utilruntime.HandleCrash()
 	defer ctrl.queue.ShutDown()
 
-	if !cache.WaitForCacheSync(stopCh, ctrl.iriListerSynced, ctrl.ccListerSynced, ctrl.mcListerSynced, ctrl.clusterVersionListerSynced, ctrl.secretListerSynced, ctrl.mcnListerSynced, ctrl.nodeListerSynced, ctrl.infraListerSynced) {
+	if !cache.WaitForCacheSync(ctx.Done(), ctrl.iriListerSynced, ctrl.ccListerSynced, ctrl.mcListerSynced, ctrl.clusterVersionListerSynced, ctrl.secretListerSynced, ctrl.mcnListerSynced, ctrl.nodeListerSynced, ctrl.infraListerSynced) {
 		return
 	}
 
@@ -184,10 +184,10 @@ func (ctrl *Controller) Run(workers int, stopCh <-chan struct{}) {
 	defer klog.Info("Shutting down MachineConfigController-InternalReleaseImageController")
 
 	for i := 0; i < workers; i++ {
-		go wait.Until(ctrl.worker, time.Second, stopCh)
+		go wait.Until(ctrl.worker, time.Second, ctx.Done())
 	}
 
-	<-stopCh
+	<-ctx.Done()
 }
 
 // worker runs a worker thread that just dequeues items, processes them, and marks them done.

--- a/pkg/controller/kubelet-config/kubelet_config_controller.go
+++ b/pkg/controller/kubelet-config/kubelet_config_controller.go
@@ -187,13 +187,13 @@ func New(
 }
 
 // Run executes the kubelet config controller.
-func (ctrl *Controller) Run(workers int, stopCh <-chan struct{}) {
+func (ctrl *Controller) Run(ctx context.Context, workers int) {
 	defer utilruntime.HandleCrash()
 	defer ctrl.queue.ShutDown()
 	defer ctrl.featureQueue.ShutDown()
 	defer ctrl.nodeConfigQueue.ShutDown()
 
-	if !cache.WaitForCacheSync(stopCh, ctrl.mcpListerSynced, ctrl.mckListerSynced, ctrl.ccListerSynced, ctrl.featListerSynced, ctrl.apiserverListerSynced) {
+	if !cache.WaitForCacheSync(ctx.Done(), ctrl.mcpListerSynced, ctrl.mckListerSynced, ctrl.ccListerSynced, ctrl.featListerSynced, ctrl.apiserverListerSynced) {
 		return
 	}
 
@@ -201,18 +201,18 @@ func (ctrl *Controller) Run(workers int, stopCh <-chan struct{}) {
 	defer klog.Info("Shutting down MachineConfigController-KubeletConfigController")
 
 	for i := 0; i < workers; i++ {
-		go wait.Until(ctrl.worker, time.Second, stopCh)
+		go wait.Until(ctrl.worker, time.Second, ctx.Done())
 	}
 
 	for i := 0; i < workers; i++ {
-		go wait.Until(ctrl.featureWorker, time.Second, stopCh)
+		go wait.Until(ctrl.featureWorker, time.Second, ctx.Done())
 	}
 
 	for i := 0; i < workers; i++ {
-		go wait.Until(ctrl.nodeConfigWorker, time.Second, stopCh)
+		go wait.Until(ctrl.nodeConfigWorker, time.Second, ctx.Done())
 	}
 
-	<-stopCh
+	<-ctx.Done()
 }
 func (ctrl *Controller) filterAPIServer(apiServer *configv1.APIServer) {
 	if apiServer.Name != "cluster" {

--- a/pkg/controller/node/node_controller.go
+++ b/pkg/controller/node/node_controller.go
@@ -318,7 +318,7 @@ func newController(
 }
 
 // Run executes the render controller.
-func (ctrl *Controller) Run(workers int, stopCh <-chan struct{}) {
+func (ctrl *Controller) Run(ctx context.Context, workers int) {
 	defer utilruntime.HandleCrash()
 	defer ctrl.queue.ShutDown()
 
@@ -331,7 +331,7 @@ func (ctrl *Controller) Run(workers int, stopCh <-chan struct{}) {
 	if ctrl.osStreamsFgEnabled {
 		syncers = append(syncers, ctrl.osImageStreamListerSynced)
 	}
-	if !cache.WaitForCacheSync(stopCh, syncers...) {
+	if !cache.WaitForCacheSync(ctx.Done(), syncers...) {
 		return
 	}
 
@@ -347,10 +347,10 @@ func (ctrl *Controller) Run(workers int, stopCh <-chan struct{}) {
 	}
 
 	for i := 0; i < workers; i++ {
-		go wait.Until(ctrl.worker, time.Second, stopCh)
+		go wait.Until(ctrl.worker, time.Second, ctx.Done())
 	}
 
-	<-stopCh
+	<-ctx.Done()
 }
 
 func (ctrl *Controller) getCurrentMasters() ([]*corev1.Node, error) {

--- a/pkg/controller/osimagestream/osimagestream_controller.go
+++ b/pkg/controller/osimagestream/osimagestream_controller.go
@@ -143,11 +143,11 @@ func New(
 	return ctrl
 }
 
-func (ctrl *Controller) Run(workers int, stopCh <-chan struct{}) {
+func (ctrl *Controller) Run(ctx context.Context, workers int) {
 	defer utilruntime.HandleCrash()
 	defer ctrl.queue.ShutDown()
 
-	if !cache.WaitForCacheSync(stopCh,
+	if !cache.WaitForCacheSync(ctx.Done(),
 		ctrl.osImageStreamListerSynced,
 		ctrl.ccListerSynced,
 		ctrl.clusterVersionListerSynced,
@@ -169,12 +169,12 @@ func (ctrl *Controller) Run(workers int, stopCh <-chan struct{}) {
 	klog.Info("Starting MachineConfigController-OSImageStreamController")
 	defer klog.Info("Shutting down MachineConfigController-OSImageStreamController")
 
-	go wait.Until(ctrl.worker, time.Second, stopCh)
+	go wait.Until(ctrl.worker, time.Second, ctx.Done())
 
 	// Run once at start at least to make sure the OSImageStream is created when creating the cluster
 	ctrl.enqueue()
 
-	<-stopCh
+	<-ctx.Done()
 }
 
 // EnsureOSImageStream blocks until the controller's first successful sync

--- a/pkg/controller/pinnedimageset/pinned_image_set.go
+++ b/pkg/controller/pinnedimageset/pinned_image_set.go
@@ -104,11 +104,11 @@ func New(
 }
 
 // Run executes the pinned image set controller.
-func (ctrl *Controller) Run(workers int, stopCh <-chan struct{}) {
+func (ctrl *Controller) Run(ctx context.Context, workers int) {
 	defer utilruntime.HandleCrash()
 	defer ctrl.queue.ShutDown()
 
-	if !cache.WaitForCacheSync(stopCh, ctrl.mcpListerSynced, ctrl.imageSetSynced) {
+	if !cache.WaitForCacheSync(ctx.Done(), ctrl.mcpListerSynced, ctrl.imageSetSynced) {
 		return
 	}
 
@@ -116,10 +116,10 @@ func (ctrl *Controller) Run(workers int, stopCh <-chan struct{}) {
 	defer klog.Info("Shutting down MachineConfigController-PinnedImageSetController")
 
 	for i := 0; i < workers; i++ {
-		go wait.Until(ctrl.worker, time.Second, stopCh)
+		go wait.Until(ctrl.worker, time.Second, ctx.Done())
 	}
 
-	<-stopCh
+	<-ctx.Done()
 }
 
 func (ctrl *Controller) addMachineConfigPool(obj interface{}) {

--- a/pkg/controller/render/render_controller.go
+++ b/pkg/controller/render/render_controller.go
@@ -191,16 +191,9 @@ func New(
 }
 
 // Run executes the render controller.
-func (ctrl *Controller) Run(workers int, stopCh <-chan struct{}) {
+func (ctrl *Controller) Run(ctx context.Context, workers int) {
 	defer utilruntime.HandleCrash()
 	defer ctrl.queue.ShutDown()
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	go func() {
-		<-stopCh
-		cancel()
-	}()
 
 	listerCaches := []cache.InformerSynced{ctrl.mcpListerSynced, ctrl.mcListerSynced, ctrl.ccListerSynced}
 
@@ -215,7 +208,7 @@ func (ctrl *Controller) Run(workers int, stopCh <-chan struct{}) {
 	if ctrl.osImageStreamListerSynced != nil {
 		listerCaches = append(listerCaches, ctrl.osImageStreamListerSynced)
 	}
-	if !cache.WaitForCacheSync(stopCh, listerCaches...) {
+	if !cache.WaitForCacheSync(ctx.Done(), listerCaches...) {
 		return
 	}
 
@@ -223,10 +216,10 @@ func (ctrl *Controller) Run(workers int, stopCh <-chan struct{}) {
 	defer klog.Info("Shutting down MachineConfigController-RenderController")
 
 	for i := 0; i < workers; i++ {
-		go wait.Until(func() { ctrl.worker(ctx) }, time.Second, stopCh)
+		go wait.Until(func() { ctrl.worker(ctx) }, time.Second, ctx.Done())
 	}
 
-	<-stopCh
+	<-ctx.Done()
 }
 
 func (ctrl *Controller) addMachineConfigPool(obj interface{}) {

--- a/pkg/controller/template/template_controller.go
+++ b/pkg/controller/template/template_controller.go
@@ -313,11 +313,11 @@ func (ctrl *Controller) deleteFeature(obj interface{}) {
 }
 
 // Run executes the template controller
-func (ctrl *Controller) Run(workers int, stopCh <-chan struct{}) {
+func (ctrl *Controller) Run(ctx context.Context, workers int) {
 	defer utilruntime.HandleCrash()
 	defer ctrl.queue.ShutDown()
 
-	if !cache.WaitForCacheSync(stopCh, ctrl.ccListerSynced, ctrl.secretsInformerSynced, ctrl.iriSecretsInformerSynced, ctrl.iriInformerSynced) {
+	if !cache.WaitForCacheSync(ctx.Done(), ctrl.ccListerSynced, ctrl.secretsInformerSynced, ctrl.iriSecretsInformerSynced, ctrl.iriInformerSynced) {
 		return
 	}
 
@@ -325,10 +325,10 @@ func (ctrl *Controller) Run(workers int, stopCh <-chan struct{}) {
 	defer klog.Info("Shutting down MachineConfigController-TemplateController")
 
 	for i := 0; i < workers; i++ {
-		go wait.Until(ctrl.worker, time.Second, stopCh)
+		go wait.Until(ctrl.worker, time.Second, ctx.Done())
 	}
 
-	<-stopCh
+	<-ctx.Done()
 }
 
 func (ctrl *Controller) addControllerConfig(obj interface{}) {

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -403,12 +403,12 @@ func New(
 }
 
 // Run runs the machine config operator.
-func (optr *Operator) Run(workers int, stopCh <-chan struct{}) {
+func (optr *Operator) Run(ctx context.Context, workers int) {
 	defer utilruntime.HandleCrash()
 	defer optr.queue.ShutDown()
 
 	apiClient := optr.apiExtClient.ApiextensionsV1()
-	_, err := apiClient.CustomResourceDefinitions().Get(context.TODO(), "controllerconfigs.machineconfiguration.openshift.io", metav1.GetOptions{})
+	_, err := apiClient.CustomResourceDefinitions().Get(ctx, "controllerconfigs.machineconfiguration.openshift.io", metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			klog.Infof("Couldn't find controllerconfig CRD, in cluster bringup mode")
@@ -457,7 +457,7 @@ func (optr *Operator) Run(workers int, stopCh <-chan struct{}) {
 	if optr.iriListerSynced != nil {
 		cacheSynced = append(cacheSynced, optr.iriListerSynced)
 	}
-	if !cache.WaitForCacheSync(stopCh,
+	if !cache.WaitForCacheSync(ctx.Done(),
 		cacheSynced...) {
 		klog.Error("failed to sync caches")
 		return
@@ -475,12 +475,12 @@ func (optr *Operator) Run(workers int, stopCh <-chan struct{}) {
 		infra.Status.PlatformStatus != nil &&
 		infra.Status.PlatformStatus.Type == configv1.BareMetalPlatformType &&
 		optr.provisioningInformerFactory != nil {
-		optr.provisioningInformerFactory.Start(stopCh)
+		optr.provisioningInformerFactory.Start(ctx.Done())
 	}
 
 	// these can only be synced after CRDs are installed
 	if !optr.inClusterBringup {
-		if !cache.WaitForCacheSync(stopCh,
+		if !cache.WaitForCacheSync(ctx.Done(),
 			optr.ccListerSynced,
 		) {
 			klog.Error("failed to sync caches")
@@ -491,13 +491,13 @@ func (optr *Operator) Run(workers int, stopCh <-chan struct{}) {
 	klog.Info("Starting MachineConfigOperator")
 	defer klog.Info("Shutting down MachineConfigOperator")
 
-	optr.stopCh = stopCh
+	optr.stopCh = ctx.Done()
 
 	for i := 0; i < workers; i++ {
-		go wait.Until(optr.worker, time.Second, stopCh)
+		go wait.Until(optr.worker, time.Second, ctx.Done())
 	}
 
-	<-stopCh
+	<-ctx.Done()
 }
 
 func (optr *Operator) enqueue(obj interface{}) {

--- a/test/e2e-2of2/osimagestream_test.go
+++ b/test/e2e-2of2/osimagestream_test.go
@@ -35,7 +35,7 @@ func TestImageStreamProviderCVO(t *testing.T) {
 	defer cancel()
 	cb, err := clients.NewBuilder("")
 	ctrlctx := ctrlcommon.CreateControllerContext(ctx, cb)
-	ctrlctx.ConfigInformerFactory.Start(ctrlctx.Stop)
+	ctrlctx.ConfigInformerFactory.Start(ctx.Done())
 
 	// Wait for the informer cache to sync before querying the lister
 	ctrlctx.ConfigInformerFactory.WaitForCacheSync(ctx.Done())
@@ -74,7 +74,7 @@ func TestConfigMapUrlProvider(t *testing.T) {
 	cmInformer := ctrlctx.KubeNamespacedInformerFactory.Core().V1().ConfigMaps()
 	_ = cmInformer.Informer()
 
-	ctrlctx.KubeNamespacedInformerFactory.Start(ctrlctx.Stop)
+	ctrlctx.KubeNamespacedInformerFactory.Start(ctx.Done())
 
 	// Wait for the informer cache to sync before querying the lister
 	ctrlctx.KubeNamespacedInformerFactory.WaitForCacheSync(ctx.Done())

--- a/test/e2e-bootstrap/bootstrap_test.go
+++ b/test/e2e-bootstrap/bootstrap_test.go
@@ -536,11 +536,11 @@ func newTestFixture(t *testing.T, cfg *rest.Config, objs []runtime.Object) *fixt
 	controllers := createControllers(ctrlctx)
 
 	// Start the shared factory informers that you need to use in your controller
-	ctrlctx.InformerFactory.Start(ctrlctx.Stop)
-	ctrlctx.KubeInformerFactory.Start(ctrlctx.Stop)
-	ctrlctx.OpenShiftConfigKubeNamespacedInformerFactory.Start(ctrlctx.Stop)
-	ctrlctx.ConfigInformerFactory.Start(ctrlctx.Stop)
-	ctrlctx.OperatorInformerFactory.Start(ctrlctx.Stop)
+	ctrlctx.InformerFactory.Start(ctx.Done())
+	ctrlctx.KubeInformerFactory.Start(ctx.Done())
+	ctrlctx.OpenShiftConfigKubeNamespacedInformerFactory.Start(ctx.Done())
+	ctrlctx.ConfigInformerFactory.Start(ctx.Done())
+	ctrlctx.OperatorInformerFactory.Start(ctx.Done())
 
 	err := ctrlctx.FeatureGatesHandler.Connect(ctx)
 	require.NoError(t, err, "FeatureGates should be available before proceeding")
@@ -548,7 +548,7 @@ func newTestFixture(t *testing.T, cfg *rest.Config, objs []runtime.Object) *fixt
 	close(ctrlctx.InformersStarted)
 
 	for _, c := range controllers {
-		go c.Run(2, ctrlctx.Stop)
+		go c.Run(ctx, 2)
 	}
 
 	return &fixture{


### PR DESCRIPTION
**- What I did**

This change tries to move all but the MCD usages of discrete signal channels to teardown processes to modern contexts that can be passed around and are easy to consume.

**- How to verify it**

E2E tests are enough.  Full longduration regression can be used to validate too.

This change tries to move all but the MCD usages of discrete signal channels to teardown processes to modern contexts that can be passed around and are easy to consume.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved component startup and shutdown coordination by standardizing cancellation handling across controllers, informers, and background workers.
  * Ensured metrics listeners and feature-gated components terminate reliably when the application context is canceled.
  * Aligned controller execution with context-based lifecycle management for more predictable service shutdown.
* **Tests**
  * Updated end-to-end test fixtures and informer startup to use the shared test context cancellation, improving cleanup and termination consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->