### PR TITLE
OCPEDGE-2826: fix fencing_validator ocdebug fence dispatch race condition

### DIFF
--- a/templates/master/00-master/two-node-with-fencing/files/fencing-validator.yaml
+++ b/templates/master/00-master/two-node-with-fencing/files/fencing-validator.yaml
@@ -472,7 +472,7 @@ contents:
     
     	if [[ "$TRANSPORT" == "ocdebug" ]]; then
     		if ! host_run "$CONDUCTOR" "if command -v systemd-run >/dev/null 2>&1; then \
-            systemd-run --no-block --unit fence-$t bash -lc 'pcs stonith fence $t'; \
+            systemd-run --no-block --collect --unit fence-$t bash -lc 'pcs stonith fence $t'; \
             else nohup bash -lc 'pcs stonith fence $t' >/var/tmp/fence-$t.log 2>&1 & disown; fi"; then
     			log_err "Dispatching fence for '$t' via ocdebug failed to start"
     			return 1

--- a/templates/master/00-master/two-node-with-fencing/files/fencing-validator.yaml
+++ b/templates/master/00-master/two-node-with-fencing/files/fencing-validator.yaml
@@ -471,9 +471,9 @@ contents:
     	((to < 1)) && to=1
     
     	if [[ "$TRANSPORT" == "ocdebug" ]]; then
-    		if ! host_run "$CONDUCTOR" "command -v systemd-run >/dev/null 2>&1 && \
-            systemd-run --unit fence-$t --collect bash -lc 'pcs stonith fence $t' \
-            || nohup bash -lc 'pcs stonith fence $t' >/var/tmp/fence-$t.log 2>&1 & disown"; then
+    		if ! host_run "$CONDUCTOR" "if command -v systemd-run >/dev/null 2>&1; then \
+            systemd-run --no-block --unit fence-$t bash -lc 'pcs stonith fence $t'; \
+            else nohup bash -lc 'pcs stonith fence $t' >/var/tmp/fence-$t.log 2>&1 & disown; fi"; then
     			log_err "Dispatching fence for '$t' via ocdebug failed to start"
     			return 1
     		fi


### PR DESCRIPTION
## Summary

Fixes the `fence()` function in the fencing_validator script for the `ocdebug` transport mode. The fence command was silently failing due to a bash parsing issue, causing the disruptive fencing validation CI lane to time out on 4.22, 4.23, and 5.0.

**Root cause:** The compound command `A && B || C & disown` backgrounds the *entire* AND-OR list (not just the `nohup` fallback), causing the `oc debug` pod to exit immediately and kill the `systemd-run` process before it dispatches the fence unit.

**Fix:** Replace `&&/||` with `if/else` to scope `& disown` to only the nohup fallback, and use `--no-block` on `systemd-run`.

## Failing CI lanes

- `periodic-ci-openshift-release-main-nightly-4.22-e2e-metal-ovn-two-node-fencing-validation`
- `periodic-ci-openshift-release-main-nightly-4.23-e2e-metal-ovn-two-node-fencing-validation`
- `periodic-ci-openshift-release-main-nightly-5.0-e2e-metal-ovn-two-node-fencing-validation`

Example failure: https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.22-e2e-metal-ovn-two-node-fencing-validation/2081600945665347584

Jira: https://redhat.atlassian.net/browse/OCPEDGE-2826

## Test plan

- [x] Reproduced the bug on a live TNF cluster: unpatched script times out waiting for master-0 NotReady (fence never happens)
- [x] Verified the fix: patched script successfully fences both nodes sequentially
- [x] Full disruptive validation passes end-to-end with the fix ("Disruptive validation PASSED", exit 0)
- [ ] CI lane passes with the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved remote fencing command execution by using an explicit inline check for `systemd-run`.
  * When available, fence actions are started via `systemd-run` with non-blocking behavior and a dedicated unit name.
  * When not available, the fence action now reliably falls back to running `pcs stonith fence` in the background.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->