### PR TITLE
OCPBUGS-113999: Add CRI-O v2 annotations alongside deprecated v1 format

### DIFF
--- a/templates/arbiter/01-arbiter-container-runtime/_base/files/crio.yaml
+++ b/templates/arbiter/01-arbiter-container-runtime/_base/files/crio.yaml
@@ -38,16 +38,16 @@ contents:
     runtime_root = "/run/runc"
     allowed_annotations = [
         "io.containers.trace-syscall",
-        "io.kubernetes.cri-o.Devices",
-        "io.kubernetes.cri-o.LinkLogs",
+        "devices.crio.io",
+        "link-logs.crio.io",
     ]
 
     [crio.runtime.runtimes.crun]
     runtime_root = "/run/crun"
     allowed_annotations = [
         "io.containers.trace-syscall",
-        "io.kubernetes.cri-o.Devices",
-        "io.kubernetes.cri-o.LinkLogs",
+        "devices.crio.io",
+        "link-logs.crio.io",
     ]
     # Based on https://github.com/containers/crun/blob/27d7dd3a0/README.md?plain=1#L48
     container_min_memory = "512KiB"
@@ -55,8 +55,8 @@ contents:
     [crio.runtime.workloads.openshift-builder]
     activation_annotation = "io.openshift.builder"
     allowed_annotations = [
-      "io.kubernetes.cri-o.userns-mode",
-      "io.kubernetes.cri-o.Devices"
+      "userns-mode.crio.io",
+      "devices.crio.io"
     ]
     [crio.runtime.workloads.openshift-builder.resources]
 

--- a/templates/arbiter/01-arbiter-container-runtime/_base/files/crio.yaml
+++ b/templates/arbiter/01-arbiter-container-runtime/_base/files/crio.yaml
@@ -39,7 +39,9 @@ contents:
     allowed_annotations = [
         "io.containers.trace-syscall",
         "io.kubernetes.cri-o.Devices",
+        "devices.crio.io",
         "io.kubernetes.cri-o.LinkLogs",
+        "link-logs.crio.io",
     ]
 
     [crio.runtime.runtimes.crun]
@@ -47,7 +49,9 @@ contents:
     allowed_annotations = [
         "io.containers.trace-syscall",
         "io.kubernetes.cri-o.Devices",
+        "devices.crio.io",
         "io.kubernetes.cri-o.LinkLogs",
+        "link-logs.crio.io",
     ]
     # Based on https://github.com/containers/crun/blob/27d7dd3a0/README.md?plain=1#L48
     container_min_memory = "512KiB"
@@ -57,7 +61,9 @@ contents:
     activation_annotation = "io.openshift.builder"
     allowed_annotations = [
       "io.kubernetes.cri-o.userns-mode",
-      "io.kubernetes.cri-o.Devices"
+      "userns-mode.crio.io",
+      "io.kubernetes.cri-o.Devices",
+      "devices.crio.io"
     ]
     [crio.runtime.workloads.openshift-builder.resources]
 

--- a/templates/master/01-master-container-runtime/_base/files/crio.yaml
+++ b/templates/master/01-master-container-runtime/_base/files/crio.yaml
@@ -38,16 +38,16 @@ contents:
     runtime_root = "/run/runc"
     allowed_annotations = [
         "io.containers.trace-syscall",
-        "io.kubernetes.cri-o.Devices",
-        "io.kubernetes.cri-o.LinkLogs",
+        "devices.crio.io",
+        "link-logs.crio.io",
     ]
 
     [crio.runtime.runtimes.crun]
     runtime_root = "/run/crun"
     allowed_annotations = [
         "io.containers.trace-syscall",
-        "io.kubernetes.cri-o.Devices",
-        "io.kubernetes.cri-o.LinkLogs",
+        "devices.crio.io",
+        "link-logs.crio.io",
     ]
     # Based on https://github.com/containers/crun/blob/27d7dd3a0/README.md?plain=1#L48
     container_min_memory = "512KiB"
@@ -56,8 +56,8 @@ contents:
     [crio.runtime.workloads.openshift-builder]
     activation_annotation = "io.openshift.builder"
     allowed_annotations = [
-      "io.kubernetes.cri-o.userns-mode",
-      "io.kubernetes.cri-o.Devices"
+      "userns-mode.crio.io",
+      "devices.crio.io"
     ]
     [crio.runtime.workloads.openshift-builder.resources]
 

--- a/templates/master/01-master-container-runtime/_base/files/crio.yaml
+++ b/templates/master/01-master-container-runtime/_base/files/crio.yaml
@@ -39,7 +39,9 @@ contents:
     allowed_annotations = [
         "io.containers.trace-syscall",
         "io.kubernetes.cri-o.Devices",
+        "devices.crio.io",
         "io.kubernetes.cri-o.LinkLogs",
+        "link-logs.crio.io",
     ]
 
     [crio.runtime.runtimes.crun]
@@ -47,7 +49,9 @@ contents:
     allowed_annotations = [
         "io.containers.trace-syscall",
         "io.kubernetes.cri-o.Devices",
+        "devices.crio.io",
         "io.kubernetes.cri-o.LinkLogs",
+        "link-logs.crio.io",
     ]
     # Based on https://github.com/containers/crun/blob/27d7dd3a0/README.md?plain=1#L48
     container_min_memory = "512KiB"
@@ -57,7 +61,9 @@ contents:
     activation_annotation = "io.openshift.builder"
     allowed_annotations = [
       "io.kubernetes.cri-o.userns-mode",
-      "io.kubernetes.cri-o.Devices"
+      "userns-mode.crio.io",
+      "io.kubernetes.cri-o.Devices",
+      "devices.crio.io"
     ]
     [crio.runtime.workloads.openshift-builder.resources]
 

--- a/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
+++ b/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
@@ -38,16 +38,16 @@ contents:
     runtime_root = "/run/runc"
     allowed_annotations = [
         "io.containers.trace-syscall",
-        "io.kubernetes.cri-o.Devices",
-        "io.kubernetes.cri-o.LinkLogs",
+        "devices.crio.io",
+        "link-logs.crio.io",
     ]
 
     [crio.runtime.runtimes.crun]
     runtime_root = "/run/crun"
     allowed_annotations = [
         "io.containers.trace-syscall",
-        "io.kubernetes.cri-o.Devices",
-        "io.kubernetes.cri-o.LinkLogs",
+        "devices.crio.io",
+        "link-logs.crio.io",
     ]
     # Based on https://github.com/containers/crun/blob/27d7dd3a0/README.md?plain=1#L48
     container_min_memory = "512KiB"
@@ -56,8 +56,8 @@ contents:
     [crio.runtime.workloads.openshift-builder]
     activation_annotation = "io.openshift.builder"
     allowed_annotations = [
-      "io.kubernetes.cri-o.userns-mode",
-      "io.kubernetes.cri-o.Devices"
+      "userns-mode.crio.io",
+      "devices.crio.io"
     ]
     [crio.runtime.workloads.openshift-builder.resources]
 

--- a/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
+++ b/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
@@ -39,7 +39,9 @@ contents:
     allowed_annotations = [
         "io.containers.trace-syscall",
         "io.kubernetes.cri-o.Devices",
+        "devices.crio.io",
         "io.kubernetes.cri-o.LinkLogs",
+        "link-logs.crio.io",
     ]
 
     [crio.runtime.runtimes.crun]
@@ -47,7 +49,9 @@ contents:
     allowed_annotations = [
         "io.containers.trace-syscall",
         "io.kubernetes.cri-o.Devices",
+        "devices.crio.io",
         "io.kubernetes.cri-o.LinkLogs",
+        "link-logs.crio.io",
     ]
     # Based on https://github.com/containers/crun/blob/27d7dd3a0/README.md?plain=1#L48
     container_min_memory = "512KiB"
@@ -57,7 +61,9 @@ contents:
     activation_annotation = "io.openshift.builder"
     allowed_annotations = [
       "io.kubernetes.cri-o.userns-mode",
-      "io.kubernetes.cri-o.Devices"
+      "userns-mode.crio.io",
+      "io.kubernetes.cri-o.Devices",
+      "devices.crio.io"
     ]
     [crio.runtime.workloads.openshift-builder.resources]
 


### PR DESCRIPTION
**- What I did**
Added CRI-O v2 annotations (`*.crio.io`) alongside the deprecated v1 format (`io.kubernetes.cri-o.*`) in the crio.yaml templates for master, worker, and arbiter roles:
- `io.kubernetes.cri-o.Devices` + `devices.crio.io`
- `io.kubernetes.cri-o.LinkLogs` + `link-logs.crio.io`
- `io.kubernetes.cri-o.userns-mode` + `userns-mode.crio.io`

Both formats are included for backward compatibility during the transition period. The v1 entries can be removed once the minimum CRI-O version fully supports v2 annotations.

Part of: https://github.com/cri-o/cri-o/issues/10194

**- How to verify it**
Check that the crio.yaml templates include both v1 and v2 annotation formats.

**- Description for the changelog**
Add CRI-O v2 annotations (`*.crio.io`) alongside deprecated v1 (`io.kubernetes.cri-o.*`) format for backward compatibility.