### PR TITLE
NO-ISSUE:  Fix setArchitectureAndCheckStatus corrupting multi-label annotations

### DIFF
--- a/test/extended-priv/machineset.go
+++ b/test/extended-priv/machineset.go
@@ -2,6 +2,7 @@ package extended
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
@@ -315,7 +316,14 @@ func (ms MachineSet) GetArchitecture() (architecture.Architecture, error) {
 		return narch, nil
 	}
 
-	return architecture.FromString(strings.Split(labeledArch, "kubernetes.io/arch=")[1]), nil
+	for _, label := range strings.Split(labeledArch, ",") {
+		label = strings.TrimSpace(label)
+		if archValue, found := strings.CutPrefix(label, "kubernetes.io/arch="); found {
+			return architecture.FromString(archValue), nil
+		}
+	}
+
+	return architecture.UNKNOWN, fmt.Errorf("kubernetes.io/arch label not found in annotation: %s", labeledArch)
 }
 
 // GetArchitectureOrFail returns the architecture configured for this Machineset and fails the test if any error happens
@@ -327,9 +335,7 @@ func (ms MachineSet) GetArchitectureOrFail() architecture.Architecture {
 
 // SetArchitecture sets the architecture annotation for this MachineSet
 func (ms MachineSet) SetArchitecture(arch string) error {
-	return ms.Patch("json",
-		fmt.Sprintf(`[{"op": "add", "path": "/metadata/annotations/capacity.cluster-autoscaler.kubernetes.io~1labels", "value": "kubernetes.io/arch=%s"}]`,
-			arch))
+	return ms.SetAutoscalerLabels("kubernetes.io/arch=" + arch)
 }
 
 // GetUserDataSecretName returns the name of the user-data secret
@@ -706,4 +712,17 @@ func GetScalableMachineSet(oc *exutil.CLI) (*MachineSet, error) {
 	}
 
 	return machinesets[0], nil
+}
+
+// SetAutoscalerLabels sets the capacity.cluster-autoscaler.kubernetes.io/labels annotation
+// for this MachineSet. The value may contain multiple comma-separated labels
+// (e.g. "kubernetes.io/arch=amd64,topology.ebs.csi.aws.com/zone=eu-central-1a").
+func (ms MachineSet) SetAutoscalerLabels(labels string) error {
+	marshaledLabels, err := json.Marshal(labels)
+	if err != nil {
+		return fmt.Errorf("failed to marshal labels: %w", err)
+	}
+	return ms.Patch("json",
+		fmt.Sprintf(`[{"op": "add", "path": "/metadata/annotations/capacity.cluster-autoscaler.kubernetes.io~1labels", "value": %s}]`,
+			string(marshaledLabels)))
 }

--- a/test/extended-priv/mco_bootimages.go
+++ b/test/extended-priv/mco_bootimages.go
@@ -1043,11 +1043,18 @@ func CheckCurrentOSImageIsUpdated(bir BootImageResource) {
 	}
 }
 
-// setArchitectureAndCheckStatus sets a different architecture in the cloned machineset and checks the status
+// setArchitectureAndCheckStatus sets the capacity labels annotation on the cloned machineset and checks the status.
+// If archValue already contains "kubernetes.io/arch=", it is used as the raw annotation value.
+// Otherwise, "kubernetes.io/arch=" is prepended automatically.
 func setArchitectureAndCheckStatus(clonedMS *MachineSet, machineConfiguration *MachineConfiguration, archValue string) {
-	exutil.By(fmt.Sprintf("Set a %s architecture in the cloned machineset", archValue))
-	o.Expect(clonedMS.SetArchitecture(archValue)).To(o.Succeed(), "Error setting architecture %s in %s", archValue, clonedMS)
-	logger.Infof("Architecture %s set in %s\n", archValue, clonedMS)
+	labels := archValue
+	if !strings.Contains(archValue, "kubernetes.io/arch=") {
+		labels = "kubernetes.io/arch=" + archValue
+	}
+
+	exutil.By(fmt.Sprintf("Set a %s architecture in the cloned machineset", labels))
+	o.Expect(clonedMS.SetAutoscalerLabels(labels)).To(o.Succeed(), "Error setting architecture %s in %s", labels, clonedMS)
+	logger.Infof("Architecture %s set in %s\n", labels, clonedMS)
 
 	exutil.By("Check that no failures are being reported")
 	o.Eventually(machineConfiguration, "5m", "20s").Should(HaveConditionField("BootImageUpdateDegraded", "status", "False"),


### PR DESCRIPTION
  - SetArchitecture() always prepends kubernetes.io/arch= to its input, which corrupts multi-label annotation values that already contain the prefix (e.g. kubernetes.io/arch=amd64,topology.ebs.csi.aws.com/zone=eu-central-1a becomes kubernetes.io/arch=kubernetes.io/arch=amd64,...)
 -  Fix 83398
  https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-machine-config-operator-release-4.23-periodics-e2e-vsphere-mco-tp-longduration-2of2/2082047377660710912 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved machine-set architecture test coverage to update architecture through capacity/autoscaler label annotations.
  * Added safer handling for comma-separated capacity label values to ensure correct annotation formatting.
  * Enhanced architecture normalization by supporting inputs both with and without the standard `kubernetes.io/arch=` prefix.
  * Improved parsing behavior to fail with a clearer error when the expected architecture label is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->