### PR TITLE
OCPBUGS-59197: Fix MOSB image deletion race during MOSC removal

### DIFF
--- a/pkg/controller/build/reconciler.go
+++ b/pkg/controller/build/reconciler.go
@@ -946,20 +946,13 @@ func (b *buildReconciler) deleteMachineOSBuild(ctx context.Context, mosb *mcfgv1
 }
 
 func (b *buildReconciler) deleteMOSBImage(ctx context.Context, mosb *mcfgv1.MachineOSBuild, moscName string) error {
-	moscExists := true
-	_, err := b.listers.machineOSConfigLister.Get(moscName)
-	if k8serrors.IsNotFound(err) {
-		moscExists = false
-	} else if err != nil {
-		return fmt.Errorf("could not get MachineOSConfig for MachineOSBuild %q: %w", mosb.Name, err)
+	poolName := mosb.ObjectMeta.Labels[constants.TargetMachineConfigPoolLabelKey]
+	if poolName == "" {
+		return fmt.Errorf("MachineOSBuild %q is missing label %s, cannot determine if image is in use", mosb.Name, constants.TargetMachineConfigPoolLabelKey)
 	}
 
-	if moscExists {
-		pool, err := b.listers.machineConfigPoolLister.Get(mosb.ObjectMeta.Labels[constants.TargetMachineConfigPoolLabelKey])
-		if err != nil {
-			return fmt.Errorf("could not get MachineConfigPool from MachineOSBuild %q: %w", mosb.Name, err)
-		}
-
+	pool, err := b.listers.machineConfigPoolLister.Get(poolName)
+	if err == nil {
 		nodes, err := helpers.GetNodesForPool(b.listers.machineConfigPoolLister, b.listers.nodeLister, pool)
 		if err != nil {
 			return fmt.Errorf("could not get nodes for MachineConfigPool %q: %w", pool.Name, err)
@@ -973,6 +966,8 @@ func (b *buildReconciler) deleteMOSBImage(ctx context.Context, mosb *mcfgv1.Mach
 				return nil
 			}
 		}
+	} else if !k8serrors.IsNotFound(err) {
+		return fmt.Errorf("could not get MachineConfigPool from MachineOSBuild %q: %w", mosb.Name, err)
 	}
 
 	image := string(mosb.Spec.RenderedImagePushSpec)


### PR DESCRIPTION
Closes https://redhat.atlassian.net/browse/OCPBUGS-59197
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
When a MachineOSConfig is deleted while nodes are actively rebasing, the node annotation safety check in deleteMOSBImage was gated on moscExists. Since the MOSC is already gone in this code path, moscExists is always false and the check is skipped entirely, allowing the image to be deleted from the registry while nodes are still using it.

Remove the moscExists gate and look up the pool directly from the MOSB's labels. If the pool exists, check node annotations before deleting. If the pool is also gone, proceed with deletion since no nodes could be using the image.

**- How to verify it**

Follow the steps in https://redhat.atlassian.net/browse/OCPBUGS-59197 and the race should no longer happen

**- Description for the changelog**
Fix MOSB image deletion race during MOSC removal
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup safeguards for build registry images.
  * Images are no longer deleted when they are currently applied to or desired by a node.
  * Added clearer handling when the associated machine pool cannot be retrieved, including validation of required labeling and better error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->