### PR TITLE
  OCPBUGS-100277: Fix TC 43278 failing when release payload has no MCO commit info

### DIFF
--- a/test/extended-priv/mco_security.go
+++ b/test/extended-priv/mco_security.go
@@ -949,15 +949,15 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/longdurati
 		logger.Infof("cluster version is %s", clusterVersion)
 		commitID, commitErr := getCommitID(oc, "machine-config", clusterVersion)
 		o.Expect(commitErr).NotTo(o.HaveOccurred())
-		// there is a case that in the payload no commit id from mco
-		if commitID == "" {
-			g.Skip("No code change from MCO, skip this case")
+		if commitID != "" {
+			logger.Infof("machine config commit id is %s", commitID)
+			goVersion, verErr := getGoVersion("machine-config-operator", commitID)
+			o.Expect(verErr).NotTo(o.HaveOccurred())
+			logger.Infof("go version is: %f", goVersion)
+			o.Expect(goVersion).Should(o.BeNumerically(">=", 1.15))
+		} else {
+			logger.Infof("No commit ID in release payload, skipping Go version check")
 		}
-		logger.Infof("machine config commit id is %s", commitID)
-		goVersion, verErr := getGoVersion("machine-config-operator", commitID)
-		o.Expect(verErr).NotTo(o.HaveOccurred())
-		logger.Infof("go version is: %f", goVersion)
-		o.Expect(goVersion).Should(o.BeNumerically(">=", 1.15))
 
 		exutil.By("verify TLS protocol version is 1.3")
 		intAPIServerURI, err := GetAPIServerInternalURI(oc.AsAdmin())

--- a/test/extended-priv/util.go
+++ b/test/extended-priv/util.go
@@ -142,9 +142,10 @@ func getCommitID(oc *exutil.CLI, component, clusterVersion string) (string, erro
 			if len(fields) >= 3 {
 				return fields[2], nil
 			}
+			return "", nil
 		}
 	}
-	return "", fmt.Errorf("component %q not found in release info output", component)
+	return "", nil
 }
 
 func getGoVersion(component, commitID string) (float64, error) {


### PR DESCRIPTION

 - Fix `getCommitID` in `util.go` to return empty string instead of error when component has no commit ID in the release payload, matching OTP3 behavior
  - Restructure TC 43278 to only skip the Go version check when commit ID is unavailable, while always running the TLS 1.3 and cipher verification checks

Issue  
Fix for CI job failure
```
{  fail [github.com/openshift/machine-config-operator/test/extended-priv/mco_security.go:951]: Unexpected error:
    <*errors.errorString | 0xc0014944c0>: 
    component "machine-config" not found in release info output
    {
        s: "component \"machine-config\" not found in release info output",
    }{  fail [github.com/openshift/machine-config-operator/test/extended-priv/mco_security.go:951]: Unexpected error:
    <*errors.errorString | 0xc0014944c0>: 
    component "machine-config" not found in release info output
    {
        s: "component \"machine-config\" not found in release info output",
    }
occurred}
occurred}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security test behavior when release metadata lacks a commit ID.
  * TLS and cipher checks now continue even when Go version verification is unavailable.
  * Improved handling of missing or malformed component information in release metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->