### PR TITLE
CNTRLPLANE-3973: Make sure unencrypted metrics bind to localhost only, and remove dead code

### DIFF
--- a/cmd/machine-config-controller/start.go
+++ b/cmd/machine-config-controller/start.go
@@ -47,8 +47,6 @@ var (
 		templates                string
 		promMetricsListenAddress string
 		resourceLockNamespace    string
-		tlsCipherSuites          []string
-		tlsMinVersion            string
 		streamsCache             string
 	}
 )
@@ -58,9 +56,11 @@ func init() {
 	startCmd.PersistentFlags().StringVar(&startOpts.kubeconfig, "kubeconfig", "", "Kubeconfig file to access a remote cluster (testing only)")
 	startCmd.PersistentFlags().StringVar(&startOpts.resourceLockNamespace, "resourcelock-namespace", metav1.NamespaceSystem, "Path to the template files used for creating MachineConfig objects")
 	startCmd.PersistentFlags().StringVar(&startOpts.promMetricsListenAddress, "metrics-listen-address", ctrlcommon.DefaultMetricsBindAddress, "Listen address for prometheus metrics listener")
-	startCmd.PersistentFlags().StringSliceVar(&startOpts.tlsCipherSuites, "tls-cipher-suites", nil, "Comma-separated list of cipher suites for the metrics server")
-	startCmd.PersistentFlags().StringVar(&startOpts.tlsMinVersion, "tls-min-version", "VersionTLS12", "Minimum TLS version supported for the metrics server")
 	startCmd.PersistentFlags().StringVar(&startOpts.streamsCache, "streams-cache", "/var/cache/mcc", "Directory to use as cache for streams discovery")
+	startCmd.PersistentFlags().StringSlice("tls-cipher-suites", nil, "")
+	startCmd.PersistentFlags().String("tls-min-version", "", "")
+	_ = startCmd.PersistentFlags().MarkDeprecated("tls-cipher-suites", "always using the APIServer setting")
+	_ = startCmd.PersistentFlags().MarkDeprecated("tls-min-version", "always using the APIServer setting")
 }
 
 func runStartCmd(_ *cobra.Command, _ []string) {

--- a/cmd/machine-config-controller/start.go
+++ b/cmd/machine-config-controller/start.go
@@ -57,7 +57,7 @@ func init() {
 	rootCmd.AddCommand(startCmd)
 	startCmd.PersistentFlags().StringVar(&startOpts.kubeconfig, "kubeconfig", "", "Kubeconfig file to access a remote cluster (testing only)")
 	startCmd.PersistentFlags().StringVar(&startOpts.resourceLockNamespace, "resourcelock-namespace", metav1.NamespaceSystem, "Path to the template files used for creating MachineConfig objects")
-	startCmd.PersistentFlags().StringVar(&startOpts.promMetricsListenAddress, "metrics-listen-address", "127.0.0.1:8797", "Listen address for prometheus metrics listener")
+	startCmd.PersistentFlags().StringVar(&startOpts.promMetricsListenAddress, "metrics-listen-address", ctrlcommon.DefaultMetricsBindAddress, "Listen address for prometheus metrics listener")
 	startCmd.PersistentFlags().StringSliceVar(&startOpts.tlsCipherSuites, "tls-cipher-suites", nil, "Comma-separated list of cipher suites for the metrics server")
 	startCmd.PersistentFlags().StringVar(&startOpts.tlsMinVersion, "tls-min-version", "VersionTLS12", "Minimum TLS version supported for the metrics server")
 	startCmd.PersistentFlags().StringVar(&startOpts.streamsCache, "streams-cache", "/var/cache/mcc", "Directory to use as cache for streams discovery")
@@ -148,7 +148,7 @@ func runStartCmd(_ *cobra.Command, _ []string) {
 			}
 		}
 
-		go ctrlcommon.StartMetricsListener(startOpts.promMetricsListenAddress, ctx.Done(), ctrlcommon.RegisterMCCMetrics, startOpts.tlsMinVersion, startOpts.tlsCipherSuites)
+		go ctrlcommon.StartMetricsListener(startOpts.promMetricsListenAddress, ctx.Done(), ctrlcommon.RegisterMCCMetrics)
 
 		controllers := createControllers(ctrlctx, inspectionCache, inspectorFactory)
 		draincontroller := drain.New(

--- a/cmd/machine-config-daemon/start.go
+++ b/cmd/machine-config-daemon/start.go
@@ -43,8 +43,6 @@ var (
 		kubeletHealthzEnabled      bool
 		kubeletHealthzEndpoint     string
 		promMetricsURL             string
-		tlsCipherSuites            []string
-		tlsMinVersion              string
 	}
 )
 
@@ -59,8 +57,10 @@ func init() {
 	startCmd.PersistentFlags().BoolVar(&startOpts.kubeletHealthzEnabled, "kubelet-healthz-enabled", true, "kubelet healthz endpoint monitoring")
 	startCmd.PersistentFlags().StringVar(&startOpts.kubeletHealthzEndpoint, "kubelet-healthz-endpoint", "http://localhost:10248/healthz", "healthz endpoint to check health")
 	startCmd.PersistentFlags().StringVar(&startOpts.promMetricsURL, "metrics-url", ctrlcommon.DefaultMetricsBindAddress, "URL for prometheus metrics listener")
-	startCmd.PersistentFlags().StringSliceVar(&startOpts.tlsCipherSuites, "tls-cipher-suites", nil, "Comma-separated list of cipher suites for the metrics server")
-	startCmd.PersistentFlags().StringVar(&startOpts.tlsMinVersion, "tls-min-version", "VersionTLS12", "Minimum TLS version supported for the metrics server")
+	startCmd.PersistentFlags().StringSlice("tls-cipher-suites", nil, "")
+	startCmd.PersistentFlags().String("tls-min-version", "", "")
+	_ = startCmd.PersistentFlags().MarkDeprecated("tls-cipher-suites", "always using the APIServer setting")
+	_ = startCmd.PersistentFlags().MarkDeprecated("tls-min-version", "always using the APIServer setting")
 }
 
 //nolint:gocritic

--- a/cmd/machine-config-daemon/start.go
+++ b/cmd/machine-config-daemon/start.go
@@ -58,7 +58,7 @@ func init() {
 	startCmd.PersistentFlags().BoolVar(&startOpts.skipReboot, "skip-reboot", false, "Skips reboot after a sync, applies only in once-from")
 	startCmd.PersistentFlags().BoolVar(&startOpts.kubeletHealthzEnabled, "kubelet-healthz-enabled", true, "kubelet healthz endpoint monitoring")
 	startCmd.PersistentFlags().StringVar(&startOpts.kubeletHealthzEndpoint, "kubelet-healthz-endpoint", "http://localhost:10248/healthz", "healthz endpoint to check health")
-	startCmd.PersistentFlags().StringVar(&startOpts.promMetricsURL, "metrics-url", "127.0.0.1:8797", "URL for prometheus metrics listener")
+	startCmd.PersistentFlags().StringVar(&startOpts.promMetricsURL, "metrics-url", ctrlcommon.DefaultMetricsBindAddress, "URL for prometheus metrics listener")
 	startCmd.PersistentFlags().StringSliceVar(&startOpts.tlsCipherSuites, "tls-cipher-suites", nil, "Comma-separated list of cipher suites for the metrics server")
 	startCmd.PersistentFlags().StringVar(&startOpts.tlsMinVersion, "tls-min-version", "VersionTLS12", "Minimum TLS version supported for the metrics server")
 }
@@ -181,7 +181,7 @@ func runStartCmd(_ *cobra.Command, _ []string) {
 	}
 
 	// Start local metrics listener
-	go ctrlcommon.StartMetricsListener(startOpts.promMetricsURL, stopCh, daemon.RegisterMCDMetrics, startOpts.tlsMinVersion, startOpts.tlsCipherSuites)
+	go ctrlcommon.StartMetricsListener(startOpts.promMetricsURL, stopCh, daemon.RegisterMCDMetrics)
 
 	ctrlctx := ctrlcommon.CreateControllerContext(ctx, cb)
 

--- a/manifests/machineconfigcontroller/deployment.yaml
+++ b/manifests/machineconfigcontroller/deployment.yaml
@@ -24,8 +24,6 @@ spec:
         - "--resourcelock-namespace={{.TargetNamespace}}"
         - "--v={{.LogLevel}}"
         - "--payload-version={{.ReleaseVersion}}"
-        - "--tls-cipher-suites={{join .TLSCipherSuites ","}}"
-        - "--tls-min-version={{.TLSMinVersion}}"
         - "--streams-cache=/var/cache/mcc"
         resources:
           requests:

--- a/manifests/machineconfigdaemon/daemonset.yaml
+++ b/manifests/machineconfigdaemon/daemonset.yaml
@@ -27,8 +27,6 @@ spec:
           - "start"
           - "--payload-version={{.ReleaseVersion}}"
           - "--v={{.LogLevel}}"
-          - "--tls-cipher-suites={{join .TLSCipherSuites ","}}"
-          - "--tls-min-version={{.TLSMinVersion}}"
         resources:
           requests:
             cpu: 20m

--- a/pkg/controller/common/metrics.go
+++ b/pkg/controller/common/metrics.go
@@ -2,8 +2,8 @@ package common
 
 import (
 	"context"
-	"crypto/tls"
 	"fmt"
+	"net"
 	"net/http"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -12,8 +12,8 @@ import (
 )
 
 const (
-	// DefaultBindAddress is the port for the metrics listener
-	DefaultBindAddress = ":8797"
+	// DefaultMetricsBindAddress is the port for the metrics listener
+	DefaultMetricsBindAddress = "127.0.0.1:8797"
 )
 
 // MCC Metrics
@@ -135,10 +135,22 @@ func RegisterMetrics(metrics []prometheus.Collector) error {
 	return nil
 }
 
-// StartMetricsListener is metrics listener via http on localhost
-func StartMetricsListener(addr string, stopCh <-chan struct{}, registerFunc func() error, tlsMinVersion string, tlsCipherSuites []string) {
+// StartMetricsListener starts the prometheus metrics listener
+//
+// It is unencrypted and should bind to localhost, with kube-rbac-proxy exposing a TLS endpoint outside localhost
+func StartMetricsListener(addr string, stopCh <-chan struct{}, registerFunc func() error) {
 	if addr == "" {
-		addr = DefaultBindAddress
+		addr = DefaultMetricsBindAddress
+	}
+
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		klog.Errorf("invalid metrics listen address %q: %v", addr, err)
+		return
+	}
+	if ip := net.ParseIP(host); ip == nil || !ip.IsLoopback() {
+		klog.Errorf("metrics is listening on %q, it should listen on localhost and be exposed via a TLS proxy", addr)
+		return
 	}
 
 	klog.Info("Registering Prometheus metrics")
@@ -148,17 +160,10 @@ func StartMetricsListener(addr string, stopCh <-chan struct{}, registerFunc func
 		return
 	}
 
-	// Get TLS config from provided settings, or use defaults
-	tlsConfig := GetGoTLSConfig(tlsMinVersion, tlsCipherSuites)
-
-	klog.Infof("Starting metrics listener on %s with TLS min version: %s", addr, tlsMinVersion)
+	klog.Infof("Starting metrics listener on %s", addr)
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", promhttp.Handler())
-	s := http.Server{
-		TLSConfig:    tlsConfig,
-		TLSNextProto: make(map[string]func(*http.Server, *tls.Conn, http.Handler)),
-		Addr:         addr,
-		Handler:      mux}
+	s := http.Server{Addr: addr, Handler: mux}
 
 	go func() {
 		if err := s.ListenAndServe(); err != nil && err != http.ErrServerClosed {


### PR DESCRIPTION
**- What I did**
* Added checks so that the unencrypted `/metrics` endpoint only binds localhost (kube-rbac-proxy is responsible for exposing the TLS endpoint)
* Removed dead code that failed to encrypt that base endpoint
* Deprecated MCC and MCD cli flags that failed to configure tls minversion and ciphersuites for the metrics endpoint (kube-rbac-proxy was only looking at the APIserver settings)

**- How to verify it**
There should be no behaviour change apart from the deprecated cli flags, this is a code cleanup.

**- Description for the changelog**
Deprecated ineffective `--tls-cipher-suites` and `--tls-min-version` flags of `machine-config-controller` and `machine-config-daemon`: the metrics TLS config is always fecthed from the APIServer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Metrics `/metrics` endpoint is now served localhost-only and unencrypted by default.
  * Metrics listener TLS configuration has been removed; TLS cipher-suite and minimum-version flags are deprecated and no longer affect metrics.
  * Updated controller/daemon startup arguments to align with the simplified metrics configuration.
* **Operational Improvements**
  * Controller/daemon lifecycles now rely on the main context cancellation for shutdown behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->