### PR TITLE
OCPBUGS-99751: Verify MOSC existence via API before serving layered image

### DIFF
--- a/pkg/server/cluster_server.go
+++ b/pkg/server/cluster_server.go
@@ -15,10 +15,13 @@ import (
 	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
 	mcfginformers "github.com/openshift/client-go/machineconfiguration/informers/externalversions"
 
+	mcfgclientset "github.com/openshift/client-go/machineconfiguration/clientset/versioned"
 	routeclientset "github.com/openshift/client-go/route/clientset/versioned"
 	"github.com/openshift/machine-config-operator/internal/clients"
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/informers"
@@ -51,6 +54,7 @@ type clusterServer struct {
 	machineOSConfigLister   v1.MachineOSConfigLister
 	machineOSBuildLister    v1.MachineOSBuildLister
 
+	mcfgclient  mcfgclientset.Interface
 	kubeclient  clientset.Interface
 	routeclient routeclientset.Interface
 
@@ -119,6 +123,7 @@ func NewClusterServer(kubeConfig, apiserverURL string) (Server, error) {
 		configMapLister:         cmLister,
 		machineOSConfigLister:   moscLister,
 		machineOSBuildLister:    mosbLister,
+		mcfgclient:              machineConfigClient,
 		kubeclient:              kubeClient,
 		routeclient:             routeClient,
 		kubeconfigFunc:          func() ([]byte, []byte, error) { return kubeconfigFromSecret(bootstrapTokenDir, apiserverURL, nil) },
@@ -286,6 +291,20 @@ func (cs *clusterServer) resolveDesiredImageForPool(pool *mcfgv1.MachineConfigPo
 	// No MOSC for this pool - not layered
 	if mosc == nil {
 		return ""
+	}
+
+	// Guard against stale informer cache: verify the MOSC still exists via a direct API call.
+	// The MCS runs as a DaemonSet with per-pod caches, so after a MOSC deletion, different
+	// pods may have stale data for different durations.
+	if cs.mcfgclient != nil {
+		_, err := cs.mcfgclient.MachineconfigurationV1().MachineOSConfigs().Get(context.TODO(), mosc.Name, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			klog.Infof("MachineOSConfig %s found in cache but deleted from API for pool %s, skipping layered image", mosc.Name, pool.Name)
+			return ""
+		}
+		if err != nil {
+			klog.Warningf("Failed to verify MachineOSConfig %s via API for pool %s, trusting cache: %v", mosc.Name, pool.Name, err)
+		}
 	}
 
 	// Check if image is ready in MOSC status

--- a/pkg/server/cluster_server.go
+++ b/pkg/server/cluster_server.go
@@ -15,10 +15,13 @@ import (
 	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
 	mcfginformers "github.com/openshift/client-go/machineconfiguration/informers/externalversions"
 
+	mcfgclientset "github.com/openshift/client-go/machineconfiguration/clientset/versioned"
 	routeclientset "github.com/openshift/client-go/route/clientset/versioned"
 	"github.com/openshift/machine-config-operator/internal/clients"
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/informers"
@@ -51,6 +54,7 @@ type clusterServer struct {
 	machineOSConfigLister   v1.MachineOSConfigLister
 	machineOSBuildLister    v1.MachineOSBuildLister
 
+	mcfgclient  mcfgclientset.Interface
 	kubeclient  clientset.Interface
 	routeclient routeclientset.Interface
 
@@ -119,6 +123,7 @@ func NewClusterServer(kubeConfig, apiserverURL string) (Server, error) {
 		configMapLister:         cmLister,
 		machineOSConfigLister:   moscLister,
 		machineOSBuildLister:    mosbLister,
+		mcfgclient:              machineConfigClient,
 		kubeclient:              kubeClient,
 		routeclient:             routeClient,
 		kubeconfigFunc:          func() ([]byte, []byte, error) { return kubeconfigFromSecret(bootstrapTokenDir, apiserverURL, nil) },
@@ -145,10 +150,12 @@ func (cs *clusterServer) GetConfig(cr poolRequest) (*runtime.RawExtension, error
 		currConf = mp.Status.Configuration.Name
 	}
 
-	mc, err := cs.machineConfigLister.Get(currConf)
+	mcCached, err := cs.machineConfigLister.Get(currConf)
 	if err != nil {
 		return nil, fmt.Errorf("could not fetch config %s, err: %w", currConf, err)
 	}
+	// DeepCopy to avoid mutating the shared informer cache (appenders modify mc.Spec.OSImageURL)
+	mc := mcCached.DeepCopy()
 	ignConf, err := ctrlcommon.ParseAndConvertConfig(mc.Spec.Config.Raw)
 	if err != nil {
 		return nil, fmt.Errorf("parsing Ignition config failed with error: %w", err)
@@ -286,6 +293,22 @@ func (cs *clusterServer) resolveDesiredImageForPool(pool *mcfgv1.MachineConfigPo
 	// No MOSC for this pool - not layered
 	if mosc == nil {
 		return ""
+	}
+
+	// Guard against stale informer cache: verify the MOSC still exists via a direct API call.
+	// The MCS runs as a DaemonSet with per-pod caches, so after a MOSC deletion, different
+	// pods may have stale data for different durations.
+	if cs.mcfgclient != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_, err := cs.mcfgclient.MachineconfigurationV1().MachineOSConfigs().Get(ctx, mosc.Name, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			klog.Infof("MachineOSConfig %s found in cache but deleted from API for pool %s, skipping layered image", mosc.Name, pool.Name)
+			return ""
+		}
+		if err != nil {
+			klog.Warningf("Failed to verify MachineOSConfig %s via API for pool %s, trusting cache: %v", mosc.Name, pool.Name, err)
+		}
 	}
 
 	// Check if image is ready in MOSC status

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -30,6 +30,7 @@ import (
 
 	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
 	routev1 "github.com/openshift/api/route/v1"
+	mcfgfake "github.com/openshift/client-go/machineconfiguration/clientset/versioned/fake"
 	routefake "github.com/openshift/client-go/route/clientset/versioned/fake"
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
 	daemonconsts "github.com/openshift/machine-config-operator/pkg/daemon/constants"
@@ -574,6 +575,7 @@ func TestResolveDesiredImageForPool(t *testing.T) {
 		name                string
 		poolName            string
 		moscExists          bool
+		moscDeletedFromAPI  bool
 		mosbExists          bool
 		mosbSuccessful      bool
 		registryInternal    bool
@@ -630,6 +632,18 @@ func TestResolveDesiredImageForPool(t *testing.T) {
 			updatedMachineCount: 0,
 			expectedImageURL:    "",
 			expectedRebootPath:  "2-reboot (no nodes have validated the new build yet)",
+		},
+		{
+			name:                "MOSC deleted but still in stale cache - no layered image",
+			poolName:            "worker",
+			moscExists:          true,
+			moscDeletedFromAPI:  true,
+			mosbExists:          true,
+			mosbSuccessful:      true,
+			registryInternal:    false,
+			updatedMachineCount: 1,
+			expectedImageURL:    "",
+			expectedRebootPath:  "Base image (MOSC deleted, stale cache should be caught by API verification)",
 		},
 	}
 
@@ -735,10 +749,20 @@ func TestResolveDesiredImageForPool(t *testing.T) {
 			// Create fake k8s clients for registry detection
 			kubeclient, routeclient := createFakeRegistryClients(tc.registryInternal)
 
+			// Create fake MCO client with MOSCs present in the API (unless testing stale cache)
+			var mcfgObjs []runtime.Object
+			if !tc.moscDeletedFromAPI {
+				for _, m := range moscList {
+					mcfgObjs = append(mcfgObjs, m)
+				}
+			}
+			mcfgclient := mcfgfake.NewSimpleClientset(mcfgObjs...)
+
 			// Create cluster server
 			cs := &clusterServer{
 				machineOSConfigLister: moscLister,
 				machineOSBuildLister:  mosbLister,
+				mcfgclient:            mcfgclient,
 				kubeclient:            kubeclient,
 				routeclient:           routeclient,
 			}
@@ -1005,10 +1029,18 @@ func TestLayeredImageServingDuringScaleUp(t *testing.T) {
 			// Create fake k8s clients for registry detection
 			kubeclient, routeclient := createFakeRegistryClients(tc.registryInternal)
 
+			// Create fake MCO client with MOSCs present in the API
+			var mcfgObjs []runtime.Object
+			for _, m := range moscList {
+				mcfgObjs = append(mcfgObjs, m)
+			}
+			mcfgclient := mcfgfake.NewSimpleClientset(mcfgObjs...)
+
 			// Create cluster server
 			cs := &clusterServer{
 				machineOSConfigLister: moscLister,
 				machineOSBuildLister:  mosbLister,
+				mcfgclient:            mcfgclient,
 				kubeclient:            kubeclient,
 				routeclient:           routeclient,
 			}
@@ -1183,12 +1215,19 @@ func TestGetConfigWithLayeredImage(t *testing.T) {
 
 			kubeclient, routeclient := createFakeRegistryClients(tc.registryInternal)
 
+			var mcfgObjs []runtime.Object
+			for _, m := range moscList {
+				mcfgObjs = append(mcfgObjs, m)
+			}
+			mcfgclient := mcfgfake.NewSimpleClientset(mcfgObjs...)
+
 			csc := &clusterServer{
 				machineConfigPoolLister: mcpLister,
 				machineConfigLister:     mcLister,
 				controllerConfigLister:  ccLister,
 				machineOSConfigLister:   moscLister,
 				machineOSBuildLister:    mosbLister,
+				mcfgclient:              mcfgclient,
 				kubeclient:              kubeclient,
 				routeclient:             routeclient,
 				kubeconfigFunc: func() ([]byte, []byte, error) {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -30,6 +30,7 @@ import (
 
 	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
 	routev1 "github.com/openshift/api/route/v1"
+	mcfgfake "github.com/openshift/client-go/machineconfiguration/clientset/versioned/fake"
 	routefake "github.com/openshift/client-go/route/clientset/versioned/fake"
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
 	daemonconsts "github.com/openshift/machine-config-operator/pkg/daemon/constants"
@@ -574,6 +575,7 @@ func TestResolveDesiredImageForPool(t *testing.T) {
 		name                string
 		poolName            string
 		moscExists          bool
+		moscDeletedFromAPI  bool
 		mosbExists          bool
 		mosbSuccessful      bool
 		registryInternal    bool
@@ -630,6 +632,18 @@ func TestResolveDesiredImageForPool(t *testing.T) {
 			updatedMachineCount: 0,
 			expectedImageURL:    "",
 			expectedRebootPath:  "2-reboot (no nodes have validated the new build yet)",
+		},
+		{
+			name:                "MOSC deleted but still in stale cache - no layered image",
+			poolName:            "worker",
+			moscExists:          true,
+			moscDeletedFromAPI:  true,
+			mosbExists:          true,
+			mosbSuccessful:      true,
+			registryInternal:    false,
+			updatedMachineCount: 1,
+			expectedImageURL:    "",
+			expectedRebootPath:  "Base image (MOSC deleted, stale cache should be caught by API verification)",
 		},
 	}
 
@@ -735,10 +749,20 @@ func TestResolveDesiredImageForPool(t *testing.T) {
 			// Create fake k8s clients for registry detection
 			kubeclient, routeclient := createFakeRegistryClients(tc.registryInternal)
 
+			// Create fake MCO client with MOSCs present in the API (unless testing stale cache)
+			var mcfgObjs []runtime.Object
+			if !tc.moscDeletedFromAPI {
+				for _, m := range moscList {
+					mcfgObjs = append(mcfgObjs, m)
+				}
+			}
+			mcfgclient := mcfgfake.NewSimpleClientset(mcfgObjs...)
+
 			// Create cluster server
 			cs := &clusterServer{
 				machineOSConfigLister: moscLister,
 				machineOSBuildLister:  mosbLister,
+				mcfgclient:            mcfgclient,
 				kubeclient:            kubeclient,
 				routeclient:           routeclient,
 			}
@@ -1005,10 +1029,18 @@ func TestLayeredImageServingDuringScaleUp(t *testing.T) {
 			// Create fake k8s clients for registry detection
 			kubeclient, routeclient := createFakeRegistryClients(tc.registryInternal)
 
+			// Create fake MCO client with MOSCs present in the API
+			var mcfgObjs []runtime.Object
+			for _, m := range moscList {
+				mcfgObjs = append(mcfgObjs, m)
+			}
+			mcfgclient := mcfgfake.NewSimpleClientset(mcfgObjs...)
+
 			// Create cluster server
 			cs := &clusterServer{
 				machineOSConfigLister: moscLister,
 				machineOSBuildLister:  mosbLister,
+				mcfgclient:            mcfgclient,
 				kubeclient:            kubeclient,
 				routeclient:           routeclient,
 			}
@@ -1183,12 +1215,19 @@ func TestGetConfigWithLayeredImage(t *testing.T) {
 
 			kubeclient, routeclient := createFakeRegistryClients(tc.registryInternal)
 
+			var mcfgObjs []runtime.Object
+			for _, m := range moscList {
+				mcfgObjs = append(mcfgObjs, m)
+			}
+			mcfgclient := mcfgfake.NewSimpleClientset(mcfgObjs...)
+
 			csc := &clusterServer{
 				machineConfigPoolLister: mcpLister,
 				machineConfigLister:     mcLister,
 				controllerConfigLister:  ccLister,
 				machineOSConfigLister:   moscLister,
 				machineOSBuildLister:    mosbLister,
+				mcfgclient:              mcfgclient,
 				kubeclient:              kubeclient,
 				routeclient:             routeclient,
 				kubeconfigFunc: func() ([]byte, []byte, error) {
@@ -1249,4 +1288,121 @@ func TestGetConfigWithLayeredImage(t *testing.T) {
 				"Desired config annotation should match expected")
 		})
 	}
+}
+
+// TestGetConfigDoesNotMutateInformerCache verifies that calling GetConfig does not
+// permanently mutate the shared informer cache. This is a regression test for the
+// bug where appendDesiredOSImage set mc.Spec.OSImageURL on the cached MC object,
+// causing subsequent calls (after MOSC deletion) to still serve the stale layered image.
+func TestGetConfigDoesNotMutateInformerCache(t *testing.T) {
+	t.Parallel()
+
+	mcPath := filepath.Join(testDir, "machine-configs", testConfig+".yaml")
+	mcData, err := os.ReadFile(mcPath)
+	require.NoError(t, err)
+
+	mc := new(mcfgv1.MachineConfig)
+	err = yaml.Unmarshal(mcData, mc)
+	require.NoError(t, err)
+	mc.Name = "rendered-worker-new"
+
+	pool := &mcfgv1.MachineConfigPool{
+		ObjectMeta: metav1.ObjectMeta{Name: "worker"},
+		Spec: mcfgv1.MachineConfigPoolSpec{
+			Configuration: mcfgv1.MachineConfigPoolStatusConfiguration{
+				ObjectReference: corev1.ObjectReference{Name: "rendered-worker-new"},
+			},
+		},
+		Status: mcfgv1.MachineConfigPoolStatus{
+			Configuration: mcfgv1.MachineConfigPoolStatusConfiguration{
+				ObjectReference: corev1.ObjectReference{Name: "rendered-worker-new"},
+			},
+			UpdatedMachineCount: 1,
+		},
+	}
+
+	mosc := &mcfgv1.MachineOSConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "worker"},
+		Spec: mcfgv1.MachineOSConfigSpec{
+			MachineConfigPool: mcfgv1.MachineConfigPoolReference{Name: "worker"},
+		},
+		Status: mcfgv1.MachineOSConfigStatus{
+			CurrentImagePullSpec: mcfgv1.ImageDigestFormat("quay.io/openshift/custom-layered-image@sha256:abc123"),
+		},
+	}
+
+	mosb := &mcfgv1.MachineOSBuild{
+		ObjectMeta: metav1.ObjectMeta{Name: "worker-rendered-worker-new"},
+		Spec: mcfgv1.MachineOSBuildSpec{
+			MachineOSConfig: mcfgv1.MachineOSConfigReference{Name: "worker"},
+			MachineConfig:   mcfgv1.MachineConfigReference{Name: "rendered-worker-new"},
+		},
+		Status: mcfgv1.MachineOSBuildStatus{
+			Conditions: []metav1.Condition{{Type: "Succeeded", Status: metav1.ConditionTrue}},
+			DigestedImagePushSpec: mcfgv1.ImageDigestFormat("quay.io/openshift/custom-layered-image@sha256:abc123"),
+		},
+	}
+
+	controllerConfig := getTestControllerConfig()
+	mcpLister := &mockMCPLister{pools: []*mcfgv1.MachineConfigPool{pool}}
+	mcLister := &mockMCLister{configs: []*mcfgv1.MachineConfig{mc}}
+	ccLister := &mockCCLister{configs: []*mcfgv1.ControllerConfig{controllerConfig}}
+	moscLister := &mockMOSCLister{configs: []*mcfgv1.MachineOSConfig{mosc}}
+	mosbLister := &mockMOSBLister{builds: []*mcfgv1.MachineOSBuild{mosb}}
+	kubeclient, routeclient := createFakeRegistryClients(false)
+	mcfgclient := mcfgfake.NewSimpleClientset(mosc)
+
+	csc := &clusterServer{
+		machineConfigPoolLister: mcpLister,
+		machineConfigLister:     mcLister,
+		controllerConfigLister:  ccLister,
+		machineOSConfigLister:   moscLister,
+		machineOSBuildLister:    mosbLister,
+		mcfgclient:              mcfgclient,
+		kubeclient:              kubeclient,
+		routeclient:             routeclient,
+		kubeconfigFunc:          func() ([]byte, []byte, error) { return getKubeConfigContent(t) },
+	}
+
+	layeredImage := "quay.io/openshift/custom-layered-image@sha256:abc123"
+	originalOSImageURL := mc.Spec.OSImageURL
+
+	// First call: MOSC exists, should serve layered image and set OSImageURL on the copy
+	_, err = csc.GetConfig(poolRequest{machineConfigPool: "worker"})
+	require.NoError(t, err)
+
+	// Verify the cached MC was NOT mutated to the layered image
+	assert.Equal(t, originalOSImageURL, mc.Spec.OSImageURL,
+		"Shared informer cache MC should not have OSImageURL mutated after GetConfig")
+
+	// Now simulate MOSC deletion: remove from API client but keep in lister (stale cache)
+	mcfgclient = mcfgfake.NewSimpleClientset()
+	csc.mcfgclient = mcfgclient
+
+	// Second call: MOSC deleted from API, stale cache still has it
+	res, err := csc.GetConfig(poolRequest{machineConfigPool: "worker"})
+	require.NoError(t, err)
+
+	resCfg, err := ctrlcommon.ParseAndConvertConfig(res.Raw)
+	require.NoError(t, err)
+
+	// Find the encapsulated MC content file
+	var encapsulatedFile *ign3types.File
+	for i := range resCfg.Storage.Files {
+		if resCfg.Storage.Files[i].Path == "/etc/mcs-machine-config-content.json" {
+			encapsulatedFile = &resCfg.Storage.Files[i]
+			break
+		}
+	}
+	require.NotNil(t, encapsulatedFile, "Encapsulated MC file should be present")
+
+	contents, err := ctrlcommon.DecodeIgnitionFileContents(encapsulatedFile.Contents.Source, encapsulatedFile.Contents.Compression)
+	require.NoError(t, err)
+
+	var encapsulatedMC mcfgv1.MachineConfig
+	err = json.Unmarshal([]byte(contents), &encapsulatedMC)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, layeredImage, encapsulatedMC.Spec.OSImageURL,
+		"After MOSC deletion, encapsulated MC should not contain stale layered image URL")
 }


### PR DESCRIPTION
Closes https://redhat.atlassian.net/browse/OCPBUGS-99751
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

The MCS runs as a DaemonSet with per-pod informer caches. When a MOSC is deleted (Image Mode disabled), different pods receive the watch event at different times. A new node hitting a stale pod gets the wrong OS image, leading to a double pivot that can leave the node NotReady.

Add a direct API verification in resolveDesiredImageForPool: after finding a MOSC in the informer cache, do a live GET to confirm it still exists before serving the layered image. This closes the race window with negligible latency cost (one small-object GET, only when a MOSC is cached for the pool).

**- How to verify it**

Opt a pool into layering then opt it out. Scale up a new node and it to that pool, the node should not be using the layered image and should stay Ready after being added to the pool.

**- Description for the changelog**
Verify MOSC existence via API before serving layered image
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved layered-image handling when configuration data is removed but stale cached information remains.
  * Prevented layered images from being served when their associated configuration no longer exists.
  * Added safer fallback behavior when current configuration data cannot be retrieved.
  * Prevented configuration updates from unintentionally altering cached data or retaining outdated layered-image information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->