### PR TITLE
MCO-1906: Add Extra Validations

### DIFF
--- a/pkg/controller/bootstrap/bootstrap.go
+++ b/pkg/controller/bootstrap/bootstrap.go
@@ -19,6 +19,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
+	k8sversion "k8s.io/apimachinery/pkg/util/version"
 	yamlutil "k8s.io/apimachinery/pkg/util/yaml"
 	kscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/klog/v2"
@@ -40,6 +41,7 @@ import (
 	kubeletconfig "github.com/openshift/machine-config-operator/pkg/controller/kubelet-config"
 	"github.com/openshift/machine-config-operator/pkg/controller/render"
 	"github.com/openshift/machine-config-operator/pkg/controller/template"
+	"github.com/openshift/machine-config-operator/pkg/daemon/osrelease"
 	"github.com/openshift/machine-config-operator/pkg/version"
 )
 
@@ -50,9 +52,11 @@ type Bootstrap struct {
 	// dir used to read pools and user defined machineconfigs.
 	manifestDir string
 	// pull secret file
-	pullSecretFile string
+	pullSecretFile     string
 	imageStreamFactory osimagestream.ImageStreamFactory
-	inspectorFactory   osimagestream.ImagesInspectorFactory
+	// ImagesInspector factory, used for OSImageStream discovery and to validate
+	// pre-built images for hybrid OCL at bootstrap time. Used for testing purposes.
+	inspectorFactory osimagestream.ImagesInspectorFactory
 }
 
 // New returns controller for bootstrap
@@ -357,11 +361,19 @@ func (b *Bootstrap) Run(destDir string) error {
 		}
 	}
 
+	sysCtxFactory := buildSysContextFactory(pullSecret, cconfig, imgCfg, icspRules, idmsRules, itmsRules)
+
 	// Create component MachineConfigs for pre-built images for hybrid OCL
 	// This must happen BEFORE render.RunBootstrap() so they can be merged into rendered MCs
 	if len(machineOSConfigs) > 0 {
 		klog.Infoln("Found machineOSConfig(s) at install time, will install cluster with Image Mode enabled")
-		preBuiltImageMCs, err := createPreBuiltImageMachineConfigs(machineOSConfigs, pools)
+
+		preBuiltImageCtx, preBuiltImageCancel := context.WithTimeout(context.Background(), time.Minute)
+		defer preBuiltImageCancel()
+
+		preBuiltImageInspector := b.inspectorFactory.ForContext(sysCtxFactory)
+
+		preBuiltImageMCs, err := createPreBuiltImageMachineConfigs(preBuiltImageCtx, machineOSConfigs, pools, cconfig, preBuiltImageInspector)
 		if err != nil {
 			return fmt.Errorf("failed to create pre-built image MachineConfigs: %w", err)
 		}
@@ -369,7 +381,6 @@ func (b *Bootstrap) Run(destDir string) error {
 		klog.Infof("Successfully created %d pre-built image component MachineConfigs for hybrid OCL.", len(preBuiltImageMCs))
 	}
 
-	sysCtxFactory := buildSysContextFactory(pullSecret, cconfig, imgCfg, icspRules, idmsRules, itmsRules)
 	inspector := osimagestream.NewStreamClassInspector(b.inspectorFactory, sysCtxFactory)
 	fpools, gconfigs, err := render.RunBootstrap(context.TODO(), pools, configs, cconfig, osImageStream, inspector)
 	if err != nil {
@@ -624,10 +635,13 @@ func parseManifests(filename string, r io.Reader) ([]manifest, error) {
 // that have associated MachineOSConfigs with pre-built image annotations.
 // These component MCs will be automatically merged into rendered MCs by the render controller.
 // This function validates pre-built images at bootstrap time and will fail if:
-// - The annotation is missing for a MOSC that hasn't been seeded yet (required for install-time OCL)
-// - The image format is invalid
+//   - The annotation is missing for a MOSC that hasn't been seeded yet (required for install-time OCL)
+//   - The image format is invalid
+//   - The image's registry is unreachable, or its OS version/base image doesn't match the cluster
+//     being installed (see validatePreBuiltImageVersion)
+//
 // MOSCs without the annotation are skipped only if seeding has already completed.
-func createPreBuiltImageMachineConfigs(machineOSConfigs []*mcfgv1.MachineOSConfig, pools []*mcfgv1.MachineConfigPool) ([]*mcfgv1.MachineConfig, error) {
+func createPreBuiltImageMachineConfigs(ctx context.Context, machineOSConfigs []*mcfgv1.MachineOSConfig, pools []*mcfgv1.MachineConfigPool, cconfig *mcfgv1.ControllerConfig, inspector osimagestream.ImagesInspector) ([]*mcfgv1.MachineConfig, error) {
 	var preBuiltImageMCs []*mcfgv1.MachineConfig
 	var validationErrors []error
 
@@ -669,6 +683,14 @@ func createPreBuiltImageMachineConfigs(machineOSConfigs []*mcfgv1.MachineOSConfi
 		// Validate the pre-built image format and digest
 		if err := validatePreBuiltImage(preBuiltImage); err != nil {
 			validationErrors = append(validationErrors, fmt.Errorf("invalid pre-built image %q for MachineOSConfig %q (pool %q): %w",
+				preBuiltImage, mosc.Name, poolName, err))
+			continue
+		}
+
+		// Validate that the pre-built image's base OS matches the cluster
+		// being installed, and that its registry is accessible.
+		if err := validatePreBuiltImageVersion(ctx, inspector, preBuiltImage, cconfig.Spec.BaseOSContainerImage); err != nil {
+			validationErrors = append(validationErrors, fmt.Errorf("pre-built image %q for MachineOSConfig %q (pool %q) failed validation: %w",
 				preBuiltImage, mosc.Name, poolName, err))
 			continue
 		}
@@ -716,4 +738,119 @@ func validatePreBuiltImage(imageSpec string) error {
 	}
 
 	return nil
+}
+
+// preBuiltImageBaseOSLabelKey is the label MCO's own Containerfile embeds
+// with the base OS image used to build the layered image (see
+// Containerfile.on-cluster-build-template).
+const preBuiltImageBaseOSLabelKey = "baseOSContainerImage"
+
+// osReleasePath is the path to the os-release file inside a container image.
+const osReleasePath = "/etc/os-release"
+
+// imageDigest parses an image reference and returns its canonical digest.
+func imageDigest(imageSpec string) (digest.Digest, error) {
+	ref, err := reference.ParseNamed(imageSpec)
+	if err != nil {
+		return "", fmt.Errorf("invalid image reference %q: %w", imageSpec, err)
+	}
+	canonical, ok := ref.(reference.Canonical)
+	if !ok {
+		return "", fmt.Errorf("image reference %q is not in digested form", imageSpec)
+	}
+	return canonical.Digest(), nil
+}
+
+// openshiftVersionFromImage fetches /etc/os-release from the given image and
+// extracts its OPENSHIFT_VERSION field (e.g. "4.16"). Returns an error if the
+// file can't be fetched/parsed or the field is absent.
+func openshiftVersionFromImage(ctx context.Context, inspector osimagestream.ImagesInspector, imageSpec string) (string, error) {
+	data, err := inspector.FetchImageFile(ctx, imageSpec, osReleasePath)
+	if err != nil {
+		return "", fmt.Errorf("could not fetch %s from image %q: %w", osReleasePath, imageSpec, err)
+	}
+	osRelease, err := osrelease.LoadOSRelease(string(data), string(data))
+	if err != nil {
+		return "", fmt.Errorf("could not parse %s from image %q: %w", osReleasePath, imageSpec, err)
+	}
+	openshiftVersion, ok := osRelease.OSRelease().ADDITIONAL_FIELDS["OPENSHIFT_VERSION"]
+	if !ok || openshiftVersion == "" {
+		return "", fmt.Errorf("image %q has no OPENSHIFT_VERSION field in %s", imageSpec, osReleasePath)
+	}
+	return openshiftVersion, nil
+}
+
+// sameMajorMinor compares two version strings by major.minor only.
+func sameMajorMinor(a, b string) (bool, error) {
+	va, err := k8sversion.ParseGeneric(a)
+	if err != nil {
+		return false, fmt.Errorf("could not parse version %q: %w", a, err)
+	}
+	vb, err := k8sversion.ParseGeneric(b)
+	if err != nil {
+		return false, fmt.Errorf("could not parse version %q: %w", b, err)
+	}
+	return va.Major() == vb.Major() && va.Minor() == vb.Minor(), nil
+}
+
+// validatePreBuiltImageDigestFallback compares the pre-built image's
+// baseOSContainerImage label digest against the cluster's resolved base OS
+// image digest. Used only when OCP-version comparison isn't possible.
+func validatePreBuiltImageDigestFallback(labels map[string]string, imageSpec, expectedBaseOSImage string) error {
+	label := labels[preBuiltImageBaseOSLabelKey]
+	if label == "" {
+		klog.Warningf("pre-built image %q has no OPENSHIFT_VERSION and no %q label; skipping version verification", imageSpec, preBuiltImageBaseOSLabelKey)
+		return nil
+	}
+	labelDigest, err := imageDigest(label)
+	if err != nil {
+		return fmt.Errorf("pre-built image %q has an invalid %q label: %w", imageSpec, preBuiltImageBaseOSLabelKey, err)
+	}
+	expectedDigest, err := imageDigest(expectedBaseOSImage)
+	if err != nil {
+		klog.Warningf("cluster's base OS image %q is not in digested form (%v); skipping digest verification for pre-built image %q", expectedBaseOSImage, err, imageSpec)
+		return nil
+	}
+	if labelDigest != expectedDigest {
+		return fmt.Errorf("pre-built image %q base OS image %q (digest %s) does not match the cluster's resolved base OS image %q (digest %s)",
+			imageSpec, label, labelDigest, expectedBaseOSImage, expectedDigest)
+	}
+	return nil
+}
+
+// validatePreBuiltImageVersion inspects the pre-built image (proving registry
+// accessibility as a side effect) and verifies it matches the cluster being
+// installed: primarily by comparing OPENSHIFT_VERSION from /etc/os-release
+// against version.ReleaseVersion; if that isn't determinable, it falls back
+// to a digest comparison via the baseOSContainerImage label. If neither
+// signal is available, it logs a warning and lets the image through
+// unverified. Inspection/registry failures are always a hard error.
+func validatePreBuiltImageVersion(ctx context.Context, inspector osimagestream.ImagesInspector, imageSpec, expectedBaseOSImage string) error {
+	imgVersion, versionErr := openshiftVersionFromImage(ctx, inspector, imageSpec)
+	if versionErr == nil {
+		matches, err := sameMajorMinor(imgVersion, version.ReleaseVersion)
+		if err != nil {
+			return fmt.Errorf("could not compare OCP versions for pre-built image %q: %w", imageSpec, err)
+		}
+		if !matches {
+			return fmt.Errorf("pre-built image %q OCP version %q does not match the cluster's OCP version %q", imageSpec, imgVersion, version.ReleaseVersion)
+		}
+		return nil
+	}
+	klog.V(4).Infof("could not determine OCP version for pre-built image %q, falling back to digest check: %v", imageSpec, versionErr)
+
+	results, err := inspector.Inspect(ctx, imageSpec)
+	if err != nil {
+		return fmt.Errorf("could not inspect pre-built image %q: %w", imageSpec, err)
+	}
+	if len(results) != 1 {
+		return fmt.Errorf("unexpected inspection result count for pre-built image %q", imageSpec)
+	}
+	if results[0].Error != nil {
+		return fmt.Errorf("could not access pre-built image %q (registry unreachable or image not found): %w", imageSpec, results[0].Error)
+	}
+	if results[0].InspectInfo == nil {
+		return fmt.Errorf("inspection of pre-built image %q returned no metadata", imageSpec)
+	}
+	return validatePreBuiltImageDigestFallback(results[0].InspectInfo.Labels, imageSpec, expectedBaseOSImage)
 }

--- a/pkg/controller/bootstrap/bootstrap_test.go
+++ b/pkg/controller/bootstrap/bootstrap_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	imgtypes "github.com/containers/image/v5/types"
 	ign3types "github.com/coreos/ignition/v2/config/v3_5/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -20,9 +21,11 @@ import (
 	apicfgv1 "github.com/openshift/api/config/v1"
 	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
 	mcoResourceRead "github.com/openshift/machine-config-operator/lib/resourceread"
+	buildconstants "github.com/openshift/machine-config-operator/pkg/controller/build/constants"
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
 	"github.com/openshift/machine-config-operator/pkg/imageutils"
 	"github.com/openshift/machine-config-operator/pkg/osimagestream"
+	"github.com/openshift/machine-config-operator/pkg/version"
 )
 
 func TestParseManifests(t *testing.T) {
@@ -181,13 +184,75 @@ func (f *fakeImageStreamFactory) Create(_ context.Context, _ imageutils.SysConte
 	return f.stream, nil
 }
 
+// Implements a fake ImagesInspector. FetchImageFileFunc and InspectFunc are
+// stubbable per-test; if left nil, the corresponding method returns an error,
+// simulating an unreachable registry.
+type fakeImagesInspector struct {
+	FetchImageFileFunc func(ctx context.Context, image, path string) ([]byte, error)
+	InspectFunc        func(ctx context.Context, image ...string) ([]imageutils.BulkInspectResult, error)
+}
+
+func (f *fakeImagesInspector) FetchImageFile(ctx context.Context, image, path string) ([]byte, error) {
+	if f.FetchImageFileFunc != nil {
+		return f.FetchImageFileFunc(ctx, image, path)
+	}
+	return nil, fmt.Errorf("fakeImagesInspector: FetchImageFile not configured for image %q", image)
+}
+
+func (f *fakeImagesInspector) Inspect(ctx context.Context, image ...string) ([]imageutils.BulkInspectResult, error) {
+	if f.InspectFunc != nil {
+		return f.InspectFunc(ctx, image...)
+	}
+	return nil, fmt.Errorf("fakeImagesInspector: Inspect not configured for image(s) %v", image)
+}
+
+// Implements a fake ImagesInspectorFactory.
+type fakeImagesInspectorFactory struct {
+	inspector *fakeImagesInspector
+	// Whether the ForContext method was called.
+	forContextCalled bool
+}
+
+func (f *fakeImagesInspectorFactory) ForContext(_ imageutils.SysContextFactory) osimagestream.ImagesInspector {
+	f.forContextCalled = true
+	return f.inspector
+}
+
+// fakeOSReleaseContent returns minimal /etc/os-release-style content with
+// the given OPENSHIFT_VERSION field set.
+func fakeOSReleaseContent(openshiftVersion string) []byte {
+	return []byte(fmt.Sprintf("ID=\"rhcos\"\nVERSION_ID=\"9\"\nOPENSHIFT_VERSION=%q\n", openshiftVersion))
+}
+
+// inspectResultWithLabels builds a successful imageutils.BulkInspectResult
+// with the given labels for a single image.
+func inspectResultWithLabels(image string, labels map[string]string) []imageutils.BulkInspectResult {
+	return []imageutils.BulkInspectResult{{
+		Image:       image,
+		InspectInfo: &imgtypes.ImageInspectInfo{Labels: labels},
+	}}
+}
+
+// inspectResultWithError builds a failed imageutils.BulkInspectResult for a
+// single image, simulating an unreachable registry.
+func inspectResultWithError(image string, err error) []imageutils.BulkInspectResult {
+	return []imageutils.BulkInspectResult{{
+		Image: image,
+		Error: err,
+	}}
+}
+
 // Instantiates a new instance of the Bootstrap struct for testing. This also
 // does the following:
 // 1. Copies the data from testdata/bootstrap into a temp directory so that it
 // may be safely overwritten to test specific scenarios.
 // 2. Creates a fake ImageStreamFactory instance and wires it up to return an
 // OSImageStream.
-func setupForBootstrapTest(t *testing.T) (*Bootstrap, *fakeImageStreamFactory, string, string) {
+// 3. Creates a fake ImagesInspectorFactory instance and wires it up so that
+// the pre-built image referenced by testdata/bootstrap/layered-worker.machineosconfig.yaml
+// passes version validation (its /etc/os-release always reports an
+// OPENSHIFT_VERSION matching version.ReleaseVersion).
+func setupForBootstrapTest(t *testing.T) (*Bootstrap, *fakeImageStreamFactory, *fakeImagesInspectorFactory, string, string) {
 	t.Helper()
 
 	srcDir := t.TempDir()
@@ -210,10 +275,18 @@ func setupForBootstrapTest(t *testing.T) (*Bootstrap, *fakeImageStreamFactory, s
 		},
 	}
 
-	bootstrap := New("../../../templates", srcDir, filepath.Join(srcDir, "machineconfigcontroller-pull-secret"), &noopImagesInspectorFactory{})
+	fakeInspectorFactory := &fakeImagesInspectorFactory{
+		inspector: &fakeImagesInspector{
+			FetchImageFileFunc: func(_ context.Context, _, _ string) ([]byte, error) {
+				return fakeOSReleaseContent(version.ReleaseVersion), nil
+			},
+		},
+	}
+
+	bootstrap := New("../../../templates", srcDir, filepath.Join(srcDir, "machineconfigcontroller-pull-secret"), fakeInspectorFactory)
 	bootstrap.imageStreamFactory = fakeFactory
 
-	return bootstrap, fakeFactory, srcDir, destDir
+	return bootstrap, fakeFactory, fakeInspectorFactory, srcDir, destDir
 }
 
 type noopImagesInspectorFactory struct{}
@@ -286,7 +359,7 @@ func TestBootstrapRunHypershift(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			bootstrap, fakeFactory, srcDir, destDir := setupForBootstrapTest(t)
+			bootstrap, fakeFactory, _, srcDir, destDir := setupForBootstrapTest(t)
 
 			require.NoError(t, exec.Command("cp", "testdata/bootstrap-hypershift/machineconfigcontroller-controllerconfig.yaml", srcDir).Run())
 
@@ -324,10 +397,15 @@ func TestBootstrapRunHypershift(t *testing.T) {
 }
 
 func TestBootstrapRun(t *testing.T) {
-	bootstrap, fakeFactory, _, destDir := setupForBootstrapTest(t)
+	bootstrap, fakeFactory, fakeInspectorFactory, _, destDir := setupForBootstrapTest(t)
 
 	err := bootstrap.Run(destDir)
 	require.NoError(t, err)
+
+	// testdata/bootstrap/layered-worker.machineosconfig.yaml carries a
+	// pre-built image annotation, so bootstrap-time validation must have
+	// used the (fake) ImagesInspector to check it.
+	assert.True(t, fakeInspectorFactory.forContextCalled)
 
 	for _, poolName := range []string{"master", "worker"} {
 		t.Run(poolName, func(t *testing.T) {
@@ -432,4 +510,366 @@ func TestValidatePreBuiltImage(t *testing.T) {
 			}
 		})
 	}
+}
+
+const (
+	testDigestA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	testDigestB = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+)
+
+func TestImageDigest(t *testing.T) {
+	tests := []struct {
+		name          string
+		imageSpec     string
+		wantDigest    string
+		errorContains string
+	}{
+		{
+			name:       "valid digested reference",
+			imageSpec:  "registry.example.com/test@sha256:" + testDigestA,
+			wantDigest: "sha256:" + testDigestA,
+		},
+		{
+			name:          "reference without digest",
+			imageSpec:     "registry.example.com/test:latest",
+			errorContains: "is not in digested form",
+		},
+		{
+			name:          "malformed reference",
+			imageSpec:     "not a valid ref!!",
+			errorContains: "invalid image reference",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := imageDigest(tt.imageSpec)
+			if tt.errorContains != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errorContains)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantDigest, got.String())
+		})
+	}
+}
+
+func TestSameMajorMinor(t *testing.T) {
+	tests := []struct {
+		name          string
+		a             string
+		b             string
+		want          bool
+		errorContains string
+	}{
+		{name: "identical major.minor with differing patch", a: "4.16", b: "4.16.3", want: true},
+		{name: "differing minor", a: "4.16", b: "4.17", want: false},
+		{name: "differing major", a: "5.0", b: "4.16", want: false},
+		{name: "leading v is tolerated", a: "v4.16", b: "4.16.1", want: true},
+		{name: "unparseable a", a: "not-a-version", b: "4.16", errorContains: "could not parse version"},
+		{name: "unparseable b", a: "4.16", b: "not-a-version", errorContains: "could not parse version"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := sameMajorMinor(tt.a, tt.b)
+			if tt.errorContains != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errorContains)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestOpenshiftVersionFromImage(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("success", func(t *testing.T) {
+		inspector := &fakeImagesInspector{
+			FetchImageFileFunc: func(_ context.Context, _, path string) ([]byte, error) {
+				assert.Equal(t, osReleasePath, path)
+				return fakeOSReleaseContent("4.16"), nil
+			},
+		}
+		got, err := openshiftVersionFromImage(ctx, inspector, "registry.example.com/test@sha256:"+testDigestA)
+		require.NoError(t, err)
+		assert.Equal(t, "4.16", got)
+	})
+
+	t.Run("fetch error", func(t *testing.T) {
+		inspector := &fakeImagesInspector{
+			FetchImageFileFunc: func(_ context.Context, _, _ string) ([]byte, error) {
+				return nil, fmt.Errorf("registry unreachable")
+			},
+		}
+		_, err := openshiftVersionFromImage(ctx, inspector, "registry.example.com/test@sha256:"+testDigestA)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "could not fetch")
+	})
+
+	t.Run("missing OPENSHIFT_VERSION field", func(t *testing.T) {
+		inspector := &fakeImagesInspector{
+			FetchImageFileFunc: func(_ context.Context, _, _ string) ([]byte, error) {
+				return []byte(`ID="rhel"` + "\n"), nil
+			},
+		}
+		_, err := openshiftVersionFromImage(ctx, inspector, "registry.example.com/test@sha256:"+testDigestA)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no OPENSHIFT_VERSION field")
+	})
+}
+
+func TestValidatePreBuiltImageDigestFallback(t *testing.T) {
+	imageSpec := "registry.example.com/layered@sha256:" + testDigestA
+
+	tests := []struct {
+		name                string
+		labels              map[string]string
+		expectedBaseOSImage string
+		errorContains       string
+	}{
+		{
+			name: "matching digest through a different registry host (mirror-tolerant)",
+			labels: map[string]string{
+				preBuiltImageBaseOSLabelKey: "mirror.example.com/os@sha256:" + testDigestB,
+			},
+			expectedBaseOSImage: "registry.host.com/os@sha256:" + testDigestB,
+		},
+		{
+			name: "mismatched digest",
+			labels: map[string]string{
+				preBuiltImageBaseOSLabelKey: "registry.host.com/os@sha256:" + testDigestA,
+			},
+			expectedBaseOSImage: "registry.host.com/os@sha256:" + testDigestB,
+			errorContains:       "does not match the cluster's resolved base OS image",
+		},
+		{
+			name:                "missing label is allowed through with a warning",
+			labels:              map[string]string{},
+			expectedBaseOSImage: "registry.host.com/os@sha256:" + testDigestB,
+		},
+		{
+			name: "invalid label",
+			labels: map[string]string{
+				preBuiltImageBaseOSLabelKey: "not a valid ref!!",
+			},
+			expectedBaseOSImage: "registry.host.com/os@sha256:" + testDigestB,
+			errorContains:       "invalid",
+		},
+		{
+			name: "invalid expected base OS image",
+			labels: map[string]string{
+				preBuiltImageBaseOSLabelKey: "registry.host.com/os@sha256:" + testDigestB,
+			},
+			expectedBaseOSImage: "registry.host.com/os:latest",
+			errorContains:       "is invalid",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validatePreBuiltImageDigestFallback(tt.labels, imageSpec, tt.expectedBaseOSImage)
+			if tt.errorContains != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errorContains)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestValidatePreBuiltImageVersion(t *testing.T) {
+	const imageSpec = "registry.example.com/layered@sha256:" + testDigestA
+	const expectedBaseOSImage = "registry.host.com/os@sha256:" + testDigestB
+
+	tests := []struct {
+		name          string
+		inspector     *fakeImagesInspector
+		errorContains string
+	}{
+		{
+			name: "OCP version matches",
+			inspector: &fakeImagesInspector{
+				FetchImageFileFunc: func(_ context.Context, _, _ string) ([]byte, error) {
+					return fakeOSReleaseContent(version.ReleaseVersion), nil
+				},
+				InspectFunc: func(_ context.Context, _ ...string) ([]imageutils.BulkInspectResult, error) {
+					t.Fatal("Inspect should not be called when the OCP version check succeeds")
+					return nil, nil
+				},
+			},
+		},
+		{
+			name: "OCP version mismatch",
+			inspector: &fakeImagesInspector{
+				FetchImageFileFunc: func(_ context.Context, _, _ string) ([]byte, error) {
+					return fakeOSReleaseContent("999.999"), nil
+				},
+			},
+			errorContains: "does not match the cluster's OCP version",
+		},
+		{
+			name: "no os-release, digest fallback matches",
+			inspector: &fakeImagesInspector{
+				FetchImageFileFunc: func(_ context.Context, _, _ string) ([]byte, error) {
+					return nil, fmt.Errorf("no such file")
+				},
+				InspectFunc: func(_ context.Context, image ...string) ([]imageutils.BulkInspectResult, error) {
+					return inspectResultWithLabels(image[0], map[string]string{
+						preBuiltImageBaseOSLabelKey: expectedBaseOSImage,
+					}), nil
+				},
+			},
+		},
+		{
+			name: "no os-release, digest mismatch",
+			inspector: &fakeImagesInspector{
+				FetchImageFileFunc: func(_ context.Context, _, _ string) ([]byte, error) {
+					return nil, fmt.Errorf("no such file")
+				},
+				InspectFunc: func(_ context.Context, image ...string) ([]imageutils.BulkInspectResult, error) {
+					return inspectResultWithLabels(image[0], map[string]string{
+						preBuiltImageBaseOSLabelKey: "registry.host.com/os@sha256:" + testDigestA,
+					}), nil
+				},
+			},
+			errorContains: "does not match the cluster's resolved base OS image",
+		},
+		{
+			name: "neither OPENSHIFT_VERSION nor baseOSContainerImage label available",
+			inspector: &fakeImagesInspector{
+				FetchImageFileFunc: func(_ context.Context, _, _ string) ([]byte, error) {
+					return nil, fmt.Errorf("no such file")
+				},
+				InspectFunc: func(_ context.Context, image ...string) ([]imageutils.BulkInspectResult, error) {
+					return inspectResultWithLabels(image[0], map[string]string{}), nil
+				},
+			},
+		},
+		{
+			name: "Inspect call itself fails (registry unreachable)",
+			inspector: &fakeImagesInspector{
+				FetchImageFileFunc: func(_ context.Context, _, _ string) ([]byte, error) {
+					return nil, fmt.Errorf("no such file")
+				},
+				InspectFunc: func(_ context.Context, _ ...string) ([]imageutils.BulkInspectResult, error) {
+					return nil, fmt.Errorf("dial tcp: no route to host")
+				},
+			},
+			errorContains: "could not inspect pre-built image",
+		},
+		{
+			name: "Inspect returns a per-image error (registry unreachable or image not found)",
+			inspector: &fakeImagesInspector{
+				FetchImageFileFunc: func(_ context.Context, _, _ string) ([]byte, error) {
+					return nil, fmt.Errorf("no such file")
+				},
+				InspectFunc: func(_ context.Context, image ...string) ([]imageutils.BulkInspectResult, error) {
+					return inspectResultWithError(image[0], fmt.Errorf("manifest unknown")), nil
+				},
+			},
+			errorContains: "could not access pre-built image",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validatePreBuiltImageVersion(context.Background(), tt.inspector, imageSpec, expectedBaseOSImage)
+			if tt.errorContains != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errorContains)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestCreatePreBuiltImageMachineConfigs(t *testing.T) {
+	pools := []*mcfgv1.MachineConfigPool{
+		{ObjectMeta: metav1.ObjectMeta{Name: "layered-worker"}},
+	}
+	cconfig := &mcfgv1.ControllerConfig{
+		Spec: mcfgv1.ControllerConfigSpec{
+			BaseOSContainerImage: "registry.host.com/os@sha256:" + testDigestB,
+		},
+	}
+	preBuiltImage := "quay.io/example/layered@sha256:" + testDigestA
+
+	versionMatchingInspector := &fakeImagesInspector{
+		FetchImageFileFunc: func(_ context.Context, _, _ string) ([]byte, error) {
+			return fakeOSReleaseContent(version.ReleaseVersion), nil
+		},
+	}
+
+	newMOSC := func(annotations map[string]string, conditions []metav1.Condition) *mcfgv1.MachineOSConfig {
+		return &mcfgv1.MachineOSConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "layered-worker",
+				Annotations: annotations,
+			},
+			Spec: mcfgv1.MachineOSConfigSpec{
+				MachineConfigPool: mcfgv1.MachineConfigPoolReference{Name: "layered-worker"},
+			},
+			Status: mcfgv1.MachineOSConfigStatus{
+				Conditions: conditions,
+			},
+		}
+	}
+
+	t.Run("valid pre-built image produces a component MachineConfig", func(t *testing.T) {
+		mosc := newMOSC(map[string]string{buildconstants.PreBuiltImageAnnotationKey: preBuiltImage}, nil)
+		mcs, err := createPreBuiltImageMachineConfigs(context.Background(), []*mcfgv1.MachineOSConfig{mosc}, pools, cconfig, versionMatchingInspector)
+		require.NoError(t, err)
+		require.Len(t, mcs, 1)
+	})
+
+	t.Run("missing annotation before seeding fails", func(t *testing.T) {
+		mosc := newMOSC(nil, nil)
+		_, err := createPreBuiltImageMachineConfigs(context.Background(), []*mcfgv1.MachineOSConfig{mosc}, pools, cconfig, versionMatchingInspector)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "is missing required annotation")
+	})
+
+	t.Run("missing annotation after seeding is skipped", func(t *testing.T) {
+		mosc := newMOSC(nil, []metav1.Condition{{
+			Type:   buildconstants.MachineOSConfigSeeded,
+			Status: metav1.ConditionTrue,
+		}})
+		mcs, err := createPreBuiltImageMachineConfigs(context.Background(), []*mcfgv1.MachineOSConfig{mosc}, pools, cconfig, versionMatchingInspector)
+		require.NoError(t, err)
+		assert.Empty(t, mcs)
+	})
+
+	t.Run("non-existent pool fails", func(t *testing.T) {
+		mosc := newMOSC(map[string]string{buildconstants.PreBuiltImageAnnotationKey: preBuiltImage}, nil)
+		mosc.Spec.MachineConfigPool.Name = "does-not-exist"
+		_, err := createPreBuiltImageMachineConfigs(context.Background(), []*mcfgv1.MachineOSConfig{mosc}, pools, cconfig, versionMatchingInspector)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "references non-existent pool")
+	})
+
+	t.Run("invalid image format fails", func(t *testing.T) {
+		mosc := newMOSC(map[string]string{buildconstants.PreBuiltImageAnnotationKey: "quay.io/example/layered:latest"}, nil)
+		_, err := createPreBuiltImageMachineConfigs(context.Background(), []*mcfgv1.MachineOSConfig{mosc}, pools, cconfig, versionMatchingInspector)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid pre-built image")
+	})
+
+	t.Run("OCP version mismatch fails", func(t *testing.T) {
+		mismatchInspector := &fakeImagesInspector{
+			FetchImageFileFunc: func(_ context.Context, _, _ string) ([]byte, error) {
+				return fakeOSReleaseContent("999.999"), nil
+			},
+		}
+		mosc := newMOSC(map[string]string{buildconstants.PreBuiltImageAnnotationKey: preBuiltImage}, nil)
+		_, err := createPreBuiltImageMachineConfigs(context.Background(), []*mcfgv1.MachineOSConfig{mosc}, pools, cconfig, mismatchInspector)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed validation")
+	})
 }


### PR DESCRIPTION
**- What I did**
- validates the OCP version by fetching the os release file(through inspectorFactory), then checking for a digest comparison against the clusters resolved base OS image when thats not available
- Verifies registry accessibility as a side effect if it is not able to fetch the image at both steps 
- Added unit tests covering version match/mismatch, digest fallback, missing-label warn-through, and registry-failure cases.

**- How to verify it**

-`go test ./pkg/controller/bootstrap/...`

or
 
- Seed a MachineOSConfig with the machineconfiguration.openshift.io/pre-built-image annotation pointing at a digested image whose /etc/os-release OPENSHIFT_VERSION doesn't match the cluster's release version, bootstrap should fail with an error like `pre-built image "..." OCP version "X.Y" does not match the cluster's OCP version "A.B".`
- Point the annotation at an unreachable/nonexistent registry, bootstrap should fail with `could not access pre-built image "..." (registry unreachable or image not found): ....`
- Point the annotation at a correctly-versioned pre-built image, bootstrap should succeed as before.

**- Description for the changelog**
Add OCP-version-match and registry-accessibility validation for hybrid-OCL pre-built images at bootstrap time
[MCO-1906](https://redhat.atlassian.net/browse/MCO-1906)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of pre-built images during installation.
  * Checks image compatibility with the cluster’s OpenShift major and minor versions.
  * Supports registry inspection and digest-based fallback validation when image metadata is unavailable.
  * Handles image inspection failures more clearly.
  * Improves error handling when creating machine configurations.
  * Expanded coverage for image parsing, version comparison, fallback validation, and related error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->