### PR TITLE
OCPBUGS-100458: Adapt bootimage tests for CAPI migration

### DIFF
--- a/test/extended-priv/machineset.go
+++ b/test/extended-priv/machineset.go
@@ -409,6 +409,7 @@ func (msl *MachineSetList) GetAll() ([]*MachineSet, error) {
 func (msl *MachineSetList) GetAllOrFail() []*MachineSet {
 	allMs, err := msl.GetAll()
 	o.ExpectWithOffset(1, err).NotTo(o.HaveOccurred(), "Error getting the list of existing MachineSets")
+	o.ExpectWithOffset(1, allMs).NotTo(o.BeEmpty(), "No MachineSets found in namespace %s", msl.GetNamespace())
 
 	return allMs
 }

--- a/test/extended-priv/mco_bootimages_aws_marketplace.go
+++ b/test/extended-priv/mco_bootimages_aws_marketplace.go
@@ -45,6 +45,8 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/disruptive
 	)
 
 	g.JustBeforeEach(func() {
+		// Skip if no MAPI MachineSets are available (e.g. compute machine management migrated to CAPI)
+		exutil.SkipIfNoMAPIMachineSets(oc.AsAdmin())
 		machineConfiguration = GetMachineConfiguration(oc.AsAdmin())
 		PreChecks(oc)
 

--- a/test/extended-priv/mco_bootimages_skew.go
+++ b/test/extended-priv/mco_bootimages_skew.go
@@ -94,6 +94,9 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/disruptive
 
 		exutil.SkipIfUnsupportedOSStreamLabel(oc.AsAdmin())
 
+		// This test only supports clusters managing compute machines via legacy MAPI MachineSets
+		exutil.SkipIfNoMAPIMachineSets(oc.AsAdmin())
+
 		// No opinion on skew enforcement for these platforms will result in Automatic mode
 		o.Expect(machineConfiguration.RemoveSkew()).To(o.Succeed())
 
@@ -130,6 +133,9 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/disruptive
 		skipTestIfSupportedPlatformNotMatched(oc, GCPPlatform, AWSPlatform, AzurePlatform, VspherePlatform)
 
 		exutil.SkipIfUnsupportedOSStreamLabel(oc.AsAdmin())
+
+		// This test only supports clusters managing compute machines via legacy MAPI MachineSets
+		exutil.SkipIfNoMAPIMachineSets(oc.AsAdmin())
 
 		// No opinion on skew enforcement for these platforms will result in Automatic mode
 		o.Expect(machineConfiguration.RemoveSkew()).To(o.Succeed())

--- a/test/extended-priv/util/clusters.go
+++ b/test/extended-priv/util/clusters.go
@@ -104,3 +104,20 @@ func SkipOnSingleNodeTopology(oc *CLI) {
 		e2eskipper.Skipf("This test does not apply to single-node topologies")
 	}
 }
+
+// SkipIfNoMAPIMachineSets skips the test if the cluster has no legacy MAPI MachineSets
+// (machinesets.machine.openshift.io) in the openshift-machine-api namespace. Clusters that
+// have migrated compute machine management to Cluster API no longer have any MAPI MachineSets, 
+// only CAPI ones under cluster.x-k8s.io in the openshift-cluster-api namespace, which these tests 
+// do not yet support.
+func SkipIfNoMAPIMachineSets(oc *CLI) {
+	out, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(
+		"machinesets.machine.openshift.io", "-n", "openshift-machine-api",
+		"-o", "jsonpath={range .items[*]}{.metadata.name}{end}",
+	).Output()
+	o.Expect(err).NotTo(o.HaveOccurred(), "failed to list machinesets")
+	if out == "" {
+		e2eskipper.Skipf("No MAPI MachineSets (machinesets.machine.openshift.io) found in openshift-machine-api; " +
+			"this test does not yet support clusters where compute machine management has been migrated to Cluster API")
+	}
+}

--- a/test/extended/osImageStream.go
+++ b/test/extended/osImageStream.go
@@ -13,7 +13,6 @@ import (
 	logger "github.com/openshift/machine-config-operator/test/extended-priv/util/logext"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 )
 
 const (
@@ -33,8 +32,8 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/disruptive
 	)
 
 	g.JustBeforeEach(func() {
-		// Skip this test if the cluster is not using MachineAPI
-		skipUnlessFunctionalMachineAPI(oc)
+		// Skip if no MAPI MachineSets are available (e.g. compute machine management migrated to CAPI)
+		exutil.SkipIfNoMAPIMachineSets(oc.AsAdmin())
 	})
 
 	g.It("Machines, MachineSets, and ControlPlaneMachineSets (if applicable) are labeled with OSStream [apigroup:machineconfiguration.openshift.io]", func() {
@@ -119,34 +118,6 @@ func validateOSStreamLabelOnControlPlaneMachineSet(machineClient *machineclient.
 	osStream, hasLabel := cpms.Labels[OSStreamLabelKey]
 	osStreamTemp, hasLabelTemp := cpms.Spec.Template.OpenShiftMachineV1Beta1Machine.ObjectMeta.Labels[OSStreamLabelKey]
 	return hasLabel && slices.Contains(expectedOSStreams, osStream) && hasLabelTemp && slices.Contains(expectedOSStreams, osStreamTemp)
-}
-
-// skipUnlessFunctionalMachineAPI skips the test if the cluster is not using Machine API
-func skipUnlessFunctionalMachineAPI(oc *exutil.CLI) {
-	machineClient, err := machineclient.NewForConfig(oc.KubeFramework().ClientConfig())
-	o.Expect(err).ToNot(o.HaveOccurred())
-	machines, err := machineClient.MachineV1beta1().Machines(MAPINamespace).List(context.Background(), metav1.ListOptions{LabelSelector: MAPIMasterMachineLabelSelector})
-	// the machine API can be unavailable resulting in a 404 or an empty list
-	if err != nil {
-		if !apierrors.IsNotFound(err) {
-			o.Expect(err).ToNot(o.HaveOccurred())
-		}
-		g.Skip("haven't found machines resources on the cluster, this test can be run on a platform that supports functional MachineAPI")
-		return
-	}
-	if len(machines.Items) == 0 {
-		g.Skip("got an empty list of machines resources from the cluster, this test can be run on a platform that supports functional MachineAPI")
-		return
-	}
-
-	// we expect just a single machine to be in the Running state
-	for _, machine := range machines.Items {
-		phase := ptr.Deref(machine.Status.Phase, "")
-		if phase == "Running" {
-			return
-		}
-	}
-	g.Skip("haven't found a machine in running state, this test can be run on a platform that supports functional MachineAPI")
 }
 
 // getAllMachineSets returns all the MachineSets in a cluster


### PR DESCRIPTION
**- What I did**
This PR skips the Automatic mode skew enforcement tests if no MAPI resources are detected. This is necessary on AWS because openshift has migrated to using CAPI resources on 5.0 tech preview installations. Once the boot image controller is updated to handle these cases, these tests can be updated alongside. 

**- How to verify it**
Running the AWS disruptive test against this should be sufficient to verify this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation when no MachineSets are available by reporting the affected namespace.
  * Prevented unsupported upgrade, boot-image, and OS image tests from running when legacy MachineSets are unavailable.
  * Standardized MachineSet availability checks across tests.
  * Test setup now distinguishes unavailable cluster data from command failures, providing clearer outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->