### PR TITLE
MCO-2485: Mark scale-up test as 'informing'

### DIFF
--- a/test/extended-priv/mco_irreconcilablechanges.go
+++ b/test/extended-priv/mco_irreconcilablechanges.go
@@ -163,7 +163,7 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/disruptive
 		logger.Infof("All worker nodes have irreconcilable changes as expected!\n")
 	})
 
-	g.It("[PolarionID:84219] Verify irreconcilable changes on new and existing nodes after scale up [Disruptive]", g.Label("Platform:aws", "Platform:gce", "Platform:azure", "Platform:vsphere"), func() {
+	g.It("[PolarionID:84219] Verify irreconcilable changes on new and existing nodes after scale up [Disruptive]", g.Label("Lifecycle:informing", "Platform:aws", "Platform:gce", "Platform:azure", "Platform:vsphere"), func() {
 		var (
 			machineconfiguration = GetMachineConfiguration(oc)
 			mcName               = "irreconcilable-scaleup-test"


### PR DESCRIPTION
Added "informing" label to Irreconcilable Changes scale-up test

**- What I did**
Added label `g.Label("Lifecycle:informing")` to scale-up test

**- How to verify it**
1. Run `./_output/linux/amd64/machine-config-tests-ext list | less` and look for scale up test

```
{
    "name": "[sig-mco][Suite:openshift/machine-config-operator/disruptive][Disruptive][OCPFeatureGate:IrreconcilableMachineConfig][Serial] [PolarionID:84219] Verify irreconcilable changes on new and existing no
des after scale up [Disruptive]",
    "labels": {
      "Lifecycle:informing": {},
      "Platform:aws": {},
      "Platform:azure": {},
      "Platform:gce": {},
      "Platform:vsphere": {}
    },
    "resources": {
      "isolation": {}
    },
    "source": "openshift:payload:machine-config-operator",
    "codeLocations": [
      "/home/fproiett/Projects/machine-config-operator/test/extended-priv/mco_irreconcilablechanges.go:99",
      "/home/fproiett/Projects/machine-config-operator/test/extended-priv/util/client.go:109",
      "set up framework | framework.go:302",
      "/home/fproiett/Projects/machine-config-operator/test/extended-priv/util/client.go:117",
      "/home/fproiett/Projects/machine-config-operator/test/extended-priv/mco_irreconcilablechanges.go:107",
      "/home/fproiett/Projects/machine-config-operator/test/extended-priv/mco_irreconcilablechanges.go:166"
    ],
    "lifecycle": "informing",
    "environmentSelector": {
      "include": "(((platform==\"aws\") || (platform==\"gce\")) || (platform==\"azure\")) || (platform==\"vsphere\")"
    }
  }
```
`"lifecycle"` key should be set `"informing"`

All other IC tests should have `"lifecycle":"blocking"`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the scale-up irreconcilable-changes test with the `Lifecycle:informing` label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->