### PR TITLE
OCPBUGS-100292: Fix MCO degradation issue when Cluster API Machine resource is missing

### DIFF
--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -1985,19 +1985,30 @@ func (optr *Operator) waitForControllerConfigToBeCompleted(resource *mcfgv1.Cont
 }
 
 func (optr *Operator) getOSImageURLsFromConfigMap() (string, string, error) {
-	cm, err := optr.mcoCmLister.ConfigMaps(optr.namespace).Get(ctrlcommon.MachineConfigOSImageURLConfigMapName)
-	if err != nil {
-		return "", "", err
+	var oscontainer, osextensionscontainer string
+	var lastErr error
+	if err := wait.PollUntilContextTimeout(context.TODO(), 1*time.Second, 3*time.Second, true, func(_ context.Context) (bool, error) {
+		cm, err := optr.mcoCmLister.ConfigMaps(optr.namespace).Get(ctrlcommon.MachineConfigOSImageURLConfigMapName)
+		if err != nil {
+			lastErr = err
+			return false, nil
+		}
+		cfg, err := ctrlcommon.ParseOSImageURLConfigMap(cm)
+		if err != nil {
+			return false, err
+		}
+		optrVersion, _ := optr.vStore.Get("operator")
+		if cfg.ReleaseVersion != optrVersion {
+			lastErr = fmt.Errorf("refusing to read osImageURL version %q, operator version %q", cfg.ReleaseVersion, optrVersion)
+			return false, nil
+		}
+		oscontainer = cfg.BaseOSContainerImage
+		osextensionscontainer = cfg.BaseOSExtensionsContainerImage
+		return true, nil
+	}); err != nil {
+		return "", "", fmt.Errorf("during osImageURL configmap check: %w", kubeErrs.NewAggregate([]error{err, lastErr}))
 	}
-	cfg, err := ctrlcommon.ParseOSImageURLConfigMap(cm)
-	if err != nil {
-		return "", "", err
-	}
-	optrVersion, _ := optr.vStore.Get("operator")
-	if cfg.ReleaseVersion != optrVersion {
-		return "", "", fmt.Errorf("refusing to read osImageURL version %q, operator version %q", cfg.ReleaseVersion, optrVersion)
-	}
-	return cfg.BaseOSContainerImage, cfg.BaseOSExtensionsContainerImage, nil
+	return oscontainer, osextensionscontainer, nil
 }
 
 // getOSImageURLForStream retrieves the OS image URL for a specific pool's stream.

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -350,8 +350,12 @@ func (optr *Operator) syncCloudConfig(spec *mcfgv1.ControllerConfigSpec, infra *
 			if apierrors.IsNotFound(err) {
 				if isKubeCloudConfigCMRequired(infra) {
 					// Return error only if the kube-cloud-config ConfigMap is required, otherwise proceeds further.
+					platformType := "Unknown"
+					if infra.Status.PlatformStatus != nil {
+						platformType = string(infra.Status.PlatformStatus.Type)
+					}
 					lastErr = fmt.Errorf("%s/%s configmap is required on platform %s but not found: %w",
-						"openshift-config-managed", "kube-cloud-config", infra.Status.PlatformStatus.Type, err)
+						"openshift-config-managed", "kube-cloud-config", platformType, err)
 					return false, nil
 				}
 				return true, nil

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -343,34 +343,44 @@ func (optr *Operator) getImageRegistryBundles() ([]mcfgv1.ImageRegistryBundle, [
 
 // Sync cloud config on supported platform from cloud.conf available in openshift-config-managed/kube-cloud-config ConfigMap.
 func (optr *Operator) syncCloudConfig(spec *mcfgv1.ControllerConfigSpec, infra *configv1.Infrastructure) error {
-	cm, err := optr.clusterCmLister.ConfigMaps("openshift-config-managed").Get("kube-cloud-config")
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			if isKubeCloudConfigCMRequired(infra) {
-				// Return error only if the kube-cloud-config ConfigMap is required, otherwise proceeds further.
-				return fmt.Errorf("%s/%s configmap is required on platform %s but not found: %w",
-					"openshift-config-managed", "kube-cloud-config", infra.Status.PlatformStatus.Type, err)
+	var lastErr error
+	if err := wait.PollUntilContextTimeout(context.TODO(), 1*time.Second, 3*time.Second, true, func(_ context.Context) (bool, error) {
+		cm, err := optr.clusterCmLister.ConfigMaps("openshift-config-managed").Get("kube-cloud-config")
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				if isKubeCloudConfigCMRequired(infra) {
+					// Return error only if the kube-cloud-config ConfigMap is required, otherwise proceeds further.
+					lastErr = fmt.Errorf("%s/%s configmap is required on platform %s but not found: %w",
+						"openshift-config-managed", "kube-cloud-config", infra.Status.PlatformStatus.Type, err)
+					return false, nil
+				}
+				return true, nil
 			}
-			return nil
+			lastErr = err
+			return false, nil
 		}
-		return err
-	}
-	// Read cloud.conf from openshift-config-managed/kube-cloud-config ConfigMap.
-	cc, err := getCloudConfigFromConfigMap(cm, "cloud.conf")
-	if err != nil {
-		if isCloudConfRequired(infra) {
-			// Return error only if cloud.conf is required, otherwise proceeds further.
-			return fmt.Errorf("%s/%s configmap must have the %s key on platform %s but not found",
-				"openshift-config-managed", "kube-cloud-config", "cloud.conf", infra.Status.PlatformStatus.Type)
+		// Read cloud.conf from openshift-config-managed/kube-cloud-config ConfigMap.
+		cc, err := getCloudConfigFromConfigMap(cm, "cloud.conf")
+		if err != nil {
+			if isCloudConfRequired(infra) {
+				// Return error only if cloud.conf is required, otherwise proceeds further.
+				lastErr = fmt.Errorf("%s/%s configmap must have the %s key on platform %s but not found",
+					"openshift-config-managed", "kube-cloud-config", "cloud.conf", infra.Status.PlatformStatus.Type)
+				return false, nil
+			}
+		} else {
+			spec.CloudProviderConfig = cc
 		}
-	} else {
-		spec.CloudProviderConfig = cc
+
+		caCert, err := ctrlcommon.GetCAsFromConfigMap(cm, "ca-bundle.pem")
+		if err == nil {
+			spec.CloudProviderCAData = caCert
+		}
+		return true, nil
+	}); err != nil {
+		return fmt.Errorf("during kube-cloud-config check: %w", kubeErrs.NewAggregate([]error{err, lastErr}))
 	}
 
-	caCert, err := ctrlcommon.GetCAsFromConfigMap(cm, "ca-bundle.pem")
-	if err == nil {
-		spec.CloudProviderCAData = caCert
-	}
 	return nil
 }
 

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -345,34 +345,44 @@ func (optr *Operator) getImageRegistryBundles() ([]mcfgv1.ImageRegistryBundle, [
 
 // Sync cloud config on supported platform from cloud.conf available in openshift-config-managed/kube-cloud-config ConfigMap.
 func (optr *Operator) syncCloudConfig(spec *mcfgv1.ControllerConfigSpec, infra *configv1.Infrastructure) error {
-	cm, err := optr.clusterCmLister.ConfigMaps("openshift-config-managed").Get("kube-cloud-config")
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			if isKubeCloudConfigCMRequired(infra) {
-				// Return error only if the kube-cloud-config ConfigMap is required, otherwise proceeds further.
-				return fmt.Errorf("%s/%s configmap is required on platform %s but not found: %w",
-					"openshift-config-managed", "kube-cloud-config", infra.Status.PlatformStatus.Type, err)
+	var lastErr error
+	if err := wait.PollUntilContextTimeout(context.TODO(), 1*time.Second, 3*time.Second, true, func(_ context.Context) (bool, error) {
+		cm, err := optr.clusterCmLister.ConfigMaps("openshift-config-managed").Get("kube-cloud-config")
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				if isKubeCloudConfigCMRequired(infra) {
+					// Return error only if the kube-cloud-config ConfigMap is required, otherwise proceeds further.
+					lastErr = fmt.Errorf("%s/%s configmap is required on platform %s but not found: %w",
+						"openshift-config-managed", "kube-cloud-config", infra.Status.PlatformStatus.Type, err)
+					return false, nil
+				}
+				return true, nil
 			}
-			return nil
+			lastErr = err
+			return false, nil
 		}
-		return err
-	}
-	// Read cloud.conf from openshift-config-managed/kube-cloud-config ConfigMap.
-	cc, err := getCloudConfigFromConfigMap(cm, "cloud.conf")
-	if err != nil {
-		if isCloudConfRequired(infra) {
-			// Return error only if cloud.conf is required, otherwise proceeds further.
-			return fmt.Errorf("%s/%s configmap must have the %s key on platform %s but not found",
-				"openshift-config-managed", "kube-cloud-config", "cloud.conf", infra.Status.PlatformStatus.Type)
+		// Read cloud.conf from openshift-config-managed/kube-cloud-config ConfigMap.
+		cc, err := getCloudConfigFromConfigMap(cm, "cloud.conf")
+		if err != nil {
+			if isCloudConfRequired(infra) {
+				// Return error only if cloud.conf is required, otherwise proceeds further.
+				lastErr = fmt.Errorf("%s/%s configmap must have the %s key on platform %s but not found",
+					"openshift-config-managed", "kube-cloud-config", "cloud.conf", infra.Status.PlatformStatus.Type)
+				return false, nil
+			}
+		} else {
+			spec.CloudProviderConfig = cc
 		}
-	} else {
-		spec.CloudProviderConfig = cc
+
+		caCert, err := ctrlcommon.GetCAsFromConfigMap(cm, "ca-bundle.pem")
+		if err == nil {
+			spec.CloudProviderCAData = caCert
+		}
+		return true, nil
+	}); err != nil {
+		return fmt.Errorf("during kube-cloud-config check: %w", kubeErrs.NewAggregate([]error{err, lastErr}))
 	}
 
-	caCert, err := ctrlcommon.GetCAsFromConfigMap(cm, "ca-bundle.pem")
-	if err == nil {
-		spec.CloudProviderCAData = caCert
-	}
 	return nil
 }
 


### PR DESCRIPTION
MCO goes Degraded when Cluster API Machine resource is not found during node mapping

**- What I did**

Implemented a Poll with 3s timeout inside getOSImageURLsFromConfigMap() to tolerate transient not found errors and version mismatches, trying to prevent MCO from going Degraded on a recoverable race condition.

**- How to verify it**

run `periodic-ci-openshift-release-main-ci-5.0-e2e-aws-ovn-techpreview-serial-2of3` job. Errors on `[Monitor:legacy-cvo-invariants][bz-Machine Config Operator] clusteroperator/machine-config should not change condition/Degraded` with reason `openshift-config-managed/kube-cloud-config configmap is required on platform AWS but not found: configmap "kube-cloud-config" not found` should not appear.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when retrieving required cloud configuration by retrying temporary availability failures.
  * Added clearer timeout reporting when required configuration remains unavailable.
  * Continued gracefully when optional configuration is missing.
  * Applied available cloud configuration and certificate authority data whenever provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->