### PR TITLE
OCPBUGS-65504: machine-config ClusterOperator relatedObjects missing ClusterRoleBinding

### DIFF
--- a/install/0000_80_machine-config_06_clusteroperator.yaml
+++ b/install/0000_80_machine-config_06_clusteroperator.yaml
@@ -27,5 +27,55 @@ status:
       resource: kubeletconfigs
     - group: machineconfiguration.openshift.io
       resource: containerruntimeconfigs
+    - group: operator.openshift.io
+      resource: machineconfigurations
     - group: ""
       resource: nodes
+    - group: rbac.authorization.k8s.io
+      name: machine-config-controller
+      resource: clusterroles
+    - group: rbac.authorization.k8s.io
+      name: machine-config-controller-events
+      resource: clusterroles
+    - group: rbac.authorization.k8s.io
+      name: machine-config-daemon
+      resource: clusterroles
+    - group: rbac.authorization.k8s.io
+      name: machine-config-daemon-events
+      resource: clusterroles
+    - group: rbac.authorization.k8s.io
+      name: machine-config-server
+      resource: clusterroles
+    - group: rbac.authorization.k8s.io
+      name: machine-os-builder
+      resource: clusterroles
+    - group: rbac.authorization.k8s.io
+      name: machine-os-builder-events
+      resource: clusterroles
+    - group: rbac.authorization.k8s.io
+      name: "system:openshift:machine-config-operator:cluster-reader"
+      resource: clusterroles
+    - group: rbac.authorization.k8s.io
+      name: machine-config-controller
+      resource: clusterrolebindings
+    - group: rbac.authorization.k8s.io
+      name: machine-config-daemon
+      resource: clusterrolebindings
+    - group: rbac.authorization.k8s.io
+      name: machine-config-server
+      resource: clusterrolebindings
+    - group: rbac.authorization.k8s.io
+      name: machine-os-builder
+      resource: clusterrolebindings
+    - group: rbac.authorization.k8s.io
+      name: machine-os-builder-anyuid
+      resource: clusterrolebindings
+    - group: rbac.authorization.k8s.io
+      name: custom-account-openshift-machine-config-operator
+      resource: clusterrolebindings
+    - group: rbac.authorization.k8s.io
+      name: system-bootstrap-node-bootstrapper
+      resource: clusterrolebindings
+    - group: rbac.authorization.k8s.io
+      name: system-bootstrap-node-renewal
+      resource: clusterrolebindings

--- a/pkg/operator/status.go
+++ b/pkg/operator/status.go
@@ -72,6 +72,23 @@ func (optr *Operator) syncRelatedObjects(co *configv1.ClusterOperator) {
 		{Resource: "namespaces", Name: "openshift-vsphere-infra"},
 		{Resource: "namespaces", Name: "openshift-nutanix-infra"},
 		{Resource: "namespaces", Name: "openshift-cloud-platform-infra"},
+		// ClusterRoles and ClusterRoleBindings are cluster-scoped and not implicitly gathered via namespace inspection.
+		{Group: "rbac.authorization.k8s.io", Resource: "clusterroles", Name: "machine-config-controller"},
+		{Group: "rbac.authorization.k8s.io", Resource: "clusterroles", Name: "machine-config-controller-events"},
+		{Group: "rbac.authorization.k8s.io", Resource: "clusterroles", Name: "machine-config-daemon"},
+		{Group: "rbac.authorization.k8s.io", Resource: "clusterroles", Name: "machine-config-daemon-events"},
+		{Group: "rbac.authorization.k8s.io", Resource: "clusterroles", Name: "machine-config-server"},
+		{Group: "rbac.authorization.k8s.io", Resource: "clusterroles", Name: "machine-os-builder"},
+		{Group: "rbac.authorization.k8s.io", Resource: "clusterroles", Name: "machine-os-builder-events"},
+		{Group: "rbac.authorization.k8s.io", Resource: "clusterroles", Name: "system:openshift:machine-config-operator:cluster-reader"},
+		{Group: "rbac.authorization.k8s.io", Resource: "clusterrolebindings", Name: "machine-config-controller"},
+		{Group: "rbac.authorization.k8s.io", Resource: "clusterrolebindings", Name: "machine-config-daemon"},
+		{Group: "rbac.authorization.k8s.io", Resource: "clusterrolebindings", Name: "machine-config-server"},
+		{Group: "rbac.authorization.k8s.io", Resource: "clusterrolebindings", Name: "machine-os-builder"},
+		{Group: "rbac.authorization.k8s.io", Resource: "clusterrolebindings", Name: "machine-os-builder-anyuid"},
+		{Group: "rbac.authorization.k8s.io", Resource: "clusterrolebindings", Name: "custom-account-openshift-machine-config-operator"},
+		{Group: "rbac.authorization.k8s.io", Resource: "clusterrolebindings", Name: "system-bootstrap-node-bootstrapper"},
+		{Group: "rbac.authorization.k8s.io", Resource: "clusterrolebindings", Name: "system-bootstrap-node-renewal"},
 	}
 
 	if !equality.Semantic.DeepEqual(coStatusCopy.RelatedObjects, co.Status.RelatedObjects) {
@@ -475,6 +492,23 @@ func (optr *Operator) initializeClusterOperator() (*configv1.ClusterOperator, er
 		{Group: "machineconfiguration.openshift.io", Resource: "machineconfigpools", Name: "worker"},
 		{Group: "machineconfiguration.openshift.io", Resource: "controllerconfigs", Name: "machine-config-controller"},
 		{Group: "operator.openshift.io", Resource: "machineconfigurations"},
+		// ClusterRoles and ClusterRoleBindings are cluster-scoped and not implicitly gathered via namespace inspection.
+		{Group: "rbac.authorization.k8s.io", Resource: "clusterroles", Name: "machine-config-controller"},
+		{Group: "rbac.authorization.k8s.io", Resource: "clusterroles", Name: "machine-config-controller-events"},
+		{Group: "rbac.authorization.k8s.io", Resource: "clusterroles", Name: "machine-config-daemon"},
+		{Group: "rbac.authorization.k8s.io", Resource: "clusterroles", Name: "machine-config-daemon-events"},
+		{Group: "rbac.authorization.k8s.io", Resource: "clusterroles", Name: "machine-config-server"},
+		{Group: "rbac.authorization.k8s.io", Resource: "clusterroles", Name: "machine-os-builder"},
+		{Group: "rbac.authorization.k8s.io", Resource: "clusterroles", Name: "machine-os-builder-events"},
+		{Group: "rbac.authorization.k8s.io", Resource: "clusterroles", Name: "system:openshift:machine-config-operator:cluster-reader"},
+		{Group: "rbac.authorization.k8s.io", Resource: "clusterrolebindings", Name: "machine-config-controller"},
+		{Group: "rbac.authorization.k8s.io", Resource: "clusterrolebindings", Name: "machine-config-daemon"},
+		{Group: "rbac.authorization.k8s.io", Resource: "clusterrolebindings", Name: "machine-config-server"},
+		{Group: "rbac.authorization.k8s.io", Resource: "clusterrolebindings", Name: "machine-os-builder"},
+		{Group: "rbac.authorization.k8s.io", Resource: "clusterrolebindings", Name: "machine-os-builder-anyuid"},
+		{Group: "rbac.authorization.k8s.io", Resource: "clusterrolebindings", Name: "custom-account-openshift-machine-config-operator"},
+		{Group: "rbac.authorization.k8s.io", Resource: "clusterrolebindings", Name: "system-bootstrap-node-bootstrapper"},
+		{Group: "rbac.authorization.k8s.io", Resource: "clusterrolebindings", Name: "system-bootstrap-node-renewal"},
 	}
 	// During an installation we report the RELEASE_VERSION as soon as the component is created.
 	// For both normal runs and upgrades, this code isn't hit and we get the right version every

--- a/pkg/operator/status_test.go
+++ b/pkg/operator/status_test.go
@@ -1329,3 +1329,48 @@ func TestCheckBootImageSkewUpgradeableGuard(t *testing.T) {
 		})
 	}
 }
+
+func TestSyncRelatedObjectsContainsRBAC(t *testing.T) {
+	optr := &Operator{
+		namespace: "openshift-machine-config-operator",
+	}
+	co := &configv1.ClusterOperator{}
+	optr.syncRelatedObjects(co)
+
+	var clusterRoles, clusterRoleBindings []string
+	for _, obj := range co.Status.RelatedObjects {
+		if obj.Group != "rbac.authorization.k8s.io" {
+			continue
+		}
+		switch obj.Resource {
+		case "clusterroles":
+			clusterRoles = append(clusterRoles, obj.Name)
+		case "clusterrolebindings":
+			clusterRoleBindings = append(clusterRoleBindings, obj.Name)
+		}
+	}
+
+	expectedClusterRoles := []string{
+		"machine-config-controller",
+		"machine-config-controller-events",
+		"machine-config-daemon",
+		"machine-config-daemon-events",
+		"machine-config-server",
+		"machine-os-builder",
+		"machine-os-builder-events",
+		"system:openshift:machine-config-operator:cluster-reader",
+	}
+	expectedClusterRoleBindings := []string{
+		"machine-config-controller",
+		"machine-config-daemon",
+		"machine-config-server",
+		"machine-os-builder",
+		"machine-os-builder-anyuid",
+		"custom-account-openshift-machine-config-operator",
+		"system-bootstrap-node-bootstrapper",
+		"system-bootstrap-node-renewal",
+	}
+
+	assert.ElementsMatch(t, expectedClusterRoles, clusterRoles, "relatedObjects must include all MCO ClusterRoles for oc adm inspect to collect them")
+	assert.ElementsMatch(t, expectedClusterRoleBindings, clusterRoleBindings, "relatedObjects must include all MCO ClusterRoleBindings for oc adm inspect to collect them")
+}


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
- ClusterRoles and ClusterRoleBindings are cluster-scoped, so `oc adm inspect` doesn't automatically collect them when inspecting a namespace they were silently missing from must gather output.
- Added all MCO-owned RBAC resources to relatedObjects in both syncRelatedObjects() and initializeClusterOperator() in status.go, covering 8 ClusterRoles and 8 ClusterRoleBindings 
- Mirrored the same list in the static ClusterOperator manifest (clusteroperator.yaml) so the install time object matches the runtime state.
- Added a unit test to assert all expected RBAC resources appear in relatedObjects after sync.

**- How to verify it**
Unit test: 
run ``go test ./pkg/operator/`` and confirm TestSyncRelatedObjectsContainsRBAC passes, which checks that all 8 ClusterRoles and 8 ClusterRoleBindings appear in relatedObjects after syncRelatedObjects() runs.

Live Cluster: 
- deploying, run `oc adm inspect clusteroperator/machine-config --dest-dir=/tmp/mco-inspect`
- Then check that the output directory contains files for the RBAC resources:
`ls /tmp/mco-inspect/cluster-scoped-resources/rbac.authorization.k8s.io/`
- You should see clusterroles/ and clusterrolebindings/ directories populated with MCO resources

**- Description for the changelog**
Add missing MCO ClusterRoles and ClusterRoleBindings to relatedObjects so oc adm inspect collects them
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved machine-config status reporting by including relevant cluster-scoped permissions and configuration resources.
  * Enhanced must-gather diagnostics with additional related objects for troubleshooting.
  * Improved visibility into machine-config components and their associated access resources during cluster health reviews and support investigations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->