### PR TITLE
OKD-419: Add missing variant check for SCOS

### DIFF
--- a/pkg/daemon/osrelease/osrelease.go
+++ b/pkg/daemon/osrelease/osrelease.go
@@ -17,6 +17,7 @@ const (
 
 // OS IDs
 const (
+	centos string = "centos"
 	coreos string = "coreos"
 	fedora string = "fedora"
 	rhel   string = "rhel"
@@ -117,7 +118,7 @@ func (os OperatingSystem) BaseVersionMinor() int {
 // https://github.com/openshift/enhancements/blob/master/enhancements/rhcos/split-rhcos-into-layers.md
 // Additional info here: https://github.com/openshift/enhancements/pull/1755
 func (os OperatingSystem) IsEL() bool {
-	return os.id == rhcos || os.id == scos || (os.id == rhel && os.variantID == coreos)
+	return os.id == rhcos || os.id == scos || (os.id == rhel && os.variantID == coreos) || (os.id == centos && os.variantID == coreos)
 }
 
 // IsEL8 is true if the OS is RHCOS 8 or SCOS 8

--- a/pkg/daemon/osrelease/osrelease_test.go
+++ b/pkg/daemon/osrelease/osrelease_test.go
@@ -156,6 +156,29 @@ VARIANT=CoreOS
 VARIANT_ID=coreos
 OPENSHIFT_VERSION="4.20"`
 
+	scos10OSReleaseContents := `NAME="CentOS Stream CoreOS"
+VERSION="10.0.20260614-0 (Coughlan)"
+RELEASE_TYPE=stable
+ID="centos"
+ID_LIKE="rhel fedora"
+VERSION_ID="10"
+PLATFORM_ID="platform:el10"
+PRETTY_NAME="CentOS Stream CoreOS 10.0.20260614-0 (Coughlan)"
+ANSI_COLOR="0;31"
+LOGO="fedora-logo-icon"
+CPE_NAME="cpe:/o:centos:centos:10"
+HOME_URL="https://centos.org/"
+VENDOR_NAME="CentOS"
+VENDOR_URL="https://centos.org/"
+BUG_REPORT_URL="https://issues.redhat.com/"
+REDHAT_SUPPORT_PRODUCT="Red Hat Enterprise Linux 10"
+REDHAT_SUPPORT_PRODUCT_VERSION="CentOS Stream"
+OSTREE_VERSION='10.0.20260614-0'
+IMAGE_VERSION='10.0.20260614-0'
+VARIANT=CoreOS
+VARIANT_ID=coreos
+OPENSHIFT_VERSION="5.0"`
+
 	testCases := []struct {
 		Name                   string
 		OSReleaseContents      string
@@ -251,6 +274,20 @@ OPENSHIFT_VERSION="4.20"`
 			IsLikeTraditionalRHEL7: false,
 			ToPrometheusLabel:      "FEDORA",
 			BaseVersionMajor:       37,
+			BaseVersionMinor:       -1,
+		},
+		{
+			Name:                   "SCOS 10",
+			OSReleaseContents:      scos10OSReleaseContents,
+			IsEL:                   true,
+			IsEL9:                  false,
+			IsEL10:                 true,
+			IsFCOS:                 false,
+			IsSCOS:                 false,
+			IsCoreOSVariant:        true,
+			IsLikeTraditionalRHEL7: false,
+			ToPrometheusLabel:      "CENTOS",
+			BaseVersionMajor:       10,
 			BaseVersionMinor:       -1,
 		},
 	}


### PR DESCRIPTION
Newer OKD releases use the `centos` ID with the `coreos` variant, similar to RHEL. This resolves issues with extensions not applying when an operator MachineConfig contains them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved operating system detection so CentOS Stream CoreOS is correctly recognized as an Enterprise Linux variant.
  * Added support for the CentOS OS identifier, helping the app classify this platform more accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->