### PR TITLE
NO-ISSUE: Add fix TC 63866 failing in CI job

### DIFF
--- a/test/extended-priv/node.go
+++ b/test/extended-priv/node.go
@@ -1618,6 +1618,7 @@ func ReplaceRpmOstree(node *Node, localScriptPath string) error {
 	}
 	_, err := node.DebugNodeWithChroot("sh", "-c",
 		"chmod +x "+fakeRpmOstreeRemotePath+" && "+
+			"{ nsenter --mount=/proc/1/ns/mnt umount -l /usr/bin/rpm-ostree 2>/dev/null || true; } && "+
 			"cp /usr/bin/rpm-ostree /var/tmp/rpm-ostree && "+
 			"nsenter --mount=/proc/1/ns/mnt mount --bind "+fakeRpmOstreeRemotePath+" /usr/bin/rpm-ostree && "+
 			"restorecon -v /usr/bin/rpm-ostree")

--- a/test/extended-priv/testdata/files/rpm-ostree-force-pivot-error.sh
+++ b/test/extended-priv/testdata/files/rpm-ostree-force-pivot-error.sh
@@ -1,12 +1,8 @@
 #!/bin/bash
 
-# To force a rebase error, we move the original rpm-ostree exec file to /usr/bin/rpm-ostree2, and we replace it with this script
-# Remember to use the right selinux type when you replace the orinal rpm-ostree file
-if [ "$1" == "rebase" ];
-then
-exit 255
-else
-/tmp/rpm-ostree "$@"
+# Fake rpm-ostree that forces a failure on "rebase" subcommand.
+# All other commands are forwarded to the real rpm-ostree backup.
+if [ "$1" == "rebase" ]; then
+  exit 255
 fi
-exit $?
-
+exec /var/tmp/rpm-ostree "$@"


### PR DESCRIPTION
Added fix for below failure 

```
[sig-mco][Suite:openshift/machine-config-operator/longduration][Serial][Disruptive] MCO alerts [PolarionID:63866][OTP] MCDPivotError alert [Disruptive] expand_less	3m47s
{  fail [github.com/openshift/machine-config-operator/test/extended-priv/mco_alerts.go:421]: The worker MCP is not reporting the right error message
In resource <Kind: mcp, Name: worker, Namespace: >, the following condition field 'NodeDegraded.message' failed to satisfy matcher.
Expected
    <string>: Node ip-10-0-61-195.us-west-2.compute.internal is reporting: "Node ip-10-0-61-195.us-west-2.compute.internal upgrade failure. unexpected on-disk state validating against rendered-worker-8d04bb6279730408aa1553d6c36a1d91: error running rpm-ostree kargs: exit status 127\n/usr/bin/rpm-ostree: line 9: /tmp/rpm-ostree: No such file or directory\n", Node ip-10-0-61-195.us-west-2.compute.internal is reporting: "unexpected on-disk state validating against rendered-worker-8d04bb6279730408aa1553d6c36a1d91: error running rpm-ostree kargs: exit status 127\n/usr/bin/rpm-ostree: line 9: /tmp/rpm-ostree: No such file or directory\n"
to match regular expression
    <string>: Node ip-10-0-61-195\.us-west-2\.compute\.internal .*[Ff]ailed to update OS to quay\.io/mcoqe/layering@sha256:aeae0ae63b1dc0dfeeff4eb618db3c6573029524172e32ca75a717420267433d
{"lastTransitionTime":"2026-08-06T06:13:08Z","message":"Node ip-10-0-61-195.us-west-2.compute.internal is reporting: \"Node ip-10-0-61-195.us-west-2.compute.internal upgrade failure. unexpected on-disk state validating against rendered-worker-8d04bb6279730408aa1553d6c36a1d91: error running rpm-ostree kargs: exit status 127\\n/usr/bin/rpm-ostree: line 9: /tmp/rpm-ostree: No such file or directory\\n\", Node ip-10-0-61-195.us-west-2.compute.internal is reporting: \"unexpected on-disk state validating against rendered-worker-8d04bb6279730408aa1553d6c36a1d91: error running rpm-ostree kargs: exit status 127\\n/usr/bin/rpm-ostree: line 9: /tmp/rpm-ostree: No such file or directory\\n\"","reason":"1 nodes are reporting degraded status on sync","status":"True","type":"NodeDegraded"}}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for update scenarios involving an already mounted system update command.
  * Improved validation of failed system pivots and recovery behavior.
  * Added clearer checks that replacement commands return the expected failure status and correctly forward other operations.
  * Strengthened testing of fallback behavior during update and recovery flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->