### PR TITLE
OCPBUGS-105315: Check secret before mutating vSphere templates

### DIFF
--- a/pkg/controller/bootimage/vsphere_helpers.go
+++ b/pkg/controller/bootimage/vsphere_helpers.go
@@ -362,6 +362,12 @@ func resolveExistingTemplateVM(
 		if len(computedName) > 80 {
 			return nil, "", false, fmt.Errorf("length of VM template name `%s` exceeds the permitted limit of 80 characters", computedName)
 		}
+		// Validate/upgrade the ignition stub before creating the template in vSphere. If this fails,
+		// we must not have already mutated vSphere state, or a subsequent reconcile would find the
+		// template already in place and silently drop the error (see reconcileVSphereProviderSpec).
+		if err := upgradeStubIgnitionIfRequired(providerSpec.UserDataSecret.Name, kubeClient); err != nil {
+			return nil, "", false, err
+		}
 		ova, ovaErr := streamData.QueryDisk(arch, "vmware", "ova")
 		if ovaErr != nil {
 			return nil, "", false, ovaErr
@@ -383,6 +389,11 @@ func resolveExistingTemplateVM(
 	}
 
 	// Rollback: restore the old template renamed away during a crashed atomic swap.
+	// Validate/upgrade the ignition stub before this rename, so an invalid user-data secret blocks
+	// even this recovery mutation rather than only the OVA-driven create/swap paths.
+	if err := upgradeStubIgnitionIfRequired(providerSpec.UserDataSecret.Name, kubeClient); err != nil {
+		return nil, "", false, err
+	}
 	klog.Infof("Recovering from mid-swap crash: renaming %s back to %s", oldTempName, computedName)
 	renameTask, renameErr := oldVM.Rename(ctx, computedName)
 	if renameErr != nil {
@@ -741,6 +752,14 @@ func createNewVMTemplate(streamData *stream.Stream, providerSpec *machinev1beta1
 
 			if templateProductVersion != release {
 				klog.Infof("Existing RHCOS v%s does not match current RHCOS v%s. Starting reconciliation process.", templateProductVersion, release)
+
+				// Validate/upgrade the ignition stub before swapping the template in vSphere. If this
+				// fails, we must not have already mutated vSphere state, or a subsequent reconcile would
+				// find the template already up to date and silently drop the error (see
+				// reconcileVSphereProviderSpec).
+				if err := upgradeStubIgnitionIfRequired(providerSpec.UserDataSecret.Name, kubeClient); err != nil {
+					return "", false, err
+				}
 
 				// Find and download the relevant OVA file
 				ova, err := streamData.QueryDisk(arch, "vmware", "ova")


### PR DESCRIPTION
**- What I did**
vSphere's reconciler swapped the VM template in vCenter before validating the user-data secret via `upgradeStubIgnitionIfRequired`. If that secret was broken, the error only surfaced after vCenter was already mutated, so the next reconcile saw a matching version and cleared `BootImageUpdateDegraded`, even though the secret was still broken. Other platforms don't hit this since none of them involve mutating objects native to their environment for performing updates.

To fix this, additionals call for `upgradeStubIgnitionIfRequired` were added before the mutating create/swap in both `resolveExistingTemplateVM` and `createNewVMTemplate`, so a bad secret fails fast and the error persists as expected. Kept the existing call in `platform_helpers.go` for the name-divergence-only patch path.

**- How to verify it**
The targeted test for this failure mode,`[sig-mco][Suite:openshift/machine-config-operator/longduration][Serial][Disruptive] MCO Bootimages [PolarionID:80436][OTP] Bootimage secret doesn't exist error upgrading stub ignition to spec 3` should now pass.

Existing boot image tests should also continue to pass. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added preflight validation before creating, recovering, or replacing vSphere templates.
  * Improved ignition-stub upgrade checks during template operations.
  * Prevented unnecessary OVA downloads and vSphere changes when validation or upgrade checks fail.
  * Reduced the risk of incomplete or outdated templates being created during boot image updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->