### PR TITLE
OCPBUGS-98258: Fix upstreams for CoreDNS pods on Cloud platforms

### DIFF
--- a/templates/common/cloud-platform-alt-dns/files/coredns.yaml
+++ b/templates/common/cloud-platform-alt-dns/files/coredns.yaml
@@ -47,7 +47,7 @@ contents:
         - "--out-dir"
         - "/etc/coredns"
         - "--resolvconf-path"
-        - "/etc/resolv.conf"
+        - "/var/run/NetworkManager/resolv.conf"
         resources: {}
         volumeMounts:
         - name: kubeconfig
@@ -59,6 +59,10 @@ contents:
         - name: conf-dir
           mountPath: "/etc/coredns"
           mountPropagation: HostToContainer
+        - name: nm-resolv
+          mountPath: "/var/run/NetworkManager"
+          mountPropagation: HostToContainer
+          readOnly: true
         imagePullPolicy: IfNotPresent
         terminationMessagePolicy: FallbackToLogsOnError
       containers:
@@ -86,8 +90,6 @@ contents:
         terminationMessagePolicy: FallbackToLogsOnError
         imagePullPolicy: IfNotPresent
       - name: coredns-monitor
-        securityContext:
-          privileged: true
         image: {{ .Images.baremetalRuntimeCfgImage }}
         command:
         - corednsmonitor


### PR DESCRIPTION
On cloud platforms, the CoreDNS Corefile's Upstreams were getting generated using the host's /etc/resolv.conf that is modified by network manager to include the local host.

That resulted in the CoreDNS upstreams to include the IP of the node on which the CoreDNS static pod was running on. Fixed to use the NetworkManager's original upstream resolv.conf instead.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated DNS resolution to use NetworkManager’s active resolver configuration, improving name resolution in cloud platform environments.
  * Improved CoreDNS security by removing unnecessary privileged access from its monitoring process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->