### PR TITLE
NO-ISSUE: resolve symlinked graph root in containers-storage policy key

### DIFF
--- a/pkg/daemon/rpm-ostree.go
+++ b/pkg/daemon/rpm-ostree.go
@@ -320,7 +320,21 @@ func (r *RpmOstreeClient) generateTransportPolicyKeyForReference(podmanImageInfo
 	if err != nil {
 		return "", fmt.Errorf("failed to get podman info for storage configuration gathering: %w", err)
 	}
-	return fmt.Sprintf("[%s@%s]%s@%s", podmanInfo.Store.GraphDriverName, podmanInfo.Store.GraphRoot, podmanImageInfo.RepoDigest, podmanImageInfo.ID), nil
+	graphRoot := canonicalizeGraphRoot(podmanInfo.Store.GraphRoot)
+	return fmt.Sprintf("[%s@%s]%s@%s", podmanInfo.Store.GraphDriverName, graphRoot, podmanImageInfo.RepoDigest, podmanImageInfo.ID), nil
+}
+
+// canonicalizeGraphRoot resolves the graph root the way containers/storage does when it
+// opens the store: EvalSymlinks, falling back to a lexically cleaned path exactly as
+// types.expandEnvPath does. "podman system info" can report the graph root unresolved, so
+// without this the allow rule is written under a scope the evaluator never looks up.
+func canonicalizeGraphRoot(graphRoot string) string {
+	resolved, err := filepath.EvalSymlinks(graphRoot)
+	if err != nil {
+		klog.V(2).Infof("Could not resolve container storage graph root %q, falling back to a cleaned path: %v", graphRoot, err)
+		return filepath.Clean(graphRoot)
+	}
+	return resolved
 }
 
 // writeTemporalOstreePolicyFileDropin creates a systemd drop-in configuration that

--- a/pkg/daemon/rpm-ostree_test.go
+++ b/pkg/daemon/rpm-ostree_test.go
@@ -1,9 +1,14 @@
 package daemon
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
 )
 
@@ -24,4 +29,55 @@ func TestParseVersion(t *testing.T) {
 	assert.Equal(t, "2022.10", q.Root.Version)
 	assert.Contains(t, q.Root.Features, "rust")
 	assert.NotContains(t, q.Root.Features, "container")
+}
+
+// symlinkedStore builds <tmp>/containers/storage -> <tmp>/kubelet/containers/storage.
+// t.TempDir() can itself sit behind a symlink, so compare against resolvedTarget.
+func symlinkedStore(t *testing.T) (link, resolvedTarget string) {
+	t.Helper()
+	tmp := t.TempDir()
+
+	target := filepath.Join(tmp, "kubelet", "containers", "storage")
+	require.NoError(t, os.MkdirAll(target, 0o755), "creating symlink target directory %s", target)
+
+	linkParent := filepath.Join(tmp, "containers")
+	require.NoError(t, os.MkdirAll(linkParent, 0o755), "creating symlink parent directory %s", linkParent)
+
+	link = filepath.Join(linkParent, "storage")
+	require.NoError(t, os.Symlink(target, link), "symlinking %s to %s", link, target)
+
+	resolvedTarget, err := filepath.EvalSymlinks(target)
+	require.NoError(t, err, "resolving symlink target %s", target)
+	return link, resolvedTarget
+}
+
+func TestCanonicalizeGraphRoot(t *testing.T) {
+	link, resolved := symlinkedStore(t)
+
+	assert.Equal(t, resolved, canonicalizeGraphRoot(link), "symlinked graph root should resolve to its target")
+	assert.Equal(t, resolved, canonicalizeGraphRoot(resolved), "already-resolved graph root should be unchanged")
+
+	// Not filepath.Join, which Cleans its own result and would make this vacuous.
+	unclean := t.TempDir() + "/absent/../absent/"
+	require.NotEqual(t, filepath.Clean(unclean), unclean, "test input must actually need cleaning")
+	assert.Equal(t, filepath.Clean(unclean), canonicalizeGraphRoot(unclean), "unresolvable path should fall back to a cleaned path")
+}
+
+func TestGenerateTransportPolicyKeyForReferenceResolvesGraphRoot(t *testing.T) {
+	link, resolved := symlinkedStore(t)
+
+	digest := "registry.example.com/os@sha256:" + strings.Repeat("a", 64)
+	imageID := strings.Repeat("b", 64)
+
+	r := &RpmOstreeClient{
+		podmanInterface: &MockPodmanInterface{
+			info: &PodmanInfo{Store: PodmanStorageConfig{GraphDriverName: "overlay", GraphRoot: link}},
+		},
+	}
+
+	key, err := r.generateTransportPolicyKeyForReference(&PodmanImageInfo{RepoDigest: digest, ID: imageID})
+	require.NoError(t, err, "generating policy key for graph root %s", link)
+
+	assert.Equal(t, fmt.Sprintf("[overlay@%s]%s@%s", resolved, digest, imageID), key, "policy key should embed the resolved graph root")
+	assert.NotContains(t, key, link, "unresolved graph root must not appear in the policy key")
 }

--- a/pkg/daemon/update_test.go
+++ b/pkg/daemon/update_test.go
@@ -924,6 +924,7 @@ func TestGenerateExtensionsArgs(t *testing.T) {
 // MockPodmanInterface for testing podmanCopy function
 type MockPodmanInterface struct {
 	createContainerFunc func(additionalArgs []string, containerName, imgURL string) ([]byte, error)
+	info                *PodmanInfo
 }
 
 func (m *MockPodmanInterface) GetPodmanImageInfoByReference(reference string) (*PodmanImageInfo, error) {
@@ -931,6 +932,9 @@ func (m *MockPodmanInterface) GetPodmanImageInfoByReference(reference string) (*
 }
 
 func (m *MockPodmanInterface) GetPodmanInfo() (*PodmanInfo, error) {
+	if m.info != nil {
+		return m.info, nil
+	}
 	return nil, fmt.Errorf("not implemented in mock")
 }
 


### PR DESCRIPTION
**- What I did**

I'm running into a bug where the `rpm-ostree` rebase from local container storage fails with `is rejected by policy` when the container store's graph root is a symlink. I found that the MCD writes a temporary allow rule so `rpm-ostree` can rebase from local container storage under a restrictive policy. The rule is keyed on the container storage graph root, but the writer and the evaluator disagree about what that is.

`generateTransportPolicyKeyForReference` in `pkg/daemon/rpm-ostree.go` takes the graph root as the store reports it, unresolved:

```
$ podman system info --format '{{.Store.GraphRoot}}'
/var/lib/containers/storage

$ readlink -f /var/lib/containers/storage
/var/lib/kubelet/containers/storage
```

The symlink is deliberate here. The container store is relocated onto a separate disk and relocating the store is a supported configuration, so the daemon should not assume the default path.

The containers/storage path resolves the graph root with `EvalSymlinks` when it opens the store, so the key we write and the key `PolicyConfigurationIdentity()` returns differ, such that we write:

```
[overlay@/var/lib/containers/storage]<repo-digest>@<image-id>
```

Then what gets looked up: 

```
[overlay@/var/lib/kubelet/containers/storage]<repo-digest>@<image-id>
```

The `PolicyConfigurationNamespaces()` fn derives its fallback scopes from the same resolved root, so nothing matches and evaluation reaches the policy default. The rebase fails with `is rejected by policy`.

This fix resolves the graph root before building the key, using the same `EvalSymlinks`-with-`Clean` fallback that containers/storage uses in `expandEnvPath`, so the written key matches what the evaluator looks up.

This PR fixes #6388

**- How to verify it**
```
go test ./pkg/daemon/ -run 'TestCanonicalizeGraphRoot|TestGenerateTransportPolicyKeyForReferenceResolvesGraphRoot'
```

**- Description for the changelog**
This PR resolves the container storage graph root symlink before building the transport policy key, fixing rpm-ostree rebase rejections from local storage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with symlinked container storage paths when generating transport policy keys.
  * Added a fallback for storage paths that cannot be resolved, preventing related operations from failing unexpectedly.
* **Tests**
  * Added coverage for resolved and unresolved storage paths.
  * Expanded test support for configured container runtime information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->