### PR TITLE
OCPBUGS-86571: filter on-prem nodeip VIP args by IPFamilies

### DIFF
--- a/pkg/controller/template/render.go
+++ b/pkg/controller/template/render.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"maps"
+	"net"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -380,8 +381,10 @@ func renderTemplate(config RenderConfig, path string, b []byte) ([]byte, error) 
 	funcs["credentialProviderConfigFlag"] = credentialProviderConfigFlag
 	funcs["onPremPlatformAPIServerInternalIP"] = onPremPlatformAPIServerInternalIP
 	funcs["onPremPlatformAPIServerInternalIPs"] = onPremPlatformAPIServerInternalIPs
+	funcs["onPremPlatformAPIServerInternalIPsForFamilies"] = onPremPlatformAPIServerInternalIPsForFamilies
 	funcs["onPremPlatformIngressIP"] = onPremPlatformIngressIP
 	funcs["onPremPlatformIngressIPs"] = onPremPlatformIngressIPs
+	funcs["onPremPlatformIngressIPsForFamilies"] = onPremPlatformIngressIPsForFamilies
 	funcs["onPremPlatformShortName"] = onPremPlatformShortName
 	funcs["urlHost"] = urlHost
 	funcs["urlPort"] = urlPort
@@ -607,6 +610,78 @@ func onPremPlatformAPIServerInternalIPs(cfg RenderConfig) (interface{}, error) {
 	} else {
 		return nil, fmt.Errorf("")
 	}
+}
+
+// onPremPlatformAPIServerInternalIPsForFamilies returns API VIP strings filtered by
+// ControllerConfig IPFamilies (from ServiceNetwork). Single-stack clusters omit
+// opposite-family VIPs so nodeip does not treat lagging Infrastructure VIPs as hints.
+func onPremPlatformAPIServerInternalIPsForFamilies(cfg RenderConfig) (interface{}, error) {
+	raw, err := onPremPlatformAPIServerInternalIPs(cfg)
+	if err != nil {
+		return nil, err
+	}
+	ips, err := onPremIPsToStrings(raw)
+	if err != nil {
+		return nil, err
+	}
+	return filterIPsForIPFamilies(ips, cfg.IPFamilies), nil
+}
+
+// onPremPlatformIngressIPsForFamilies returns Ingress VIP strings filtered by IPFamilies.
+func onPremPlatformIngressIPsForFamilies(cfg RenderConfig) (interface{}, error) {
+	raw, err := onPremPlatformIngressIPs(cfg)
+	if err != nil {
+		return nil, err
+	}
+	ips, err := onPremIPsToStrings(raw)
+	if err != nil {
+		return nil, err
+	}
+	return filterIPsForIPFamilies(ips, cfg.IPFamilies), nil
+}
+
+// onPremIPsToStrings normalizes platform VIP list types to []string.
+func onPremIPsToStrings(v interface{}) ([]string, error) {
+	switch x := v.(type) {
+	case nil:
+		return []string{}, nil
+	case []string:
+		return x, nil
+	case []configv1.IP:
+		out := make([]string, len(x))
+		for i, ip := range x {
+			out[i] = string(ip)
+		}
+		return out, nil
+	default:
+		return nil, fmt.Errorf("unexpected VIP list type %T", v)
+	}
+}
+
+// filterIPsForIPFamilies keeps VIP strings that match ControllerConfig IPFamilies.
+// DualStack / DualStackIPv6Primary / empty / unknown: return the full list.
+// Unparseable entries are skipped.
+func filterIPsForIPFamilies(ips []string, families mcfgv1.IPFamiliesType) []string {
+	wantV4 := families == mcfgv1.IPFamiliesIPv4
+	wantV6 := families == mcfgv1.IPFamiliesIPv6
+	if !wantV4 && !wantV6 {
+		return ips
+	}
+	out := make([]string, 0, len(ips))
+	for _, s := range ips {
+		ip := net.ParseIP(s)
+		if ip == nil {
+			continue
+		}
+		isV4 := ip.To4() != nil
+		if wantV4 && isV4 {
+			out = append(out, s)
+		}
+		if wantV6 && !isV4 {
+			out = append(out, s)
+		}
+	}
+	return out
 }
 
 // existsDir returns true if path exists and is a directory, false if the path

--- a/pkg/controller/template/render_test.go
+++ b/pkg/controller/template/render_test.go
@@ -197,6 +197,116 @@ func TestSkipMissing(t *testing.T) {
 	}
 }
 
+func TestFilterIPsForIPFamilies(t *testing.T) {
+	t.Parallel()
+	dual := []string{"192.0.2.10", "2001:db8::10", "192.0.2.20", "2001:db8::20"}
+	cases := []struct {
+		name     string
+		families mcfgv1.IPFamiliesType
+		in       []string
+		want     []string
+	}{
+		{
+			name:     "IPv4 drops v6 preserves order",
+			families: mcfgv1.IPFamiliesIPv4,
+			in:       dual,
+			want:     []string{"192.0.2.10", "192.0.2.20"},
+		},
+		{
+			name:     "IPv6 drops v4 preserves order",
+			families: mcfgv1.IPFamiliesIPv6,
+			in:       dual,
+			want:     []string{"2001:db8::10", "2001:db8::20"},
+		},
+		{
+			name:     "DualStack keeps both",
+			families: mcfgv1.IPFamiliesDualStack,
+			in:       dual,
+			want:     dual,
+		},
+		{
+			name:     "DualStackIPv6Primary keeps both",
+			families: mcfgv1.IPFamiliesDualStackIPv6Primary,
+			in:       dual,
+			want:     dual,
+		},
+		{
+			name:     "empty families keeps both",
+			families: "",
+			in:       dual,
+			want:     dual,
+		},
+		{
+			name:     "skips unparseable",
+			families: mcfgv1.IPFamiliesIPv4,
+			in:       []string{"not-an-ip", "192.0.2.1", "also-bad", "2001:db8::1"},
+			want:     []string{"192.0.2.1"},
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := filterIPsForIPFamilies(tc.in, tc.families)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("got %#v want %#v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNodeipConfigurationVIPArgsForFamilies(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(templateDir, "common/on-prem/units/nodeip-configuration.service.yaml")
+	templateData, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read template: %v", err)
+	}
+
+	const (
+		apiV4 = "192.0.2.10"
+		apiV6 = "2001:db8::10"
+		ingV4 = "192.0.2.20"
+		ingV6 = "2001:db8::20"
+	)
+
+	config := &mcfgv1.ControllerConfig{
+		Spec: mcfgv1.ControllerConfigSpec{
+			IPFamilies: mcfgv1.IPFamiliesIPv4,
+			Infra: &configv1.Infrastructure{
+				Status: configv1.InfrastructureStatus{
+					PlatformStatus: &configv1.PlatformStatus{
+						Type: configv1.BareMetalPlatformType,
+						BareMetal: &configv1.BareMetalPlatformStatus{
+							APIServerInternalIPs: []string{apiV4, apiV6},
+							IngressIPs:           []string{ingV4, ingV6},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	got, err := renderTemplate(RenderConfig{&config.Spec, `{"dummy":"dummy"}`, "dummy", nil, nil}, path, templateData)
+	if err != nil {
+		t.Fatalf("renderTemplate: %v", err)
+	}
+	out := string(got)
+	for _, want := range []string{apiV4, ingV4} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("expected %q in rendered unit\n%s", want, out)
+		}
+	}
+	for _, drop := range []string{apiV6, ingV6} {
+		if strings.Contains(out, drop) {
+			t.Fatalf("did not expect %q in rendered unit with IPFamilies=IPv4\n%s", drop, out)
+		}
+	}
+	if !strings.Contains(out, "enabled: true") {
+		t.Fatalf("expected enabled: true from unfiltered VIP list\n%s", out)
+	}
+}
+
 const templateDir = "../../../templates"
 
 var (

--- a/pkg/operator/render.go
+++ b/pkg/operator/render.go
@@ -81,8 +81,10 @@ func (a *assetRenderer) addTemplateFuncs() {
 	funcs["toYAML"] = toYAML
 	funcs["onPremPlatformAPIServerInternalIP"] = onPremPlatformAPIServerInternalIP
 	funcs["onPremPlatformAPIServerInternalIPs"] = onPremPlatformAPIServerInternalIPs
+	funcs["onPremPlatformAPIServerInternalIPsForFamilies"] = onPremPlatformAPIServerInternalIPsForFamilies
 	funcs["onPremPlatformIngressIP"] = onPremPlatformIngressIP
 	funcs["onPremPlatformIngressIPs"] = onPremPlatformIngressIPs
+	funcs["onPremPlatformIngressIPsForFamilies"] = onPremPlatformIngressIPsForFamilies
 	funcs["onPremPlatformShortName"] = onPremPlatformShortName
 	funcs["cloudPlatformAPIIntLoadBalancerIPs"] = cloudPlatformAPIIntLoadBalancerIPs
 	funcs["cloudPlatformAPILoadBalancerIPs"] = cloudPlatformAPILoadBalancerIPs
@@ -373,6 +375,73 @@ func onPremPlatformAPIServerInternalIPs(cfg mcfgv1.ControllerConfigSpec) (interf
 		}
 	}
 	return nil, fmt.Errorf("")
+}
+
+// onPremPlatformAPIServerInternalIPsForFamilies returns API VIP strings filtered by
+// ControllerConfig IPFamilies (from ServiceNetwork).
+func onPremPlatformAPIServerInternalIPsForFamilies(cfg mcfgv1.ControllerConfigSpec) (interface{}, error) {
+	raw, err := onPremPlatformAPIServerInternalIPs(cfg)
+	if err != nil {
+		return nil, err
+	}
+	ips, err := onPremIPsToStrings(raw)
+	if err != nil {
+		return nil, err
+	}
+	return filterIPsForIPFamilies(ips, cfg.IPFamilies), nil
+}
+
+// onPremPlatformIngressIPsForFamilies returns Ingress VIP strings filtered by IPFamilies.
+func onPremPlatformIngressIPsForFamilies(cfg mcfgv1.ControllerConfigSpec) (interface{}, error) {
+	raw, err := onPremPlatformIngressIPs(cfg)
+	if err != nil {
+		return nil, err
+	}
+	ips, err := onPremIPsToStrings(raw)
+	if err != nil {
+		return nil, err
+	}
+	return filterIPsForIPFamilies(ips, cfg.IPFamilies), nil
+}
+
+func onPremIPsToStrings(v interface{}) ([]string, error) {
+	switch x := v.(type) {
+	case nil:
+		return []string{}, nil
+	case []string:
+		return x, nil
+	case []configv1.IP:
+		out := make([]string, len(x))
+		for i, ip := range x {
+			out[i] = string(ip)
+		}
+		return out, nil
+	default:
+		return nil, fmt.Errorf("unexpected VIP list type %T", v)
+	}
+}
+
+func filterIPsForIPFamilies(ips []string, families mcfgv1.IPFamiliesType) []string {
+	wantV4 := families == mcfgv1.IPFamiliesIPv4
+	wantV6 := families == mcfgv1.IPFamiliesIPv6
+	if !wantV4 && !wantV6 {
+		return ips
+	}
+	out := make([]string, 0, len(ips))
+	for _, s := range ips {
+		ip := net.ParseIP(s)
+		if ip == nil {
+			continue
+		}
+		isV4 := ip.To4() != nil
+		if wantV4 && isV4 {
+			out = append(out, s)
+		}
+		if wantV6 && !isV4 {
+			out = append(out, s)
+		}
+	}
+	return out
 }
 
 // cloudPlatformLoadBalancerIPs provides a generic method to obtain API, API-Int and Ingrerss Load Balancer IPs

--- a/pkg/operator/render_test.go
+++ b/pkg/operator/render_test.go
@@ -94,6 +94,62 @@ func TestIPFamilies(t *testing.T) {
 	}
 }
 
+func TestFilterIPsForIPFamilies(t *testing.T) {
+	t.Parallel()
+	dual := []string{"192.0.2.10", "2001:db8::10", "192.0.2.20", "2001:db8::20"}
+	cases := []struct {
+		name     string
+		families mcfgv1.IPFamiliesType
+		in       []string
+		want     []string
+	}{
+		{
+			name:     "IPv4 drops v6 preserves order",
+			families: mcfgv1.IPFamiliesIPv4,
+			in:       dual,
+			want:     []string{"192.0.2.10", "192.0.2.20"},
+		},
+		{
+			name:     "IPv6 drops v4 preserves order",
+			families: mcfgv1.IPFamiliesIPv6,
+			in:       dual,
+			want:     []string{"2001:db8::10", "2001:db8::20"},
+		},
+		{
+			name:     "DualStack keeps both",
+			families: mcfgv1.IPFamiliesDualStack,
+			in:       dual,
+			want:     dual,
+		},
+		{
+			name:     "DualStackIPv6Primary keeps both",
+			families: mcfgv1.IPFamiliesDualStackIPv6Primary,
+			in:       dual,
+			want:     dual,
+		},
+		{
+			name:     "empty families keeps both",
+			families: "",
+			in:       dual,
+			want:     dual,
+		},
+		{
+			name:     "skips unparseable",
+			families: mcfgv1.IPFamiliesIPv4,
+			in:       []string{"not-an-ip", "192.0.2.1", "also-bad", "2001:db8::1"},
+			want:     []string{"192.0.2.1"},
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := filterIPsForIPFamilies(tc.in, tc.families)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
 // Smoke test to render all manifests to validate if they can be rendered or
 // not and if they can be read into the appropriate structs.
 // TODO: Consolidate this and the TestRenderAsset tests

--- a/templates/common/on-prem/files/resolv-prepender.yaml
+++ b/templates/common/on-prem/files/resolv-prepender.yaml
@@ -57,8 +57,8 @@ contents:
                 {{if not (isOpenShiftManagedDefaultLB .) -}}
                 --user-managed-lb \
                 {{end -}}
-                {{range onPremPlatformAPIServerInternalIPs . }}"{{.}}" {{end}} \
-                {{range onPremPlatformIngressIPs . }}"{{.}}" {{end}})"
+                {{range onPremPlatformAPIServerInternalIPsForFamilies . }}"{{.}}" {{end}} \
+                {{range onPremPlatformIngressIPsForFamilies . }}"{{.}}" {{end}})"
             DOMAINS="${IP4_DOMAINS:-} ${IP6_DOMAINS:-} {{.DNS.Spec.BaseDomain}}"
             if [[ -n "$NAMESERVER_IP" ]]; then
                 KNICONFDONEPATH="/run/resolv-prepender-kni-conf-done"

--- a/templates/common/on-prem/units/nodeip-configuration.service.yaml
+++ b/templates/common/on-prem/units/nodeip-configuration.service.yaml
@@ -38,8 +38,8 @@ contents: |
     {{end -}}
     --retry-on-failure \
     ${NODEIP_HINT:-} \
-    {{ range onPremPlatformAPIServerInternalIPs . }}{{.}} {{end}} \
-    {{ range onPremPlatformIngressIPs . }}{{.}} {{end}}; \
+    {{ range onPremPlatformAPIServerInternalIPsForFamilies . }}{{.}} {{end}} \
+    {{ range onPremPlatformIngressIPsForFamilies . }}{{.}} {{end}}; \
     do \
     sleep 5; \
     done"


### PR DESCRIPTION
Since we use service network and IP families as the canonical single source of dual stack capability, it seems to follow that we should filter the VIPs based on the IP family.

We are templating the file anyways.

Cursor AI assisted.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

Added a new template function To filter IPs based on IP family. 

**- How to verify it**

Change the IP family look at the VIPs. 




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved on-premises node IP configuration for IPv4-only and IPv6-only environments.
  * API server and ingress VIPs are now filtered according to the configured IP family.
  * Dual-stack and unspecified configurations retain all valid addresses.
* **Bug Fixes**
  * Invalid or mismatched IP addresses are excluded while preserving address order.
  * Updated configuration rendering ensures matching API and ingress addresses are used consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->