### PR TITLE
AGENT-1570: Remove all NoRegistryClusterInstall feature gate check

### DIFF
--- a/cmd/machine-config-controller/start.go
+++ b/cmd/machine-config-controller/start.go
@@ -8,8 +8,6 @@ import (
 	"path"
 	"time"
 
-	features "github.com/openshift/api/features"
-	mcfginformersv1 "github.com/openshift/client-go/machineconfiguration/informers/externalversions/machineconfiguration/v1"
 	"github.com/openshift/machine-config-operator/cmd/common"
 	"github.com/openshift/machine-config-operator/internal/clients"
 	bootimagecontroller "github.com/openshift/machine-config-operator/pkg/controller/bootimage"
@@ -29,7 +27,6 @@ import (
 	"github.com/openshift/machine-config-operator/pkg/version"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	coreinformersv1 "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/tools/leaderelection"
 	"k8s.io/klog/v2"
 )
@@ -214,25 +211,23 @@ func runStartCmd(_ *cobra.Command, _ []string) {
 
 		close(ctrlctx.InformersStarted)
 
-		if ctrlctx.FeatureGatesHandler.Enabled(features.FeatureGateNoRegistryClusterInstall) {
-			iriController := internalreleaseimage.New(
-				ctrlctx.InformerFactory.Machineconfiguration().V1().InternalReleaseImages(),
-				ctrlctx.InformerFactory.Machineconfiguration().V1().ControllerConfigs(),
-				ctrlctx.InformerFactory.Machineconfiguration().V1().MachineConfigs(),
-				ctrlctx.ConfigInformerFactory.Config().V1().ClusterVersions(),
-				ctrlctx.KubeInformerFactory.Core().V1().Secrets(),
-				ctrlctx.InformerFactory.Machineconfiguration().V1().MachineConfigNodes(),
-				ctrlctx.KubeInformerFactory.Core().V1().Nodes(),
-				ctrlctx.ConfigInformerFactory.Config().V1().Infrastructures(),
-				ctrlctx.ClientBuilder.KubeClientOrDie("internalreleaseimage-controller"),
-				ctrlctx.ClientBuilder.MachineConfigClientOrDie("internalreleaseimage-controller"))
+		iriController := internalreleaseimage.New(
+			ctrlctx.InformerFactory.Machineconfiguration().V1().InternalReleaseImages(),
+			ctrlctx.InformerFactory.Machineconfiguration().V1().ControllerConfigs(),
+			ctrlctx.InformerFactory.Machineconfiguration().V1().MachineConfigs(),
+			ctrlctx.ConfigInformerFactory.Config().V1().ClusterVersions(),
+			ctrlctx.KubeInformerFactory.Core().V1().Secrets(),
+			ctrlctx.InformerFactory.Machineconfiguration().V1().MachineConfigNodes(),
+			ctrlctx.KubeInformerFactory.Core().V1().Nodes(),
+			ctrlctx.ConfigInformerFactory.Config().V1().Infrastructures(),
+			ctrlctx.ClientBuilder.KubeClientOrDie("internalreleaseimage-controller"),
+			ctrlctx.ClientBuilder.MachineConfigClientOrDie("internalreleaseimage-controller"))
 
-			go iriController.Run(ctx, 2)
-			// start the informers again to enable feature gated types.
-			// see comments in SharedInformerFactory interface.
-			ctrlctx.InformerFactory.Start(ctx.Done())
-			ctrlctx.KubeInformerFactory.Start(ctx.Done())
-		}
+		go iriController.Run(ctx, 2)
+		// start the informers again to pick up newly registered types.
+		// see comments in SharedInformerFactory interface.
+		ctrlctx.InformerFactory.Start(ctx.Done())
+		ctrlctx.KubeInformerFactory.Start(ctx.Done())
 
 		if ctrlcommon.IsBootImageControllerRequired(ctrlctx) {
 			bootImageController := bootimagecontroller.New(
@@ -290,17 +285,6 @@ func runStartCmd(_ *cobra.Command, _ []string) {
 }
 
 func createControllers(ctx *ctrlcommon.ControllerContext, inspectionCache *imageutils.FileInspectionCache, inspectorFactory osimagestream.ImagesInspectorFactory) []ctrlcommon.Controller {
-	// Only watch IRI informers when the feature gate is enabled. The
-	// InternalReleaseImages CRD is not installed on clusters where the gate is
-	// off, so the informer list call would fail and WaitForCacheSync in the
-	// template controller would block forever.
-	var iriSecretsInformer coreinformersv1.SecretInformer
-	var iriInformer mcfginformersv1.InternalReleaseImageInformer
-	if ctx.FeatureGatesHandler.Enabled(features.FeatureGateNoRegistryClusterInstall) {
-		iriSecretsInformer = ctx.KubeInformerFactory.Core().V1().Secrets()
-		iriInformer = ctx.InformerFactory.Machineconfiguration().V1().InternalReleaseImages()
-	}
-
 	renderCtrl := render.New(
 		ctx.InformerFactory.Machineconfiguration().V1().MachineConfigPools(),
 		ctx.InformerFactory.Machineconfiguration().V1().MachineConfigs(),
@@ -331,12 +315,11 @@ func createControllers(ctx *ctrlcommon.ControllerContext, inspectionCache *image
 			rootOpts.templates,
 			ctx.InformerFactory.Machineconfiguration().V1().ControllerConfigs(),
 			ctx.OpenShiftConfigKubeNamespacedInformerFactory.Core().V1().Secrets(),
-			iriSecretsInformer,
-			iriInformer,
+			ctx.KubeInformerFactory.Core().V1().Secrets(),
+			ctx.InformerFactory.Machineconfiguration().V1().InternalReleaseImages(),
 			ctx.ConfigInformerFactory.Config().V1().APIServers(),
 			ctx.ClientBuilder.KubeClientOrDie("template-controller"),
 			ctx.ClientBuilder.MachineConfigClientOrDie("template-controller"),
-			ctx.FeatureGatesHandler,
 		),
 		// Add all "sub-renderers here"
 		kubeletconfig.New(

--- a/cmd/machine-config-controller/start.go
+++ b/cmd/machine-config-controller/start.go
@@ -211,24 +211,6 @@ func runStartCmd(_ *cobra.Command, _ []string) {
 
 		close(ctrlctx.InformersStarted)
 
-		iriController := internalreleaseimage.New(
-			ctrlctx.InformerFactory.Machineconfiguration().V1().InternalReleaseImages(),
-			ctrlctx.InformerFactory.Machineconfiguration().V1().ControllerConfigs(),
-			ctrlctx.InformerFactory.Machineconfiguration().V1().MachineConfigs(),
-			ctrlctx.ConfigInformerFactory.Config().V1().ClusterVersions(),
-			ctrlctx.KubeInformerFactory.Core().V1().Secrets(),
-			ctrlctx.InformerFactory.Machineconfiguration().V1().MachineConfigNodes(),
-			ctrlctx.KubeInformerFactory.Core().V1().Nodes(),
-			ctrlctx.ConfigInformerFactory.Config().V1().Infrastructures(),
-			ctrlctx.ClientBuilder.KubeClientOrDie("internalreleaseimage-controller"),
-			ctrlctx.ClientBuilder.MachineConfigClientOrDie("internalreleaseimage-controller"))
-
-		go iriController.Run(ctx, 2)
-		// start the informers again to pick up newly registered types.
-		// see comments in SharedInformerFactory interface.
-		ctrlctx.InformerFactory.Start(ctx.Done())
-		ctrlctx.KubeInformerFactory.Start(ctx.Done())
-
 		if ctrlcommon.IsBootImageControllerRequired(ctrlctx) {
 			bootImageController := bootimagecontroller.New(
 				ctrlctx.ClientBuilder.KubeClientOrDie("machine-set-boot-image-controller"),
@@ -368,6 +350,18 @@ func createControllers(ctx *ctrlcommon.ControllerContext, inspectionCache *image
 			ctx.ClientBuilder.KubeClientOrDie("node-update-controller"),
 			ctx.ClientBuilder.MachineConfigClientOrDie("node-update-controller"),
 			ctx.FeatureGatesHandler,
+		),
+		internalreleaseimage.New(
+			ctx.InformerFactory.Machineconfiguration().V1().InternalReleaseImages(),
+			ctx.InformerFactory.Machineconfiguration().V1().ControllerConfigs(),
+			ctx.InformerFactory.Machineconfiguration().V1().MachineConfigs(),
+			ctx.ConfigInformerFactory.Config().V1().ClusterVersions(),
+			ctx.KubeInformerFactory.Core().V1().Secrets(),
+			ctx.InformerFactory.Machineconfiguration().V1().MachineConfigNodes(),
+			ctx.KubeInformerFactory.Core().V1().Nodes(),
+			ctx.ConfigInformerFactory.Config().V1().Infrastructures(),
+			ctx.ClientBuilder.KubeClientOrDie("internalreleaseimage-controller"),
+			ctx.ClientBuilder.MachineConfigClientOrDie("internalreleaseimage-controller"),
 		),
 	)
 

--- a/cmd/machine-config-daemon/start.go
+++ b/cmd/machine-config-daemon/start.go
@@ -12,7 +12,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/client-go/tools/clientcmd"
 
-	"github.com/openshift/api/features"
 	"github.com/openshift/machine-config-operator/internal/clients"
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
 	"github.com/openshift/machine-config-operator/pkg/daemon"
@@ -236,27 +235,21 @@ func runStartCmd(_ *cobra.Command, _ []string) {
 	)
 	go pinnedImageSetManager.Run(2, stopCh)
 
-	var mcnScopedInformerStartFunc func(<-chan struct{})
-	if ctrlctx.FeatureGatesHandler.Enabled(features.FeatureGateNoRegistryClusterInstall) {
-		mcnScopedInformer, startFunc := ctrlcommon.NewScopedMachineConfigNodeInformerFromClientBuilder(cb, startOpts.nodeName)
-		mcnScopedInformerStartFunc = startFunc
-		internalReleaseImageManager := internalreleaseimage.New(
-			startOpts.nodeName,
-			ctrlctx.ClientBuilder.MachineConfigClientOrDie(componentName),
-			ctrlctx.InformerFactory.Machineconfiguration().V1().InternalReleaseImages(),
-			mcnScopedInformer,
-		)
-		go internalReleaseImageManager.Run(1, stopCh)
-	}
+	mcnScopedInformer, mcnScopedInformerStartFunc := ctrlcommon.NewScopedMachineConfigNodeInformerFromClientBuilder(cb, startOpts.nodeName)
+	internalReleaseImageManager := internalreleaseimage.New(
+		startOpts.nodeName,
+		ctrlctx.ClientBuilder.MachineConfigClientOrDie(componentName),
+		ctrlctx.InformerFactory.Machineconfiguration().V1().InternalReleaseImages(),
+		mcnScopedInformer,
+	)
+	go internalReleaseImageManager.Run(1, stopCh)
 
 	ctrlctx.KubeInformerFactory.Start(stopCh)
 	ctrlctx.KubeNamespacedInformerFactory.Start(stopCh)
 	ctrlctx.InformerFactory.Start(stopCh)
 	ctrlctx.OperatorInformerFactory.Start(stopCh)
 	nodeScopedInformerStartFunc(ctrlctx.Stop)
-	if mcnScopedInformerStartFunc != nil {
-		mcnScopedInformerStartFunc(ctrlctx.Stop)
-	}
+	mcnScopedInformerStartFunc(ctrlctx.Stop)
 	close(ctrlctx.InformersStarted)
 
 	if err := dn.Run(stopCh, exitCh, errCh); err != nil {

--- a/cmd/machine-config-operator/start.go
+++ b/cmd/machine-config-operator/start.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 
-	features "github.com/openshift/api/features"
 	"github.com/openshift/machine-config-operator/cmd/common"
 	"github.com/openshift/machine-config-operator/internal/clients"
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
@@ -67,13 +66,6 @@ func runStartCmd(_ *cobra.Command, _ []string) {
 			klog.Fatal(fmt.Errorf("failed to connect to feature gates %w", fgErr))
 		}
 
-		// Only pass IRI informer when the feature gate is enabled to avoid
-		// watching for a CRD that may not exist
-		var iriInformer = ctrlctx.InformerFactory.Machineconfiguration().V1().InternalReleaseImages()
-		if !ctrlctx.FeatureGatesHandler.Enabled(features.FeatureGateNoRegistryClusterInstall) {
-			iriInformer = nil
-		}
-
 		controller := operator.New(
 			ctrlcommon.MCONamespace, componentName,
 			startOpts.imagesFile,
@@ -117,7 +109,7 @@ func runStartCmd(_ *cobra.Command, _ []string) {
 			ctrlctx.ConfigInformerFactory.Config().V1().ClusterVersions(),
 			ctrlctx.InformerFactory.Machineconfiguration().V1().OSImageStreams(),
 			ctrlctx.KubeNamespacedInformerFactory.Networking().V1().NetworkPolicies(),
-			iriInformer,
+			ctrlctx.InformerFactory.Machineconfiguration().V1().InternalReleaseImages(),
 			ctrlctx,
 		)
 

--- a/pkg/controller/bootstrap/bootstrap.go
+++ b/pkg/controller/bootstrap/bootstrap.go
@@ -27,7 +27,7 @@ import (
 	"github.com/opencontainers/go-digest"
 	apicfgv1 "github.com/openshift/api/config/v1"
 	apicfgv1alpha1 "github.com/openshift/api/config/v1alpha1"
-	"github.com/openshift/api/features"
+
 	imagev1 "github.com/openshift/api/image/v1"
 	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
 	mcfgv1alpha1 "github.com/openshift/api/machineconfiguration/v1alpha1"
@@ -280,7 +280,7 @@ func (b *Bootstrap) Run(destDir string) error {
 	// The template controller has not yet run at this point, so machine-config-daemon-pull.service
 	// would otherwise fail to authenticate against the IRI registry.
 	// Merge is a no-op if the feature gate is off or the IRI resource is absent.
-	merger := ctrlcommon.NewIRISecretMergerFromObjects(iriCredentialsSecret, cconfig, fgHandler, iri)
+	merger := ctrlcommon.NewIRISecretMergerFromObjects(iriCredentialsSecret, cconfig, iri)
 	pullSecretBytes, err = merger.Merge(pullSecretBytes)
 	if err != nil {
 		return fmt.Errorf("could not merge IRI credentials into pull secret for bootstrap: %w", err)
@@ -346,15 +346,13 @@ func (b *Bootstrap) Run(destDir string) error {
 	}
 	klog.Infof("Successfully generated MachineConfigs from kubelet configs.")
 
-	if fgHandler != nil && fgHandler.Enabled(features.FeatureGateNoRegistryClusterInstall) {
-		if iri {
-			iriConfigs, err := internalreleaseimage.RunInternalReleaseImageBootstrap(iriTLSCert, iriCredentialsSecret, cconfig)
-			if err != nil {
-				return err
-			}
-			configs = append(configs, iriConfigs...)
-			klog.Infof("Successfully generated MachineConfig from InternalReleaseImage.")
+	if iri {
+		iriConfigs, err := internalreleaseimage.RunInternalReleaseImageBootstrap(iriTLSCert, iriCredentialsSecret, cconfig)
+		if err != nil {
+			return err
 		}
+		configs = append(configs, iriConfigs...)
+		klog.Infof("Successfully generated MachineConfig from InternalReleaseImage.")
 	}
 
 	// Create component MachineConfigs for pre-built images for hybrid OCL

--- a/pkg/controller/certrotation/certrotation_controller.go
+++ b/pkg/controller/certrotation/certrotation_controller.go
@@ -503,11 +503,6 @@ func (c *CertRotationController) reconcileSecret(secret corev1.Secret) error {
 }
 
 func (c *CertRotationController) reconcileIRICertificate() {
-	if !c.featureGatesHandler.Enabled(features.FeatureGateNoRegistryClusterInstall) {
-		klog.V(4).Infof("Skipping IRI certificate reconciliation: %s feature gate is not enabled", features.FeatureGateNoRegistryClusterInstall)
-		return
-	}
-
 	// Check that the IRI cluster resource exists to confirm the feature is actually enabled
 	if _, err := c.mcfgClient.MachineconfigurationV1().InternalReleaseImages().Get(context.TODO(), ctrlcommon.InternalReleaseImageInstanceName, metav1.GetOptions{}); err != nil {
 		if k8serrors.IsNotFound(err) {

--- a/pkg/controller/certrotation/certrotation_controller_test.go
+++ b/pkg/controller/certrotation/certrotation_controller_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/openshift/library-go/pkg/crypto"
 	"github.com/openshift/library-go/pkg/operator/certrotation"
 	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 
@@ -120,10 +119,7 @@ func (f *fixture) newController() *CertRotationController {
 		f.infraLister = append(f.infraLister, infra.(*configv1.Infrastructure))
 	}
 
-	fgHandler := ctrlcommon.NewFeatureGatesHardcodedHandler(
-		[]configv1.FeatureGateName{features.FeatureGateNoRegistryClusterInstall},
-		nil,
-	)
+	fgHandler := ctrlcommon.NewFeatureGatesHardcodedHandler(nil, nil)
 	c, err := New(f.kubeClient, f.configClient, f.machineClient, f.aroClient, f.k8sI.Core().V1().Secrets(), f.k8sI.Core().V1().Secrets(), f.k8sI.Core().V1().ConfigMaps(), f.infraInformer.Config().V1().Infrastructures(), nil, fgHandler, f.mcfgClient)
 	require.NoError(f.t, err)
 
@@ -443,39 +439,6 @@ func TestIRICertificateRotation(t *testing.T) {
 	})
 }
 
-func TestIRICertificateReconcileSkippedWhenFeatureGateDisabled(t *testing.T) {
-	f := newFixture(t)
-	f.mcfgObjects = append(f.mcfgObjects, getIRIClusterResource())
-	f.machineObjects = append(f.machineObjects, getMachineSet("test-machine"))
-
-	// Build a controller with the feature gate disabled.
-	f.kubeClient = fake.NewSimpleClientset(f.objects...)
-	f.configClient = fakeconfigv1client.NewSimpleClientset(f.configObjects...)
-	f.machineClient = fakemachineclientset.NewSimpleClientset(f.machineObjects...)
-	f.mcfgClient = fakemcfgclientset.NewSimpleClientset(f.mcfgObjects...)
-	f.aroClient = fakearoclientset.NewSimpleClientset(f.aroObjects...)
-	f.k8sI = kubeinformers.NewSharedInformerFactory(f.kubeClient, noResyncPeriodFunc())
-	f.infraInformer = configinformers.NewSharedInformerFactory(f.configClient, noResyncPeriodFunc())
-
-	fgHandler := ctrlcommon.NewFeatureGatesHardcodedHandler(
-		nil,
-		[]configv1.FeatureGateName{features.FeatureGateNoRegistryClusterInstall},
-	)
-	c, err := New(f.kubeClient, f.configClient, f.machineClient, f.aroClient,
-		f.k8sI.Core().V1().Secrets(), f.k8sI.Core().V1().Secrets(),
-		f.k8sI.Core().V1().ConfigMaps(), f.infraInformer.Config().V1().Infrastructures(),
-		nil, fgHandler, f.mcfgClient)
-	require.NoError(t, err)
-
-	// reconcileIRICertificate must be a no-op when the feature gate is disabled.
-	c.reconcileIRICertificate()
-
-	// Verify no IRI TLS secret was created.
-	_, err = f.kubeClient.CoreV1().Secrets(ctrlcommon.MCONamespace).Get(context.TODO(), ctrlcommon.InternalReleaseImageTLSSecretName, metav1.GetOptions{})
-	require.Error(t, err, "IRI TLS secret should not exist when feature gate is disabled")
-	require.True(t, k8serrors.IsNotFound(err))
-}
-
 func TestNewWithConfigurablePKI(t *testing.T) {
 	testCases := []struct {
 		name           string
@@ -527,7 +490,7 @@ func TestNewWithConfigurablePKI(t *testing.T) {
 			}
 			infraInformer.Config().V1().Infrastructures().Informer().GetIndexer().Add(infraObj)
 
-			enabledGates := []configv1.FeatureGateName{features.FeatureGateNoRegistryClusterInstall}
+			var enabledGates []configv1.FeatureGateName
 			if tc.enablePKI {
 				enabledGates = append(enabledGates, features.FeatureGateConfigurablePKI)
 			}

--- a/pkg/controller/common/iri_secret_merger.go
+++ b/pkg/controller/common/iri_secret_merger.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"strings"
 
-	features "github.com/openshift/api/features"
 	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
 	mcfglistersv1 "github.com/openshift/client-go/machineconfiguration/listers/machineconfiguration/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -16,10 +15,9 @@ import (
 	"k8s.io/klog/v2"
 )
 
-// errIRIDisabled is returned by resolve when the NoRegistryClusterInstall
-// feature gate is off or the InternalReleaseImage resource is absent.
-// Merge treats it as a skip signal rather than an error.
-var errIRIDisabled = errors.New("IRI not enabled or not present")
+// errIRIDisabled is returned by resolve when the InternalReleaseImage
+// resource is absent. Merge treats it as a skip signal rather than an error.
+var errIRIDisabled = errors.New("IRI not present")
 
 // IRISecretMerger merges IRI registry credentials into a pull secret.
 // Construct via NewIRISecretMerger (controller use) or NewIRISecretMergerFromObjects
@@ -30,21 +28,16 @@ type IRISecretMerger struct {
 	resolve func() (password, baseDomain string, err error)
 }
 
-// NewIRISecretMerger creates an IRISecretMerger that resolves the feature gate,
+// NewIRISecretMerger creates an IRISecretMerger that resolves the
 // IRI resource, credentials secret, and ControllerConfig from the informer cache
 // at merge time. Use this in controllers where informers are available.
-// fgHandler must not be nil.
 func NewIRISecretMerger(
 	secretLister corelistersv1.SecretLister,
 	ccLister mcfglistersv1.ControllerConfigLister,
 	iriLister mcfglistersv1.InternalReleaseImageLister,
-	fgHandler FeatureGatesHandler,
 ) *IRISecretMerger {
 	return &IRISecretMerger{
 		resolve: func() (string, string, error) {
-			if !fgHandler.Enabled(features.FeatureGateNoRegistryClusterInstall) {
-				return "", "", errIRIDisabled
-			}
 			_, err := iriLister.Get(InternalReleaseImageInstanceName)
 			if apierrors.IsNotFound(err) {
 				return "", "", errIRIDisabled
@@ -67,19 +60,15 @@ func NewIRISecretMerger(
 
 // NewIRISecretMergerFromObjects creates an IRISecretMerger from pre-fetched objects.
 // Use this during bootstrap where informer caches are not yet available.
-// The feature gate and iri checks are deferred to Merge time so the constructor
-// never returns an error; if either check fails, Merge skips and logs.
+// The iri check is deferred to Merge time so the constructor
+// never returns an error; if the check fails, Merge skips and logs.
 func NewIRISecretMergerFromObjects(
 	secret *corev1.Secret,
 	cconfig *mcfgv1.ControllerConfig,
-	fgHandler FeatureGatesHandler,
 	iri bool,
 ) *IRISecretMerger {
 	return &IRISecretMerger{
 		resolve: func() (string, string, error) {
-			if fgHandler == nil || !fgHandler.Enabled(features.FeatureGateNoRegistryClusterInstall) {
-				return "", "", errIRIDisabled
-			}
 			if !iri {
 				return "", "", errIRIDisabled
 			}
@@ -91,12 +80,12 @@ func NewIRISecretMergerFromObjects(
 // Merge merges IRI registry credentials into pullSecretRaw, adding auth entries
 // for api-int.<baseDomain>:<IRIRegistryPort> (all nodes) and
 // localhost:<IRIRegistryPort> (masters, where the registry runs locally).
-// If the feature gate is disabled or the InternalReleaseImage resource is absent,
-// Merge logs and returns pullSecretRaw unchanged.
+// If the InternalReleaseImage resource is absent, Merge logs and returns
+// pullSecretRaw unchanged.
 func (m *IRISecretMerger) Merge(pullSecretRaw []byte) ([]byte, error) {
 	password, baseDomain, err := m.resolve()
 	if errors.Is(err, errIRIDisabled) {
-		klog.V(4).Info("Skipping IRI registry credential merge: IRI not enabled or not present")
+		klog.V(4).Info("Skipping IRI registry credential merge: IRI not present")
 		return pullSecretRaw, nil
 	}
 	if err != nil {

--- a/pkg/controller/common/iri_secret_merger_test.go
+++ b/pkg/controller/common/iri_secret_merger_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	configv1 "github.com/openshift/api/config/v1"
-	features "github.com/openshift/api/features"
 	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
 	mcfglistersv1 "github.com/openshift/client-go/machineconfiguration/listers/machineconfiguration/v1"
 	"github.com/stretchr/testify/assert"
@@ -51,14 +50,6 @@ func newIRIObject() *mcfgv1.InternalReleaseImage {
 	}
 }
 
-func fgEnabled() FeatureGatesHandler {
-	return NewFeatureGatesHardcodedHandler([]configv1.FeatureGateName{features.FeatureGateNoRegistryClusterInstall}, nil)
-}
-
-func fgDisabled() FeatureGatesHandler {
-	return NewFeatureGatesHardcodedHandler(nil, []configv1.FeatureGateName{features.FeatureGateNoRegistryClusterInstall})
-}
-
 func newSecretLister(secrets ...*corev1.Secret) corelistersv1.SecretLister {
 	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
 	for _, s := range secrets {
@@ -97,8 +88,7 @@ func TestIRISecretMergerFromObjects(t *testing.T) {
 		pullSecret      string
 		secret          *corev1.Secret
 		cconfig         *mcfgv1.ControllerConfig
-		fgHandler       FeatureGatesHandler
-		iri        bool
+		iri             bool
 		expectUnchanged bool
 		expectError     bool
 		verifyAuthHost  string
@@ -108,26 +98,15 @@ func TestIRISecretMergerFromObjects(t *testing.T) {
 			pullSecret:     basePullSecret,
 			secret:         validSecret,
 			cconfig:        validCconfig,
-			fgHandler:      fgEnabled(),
-			iri:       true,
+			iri:            true,
 			verifyAuthHost: "api-int.example.com:22625",
-		},
-		{
-			name:            "feature gate disabled skips merge",
-			pullSecret:      basePullSecret,
-			secret:          validSecret,
-			cconfig:         validCconfig,
-			fgHandler:       fgDisabled(),
-			iri:        true,
-			expectUnchanged: true,
 		},
 		{
 			name:            "iri not found skips merge",
 			pullSecret:      basePullSecret,
 			secret:          validSecret,
 			cconfig:         validCconfig,
-			fgHandler:       fgEnabled(),
-			iri:        false,
+			iri:             false,
 			expectUnchanged: true,
 		},
 		{
@@ -135,8 +114,7 @@ func TestIRISecretMergerFromObjects(t *testing.T) {
 			pullSecret:  basePullSecret,
 			secret:      nil,
 			cconfig:     validCconfig,
-			fgHandler:   fgEnabled(),
-			iri:    true,
+			iri:         true,
 			expectError: true,
 		},
 		{
@@ -144,8 +122,7 @@ func TestIRISecretMergerFromObjects(t *testing.T) {
 			pullSecret:  basePullSecret,
 			secret:      validSecret,
 			cconfig:     nil,
-			fgHandler:   fgEnabled(),
-			iri:    true,
+			iri:         true,
 			expectError: true,
 		},
 		{
@@ -153,8 +130,7 @@ func TestIRISecretMergerFromObjects(t *testing.T) {
 			pullSecret:  basePullSecret,
 			secret:      validSecret,
 			cconfig:     &mcfgv1.ControllerConfig{},
-			fgHandler:   fgEnabled(),
-			iri:    true,
+			iri:         true,
 			expectError: true,
 		},
 		{
@@ -162,8 +138,7 @@ func TestIRISecretMergerFromObjects(t *testing.T) {
 			pullSecret:  basePullSecret,
 			secret:      newIRIRegistryCredentialsSecret(""),
 			cconfig:     validCconfig,
-			fgHandler:   fgEnabled(),
-			iri:    true,
+			iri:         true,
 			expectError: true,
 		},
 		{
@@ -171,8 +146,7 @@ func TestIRISecretMergerFromObjects(t *testing.T) {
 			pullSecret:      pullSecretWithIRIRegistryCredentials("example.com", "testpassword"),
 			secret:          validSecret,
 			cconfig:         validCconfig,
-			fgHandler:       fgEnabled(),
-			iri:        true,
+			iri:             true,
 			expectUnchanged: true,
 		},
 		{
@@ -180,8 +154,7 @@ func TestIRISecretMergerFromObjects(t *testing.T) {
 			pullSecret:     pullSecretWithIRIRegistryCredentials("example.com", "oldpassword"),
 			secret:         newIRIRegistryCredentialsSecret("newpassword"),
 			cconfig:        validCconfig,
-			fgHandler:      fgEnabled(),
-			iri:       true,
+			iri:            true,
 			verifyAuthHost: "api-int.example.com:22625",
 		},
 		{
@@ -189,8 +162,7 @@ func TestIRISecretMergerFromObjects(t *testing.T) {
 			pullSecret:  "not-json",
 			secret:      validSecret,
 			cconfig:     validCconfig,
-			fgHandler:   fgEnabled(),
-			iri:    true,
+			iri:         true,
 			expectError: true,
 		},
 		{
@@ -198,15 +170,14 @@ func TestIRISecretMergerFromObjects(t *testing.T) {
 			pullSecret:  `{"registry":"quay.io"}`,
 			secret:      validSecret,
 			cconfig:     validCconfig,
-			fgHandler:   fgEnabled(),
-			iri:    true,
+			iri:         true,
 			expectError: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			merger := NewIRISecretMergerFromObjects(tt.secret, tt.cconfig, tt.fgHandler, tt.iri)
+			merger := NewIRISecretMergerFromObjects(tt.secret, tt.cconfig, tt.iri)
 			result, err := merger.Merge([]byte(tt.pullSecret))
 
 			if tt.expectError {
@@ -235,7 +206,6 @@ func TestIRISecretMergerFromListers(t *testing.T) {
 		secrets         []*corev1.Secret
 		cconfigs        []*mcfgv1.ControllerConfig
 		iris            []*mcfgv1.InternalReleaseImage
-		fgHandler       FeatureGatesHandler
 		expectUnchanged bool
 		expectError     bool
 		verifyAuthHost  string
@@ -246,17 +216,7 @@ func TestIRISecretMergerFromListers(t *testing.T) {
 			secrets:        []*corev1.Secret{secret},
 			cconfigs:       []*mcfgv1.ControllerConfig{cconfig},
 			iris:           []*mcfgv1.InternalReleaseImage{iri},
-			fgHandler:      fgEnabled(),
 			verifyAuthHost: "api-int.example.com:22625",
-		},
-		{
-			name:            "feature gate disabled skips merge",
-			pullSecret:      basePullSecret,
-			secrets:         []*corev1.Secret{secret},
-			cconfigs:        []*mcfgv1.ControllerConfig{cconfig},
-			iris:            []*mcfgv1.InternalReleaseImage{iri},
-			fgHandler:       fgDisabled(),
-			expectUnchanged: true,
 		},
 		{
 			name:            "IRI resource not found skips merge",
@@ -264,7 +224,6 @@ func TestIRISecretMergerFromListers(t *testing.T) {
 			secrets:         []*corev1.Secret{secret},
 			cconfigs:        []*mcfgv1.ControllerConfig{cconfig},
 			iris:            nil,
-			fgHandler:       fgEnabled(),
 			expectUnchanged: true,
 		},
 		{
@@ -273,7 +232,6 @@ func TestIRISecretMergerFromListers(t *testing.T) {
 			secrets:     nil,
 			cconfigs:    []*mcfgv1.ControllerConfig{cconfig},
 			iris:        []*mcfgv1.InternalReleaseImage{iri},
-			fgHandler:   fgEnabled(),
 			expectError: true,
 		},
 		{
@@ -281,8 +239,7 @@ func TestIRISecretMergerFromListers(t *testing.T) {
 			pullSecret:      pullSecretWithIRIRegistryCredentials("example.com", "testpassword"),
 			secrets:         []*corev1.Secret{secret},
 			cconfigs:        []*mcfgv1.ControllerConfig{cconfig},
-			iris:            []*mcfgv1.InternalReleaseImage{iri},
-			fgHandler:       fgEnabled(),
+			iris:           []*mcfgv1.InternalReleaseImage{iri},
 			expectUnchanged: true,
 		},
 		{
@@ -291,7 +248,6 @@ func TestIRISecretMergerFromListers(t *testing.T) {
 			secrets:        []*corev1.Secret{newIRIRegistryCredentialsSecret("newpassword")},
 			cconfigs:       []*mcfgv1.ControllerConfig{cconfig},
 			iris:           []*mcfgv1.InternalReleaseImage{iri},
-			fgHandler:      fgEnabled(),
 			verifyAuthHost: "api-int.example.com:22625",
 		},
 		{
@@ -300,7 +256,6 @@ func TestIRISecretMergerFromListers(t *testing.T) {
 			secrets:     []*corev1.Secret{secret},
 			cconfigs:    []*mcfgv1.ControllerConfig{{ObjectMeta: metav1.ObjectMeta{Name: ControllerConfigName}}},
 			iris:        []*mcfgv1.InternalReleaseImage{iri},
-			fgHandler:   fgEnabled(),
 			expectError: true,
 		},
 		{
@@ -309,7 +264,6 @@ func TestIRISecretMergerFromListers(t *testing.T) {
 			secrets:     []*corev1.Secret{newIRIRegistryCredentialsSecret("")},
 			cconfigs:    []*mcfgv1.ControllerConfig{cconfig},
 			iris:        []*mcfgv1.InternalReleaseImage{iri},
-			fgHandler:   fgEnabled(),
 			expectError: true,
 		},
 	}
@@ -320,7 +274,6 @@ func TestIRISecretMergerFromListers(t *testing.T) {
 				newSecretLister(tt.secrets...),
 				newCCLister(tt.cconfigs...),
 				newIRILister(tt.iris...),
-				tt.fgHandler,
 			)
 			result, err := merger.Merge([]byte(tt.pullSecret))
 

--- a/pkg/controller/template/template_controller.go
+++ b/pkg/controller/template/template_controller.go
@@ -121,13 +121,8 @@ func New(
 	} else {
 		ctrl.iriSecretsInformerSynced = func() bool { return true }
 	}
-	if iriInformer != nil {
-		ctrl.iriInformerSynced = iriInformer.Informer().HasSynced
-		ctrl.iriMerger = ctrlcommon.NewIRISecretMerger(iriSecretsInformer.Lister(), ctrl.ccLister, iriInformer.Lister())
-	} else {
-		ctrl.iriInformerSynced = func() bool { return true }
-		ctrl.iriMerger = ctrlcommon.NewIRISecretMerger(nil, ctrl.ccLister, nil)
-	}
+	ctrl.iriInformerSynced = iriInformer.Informer().HasSynced
+	ctrl.iriMerger = ctrlcommon.NewIRISecretMerger(iriSecretsInformer.Lister(), ctrl.ccLister, iriInformer.Lister())
 
 	ccInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    ctrl.addControllerConfig,

--- a/pkg/controller/template/template_controller.go
+++ b/pkg/controller/template/template_controller.go
@@ -92,7 +92,6 @@ func New(
 	apiserverInformer configinformersv1.APIServerInformer,
 	kubeClient clientset.Interface,
 	mcfgClient mcfgclientset.Interface,
-	fgHandler ctrlcommon.FeatureGatesHandler,
 ) *Controller {
 	eventBroadcaster := record.NewBroadcaster()
 	eventBroadcaster.StartLogging(klog.Infof)
@@ -124,10 +123,10 @@ func New(
 	}
 	if iriInformer != nil {
 		ctrl.iriInformerSynced = iriInformer.Informer().HasSynced
-		ctrl.iriMerger = ctrlcommon.NewIRISecretMerger(iriSecretsInformer.Lister(), ctrl.ccLister, iriInformer.Lister(), fgHandler)
+		ctrl.iriMerger = ctrlcommon.NewIRISecretMerger(iriSecretsInformer.Lister(), ctrl.ccLister, iriInformer.Lister())
 	} else {
 		ctrl.iriInformerSynced = func() bool { return true }
-		ctrl.iriMerger = ctrlcommon.NewIRISecretMerger(nil, ctrl.ccLister, nil, fgHandler)
+		ctrl.iriMerger = ctrlcommon.NewIRISecretMerger(nil, ctrl.ccLister, nil)
 	}
 
 	ccInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{

--- a/pkg/controller/template/template_controller_test.go
+++ b/pkg/controller/template/template_controller_test.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 
-	features "github.com/openshift/api/features"
 	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
 
@@ -62,9 +61,6 @@ type fixture struct {
 	// iriObjects are loaded into a separate fake client used only for the IRI
 	// informer, so that IRI list/watch calls do not pollute the main f.actions list.
 	iriObjects []runtime.Object
-	// fgHandler overrides the feature gate handler used by the controller.
-	// Defaults to all gates disabled (nil, nil) if not set.
-	fgHandler ctrlcommon.FeatureGatesHandler
 }
 
 func newFixture(t *testing.T) *fixture {
@@ -74,7 +70,6 @@ func newFixture(t *testing.T) *fixture {
 	f.kubeobjects = []runtime.Object{}
 	f.oseobjects = []runtime.Object{}
 	f.iriObjects = []runtime.Object{}
-	f.fgHandler = ctrlcommon.NewFeatureGatesHardcodedHandler(nil, nil)
 	return f
 }
 
@@ -134,8 +129,7 @@ func (f *fixture) newController() *Controller {
 		cinformer.Core().V1().Secrets(), // iriSecretsInformer: reuse same factory in tests; not exercised here
 		iriInformers.Machineconfiguration().V1().InternalReleaseImages(),
 		apiserverinformer.Config().V1().APIServers(),
-		f.kubeclient, f.client,
-		f.fgHandler)
+		f.kubeclient, f.client)
 
 	c.ccListerSynced = alwaysReady
 	c.secretsInformerSynced = alwaysReady
@@ -571,8 +565,6 @@ func TestMergesIRIRegistryCredentialsIntoPullSecret(t *testing.T) {
 	f.iriObjects = append(f.iriObjects, &mcfgv1.InternalReleaseImage{
 		ObjectMeta: metav1.ObjectMeta{Name: ctrlcommon.InternalReleaseImageInstanceName},
 	})
-	f.fgHandler = ctrlcommon.NewFeatureGatesHardcodedHandler(
-		[]configv1.FeatureGateName{features.FeatureGateNoRegistryClusterInstall}, nil)
 
 	ctrl := f.newController()
 	if err := ctrl.syncHandler(ctrlcommon.ControllerConfigName); err != nil {

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -372,10 +372,8 @@ func New(
 		// TODO: Move this AddEventHandler to the main loop when the FG is removed
 		osImageStreamInformer.Informer().AddEventHandler(optr.eventHandler())
 	}
-	if iriInformer != nil {
-		optr.iriLister = iriInformer.Lister()
-		optr.iriListerSynced = iriInformer.Informer().HasSynced
-	}
+	optr.iriLister = iriInformer.Lister()
+	optr.iriListerSynced = iriInformer.Informer().HasSynced
 
 	// Set up a dynamic informer for the Provisioning CR (metal3.io/v1alpha1).
 	// The informer is only started in Run() when the cluster is on BareMetal to avoid
@@ -454,9 +452,7 @@ func (optr *Operator) Run(ctx context.Context, workers int) {
 	if optr.osImageStreamListerSynced != nil && osimagestream.IsFeatureEnabled(optr.fgHandler) {
 		cacheSynced = append(cacheSynced, optr.osImageStreamListerSynced)
 	}
-	if optr.iriListerSynced != nil {
-		cacheSynced = append(cacheSynced, optr.iriListerSynced)
-	}
+	cacheSynced = append(cacheSynced, optr.iriListerSynced)
 	if !cache.WaitForCacheSync(ctx.Done(),
 		cacheSynced...) {
 		klog.Error("failed to sync caches")

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -1247,13 +1247,11 @@ func (optr *Operator) syncMachineConfigController(config *renderConfig, _ *confi
 		paths.validatingAdmissionPolicyBindings = append(paths.validatingAdmissionPolicyBindings, mccUpdateBootImagesCPMSValidatingAdmissionPolicyBindingPath)
 	}
 
-	if optr.fgHandler.Enabled(features.FeatureGateNoRegistryClusterInstall) {
-		// Only deploy the IRI deletion guard policy if the IRI resource actually exists
-		if optr.iriLister != nil {
-			if _, err := optr.iriLister.Get(ctrlcommon.InternalReleaseImageInstanceName); err == nil {
-				paths.validatingAdmissionPolicies = append(paths.validatingAdmissionPolicies, mccIRIDeletionGuardValidatingAdmissionPolicyPath)
-				paths.validatingAdmissionPolicyBindings = append(paths.validatingAdmissionPolicyBindings, mccIRIDeletionGuardValidatingAdmissionPolicyBindingPath)
-			}
+	// Only deploy the IRI deletion guard policy if the IRI resource actually exists
+	if optr.iriLister != nil {
+		if _, err := optr.iriLister.Get(ctrlcommon.InternalReleaseImageInstanceName); err == nil {
+			paths.validatingAdmissionPolicies = append(paths.validatingAdmissionPolicies, mccIRIDeletionGuardValidatingAdmissionPolicyPath)
+			paths.validatingAdmissionPolicyBindings = append(paths.validatingAdmissionPolicyBindings, mccIRIDeletionGuardValidatingAdmissionPolicyBindingPath)
 		}
 	}
 

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -1248,11 +1248,9 @@ func (optr *Operator) syncMachineConfigController(config *renderConfig, _ *confi
 	}
 
 	// Only deploy the IRI deletion guard policy if the IRI resource actually exists
-	if optr.iriLister != nil {
-		if _, err := optr.iriLister.Get(ctrlcommon.InternalReleaseImageInstanceName); err == nil {
-			paths.validatingAdmissionPolicies = append(paths.validatingAdmissionPolicies, mccIRIDeletionGuardValidatingAdmissionPolicyPath)
-			paths.validatingAdmissionPolicyBindings = append(paths.validatingAdmissionPolicyBindings, mccIRIDeletionGuardValidatingAdmissionPolicyBindingPath)
-		}
+	if _, err := optr.iriLister.Get(ctrlcommon.InternalReleaseImageInstanceName); err == nil {
+		paths.validatingAdmissionPolicies = append(paths.validatingAdmissionPolicies, mccIRIDeletionGuardValidatingAdmissionPolicyPath)
+		paths.validatingAdmissionPolicyBindings = append(paths.validatingAdmissionPolicyBindings, mccIRIDeletionGuardValidatingAdmissionPolicyBindingPath)
 	}
 
 	if err := optr.applyManifests(config, paths); err != nil {

--- a/test/e2e-bootstrap/bootstrap_test.go
+++ b/test/e2e-bootstrap/bootstrap_test.go
@@ -571,7 +571,6 @@ func createControllers(ctx *ctrlcommon.ControllerContext) []ctrlcommon.Controlle
 			ctx.ConfigInformerFactory.Config().V1().APIServers(),
 			ctx.ClientBuilder.KubeClientOrDie("template-controller"),
 			ctx.ClientBuilder.MachineConfigClientOrDie("template-controller"),
-			ctx.FeatureGatesHandler,
 		),
 		// Add all "sub-renderers here"
 		kubeletconfig.New(

--- a/test/e2e-iri/main_test.go
+++ b/test/e2e-iri/main_test.go
@@ -2,48 +2,14 @@ package e2e_iri_test
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"testing"
 
-	"github.com/openshift/api/features"
-	"github.com/stretchr/testify/require"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/machine-config-operator/test/framework"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
-
-func TestMain(m *testing.M) {
-	skip, err := skipIRITests()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "skip IRI check failed: %v\n", err)
-		os.Exit(1)
-	}
-	if skip {
-		os.Exit(0)
-	}
-	os.Exit(m.Run())
-}
-
-func skipIRITests() (bool, error) {
-	cs := framework.NewClientSet("")
-	ctx := context.Background()
-
-	// Check if NoRegistryClusterInstall feature is enabled.
-	fg, err := cs.FeatureGates().Get(ctx, "cluster", v1.GetOptions{})
-	if err != nil {
-		return true, err
-	}
-	// Assume only one version has been installed.
-	for _, d := range fg.Status.FeatureGates[0].Disabled {
-		if d.Name == features.FeatureGateNoRegistryClusterInstall {
-			return true, nil
-		}
-	}
-
-	return false, nil
-}
 
 func skipIfNoBaremetal(t *testing.T) {
 	infra, err := framework.NewClientSet("").Infrastructures().Get(context.Background(), "cluster", v1.GetOptions{})


### PR DESCRIPTION
The InternalReleaseImage(IRI) functionality will now be always active instead of being gated behind a feature flag

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Remove all NoRegistryClusterInstall feature gate check

**- How to verify it**

/test e2e-agent-compact-ipv4-iso-no-registry

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Internal Release Image management is now enabled by default.
  * Internal Release Image resources, certificates, credentials, bootstrap configuration, and deletion safeguards are processed whenever the resource is present.
  * Related controllers and informers now start automatically, providing more consistent cluster setup and resource management.

* **Tests**
  * Updated unit and end-to-end coverage to reflect always-on Internal Release Image functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->