### PR TITLE
NO-JIRA: Skip OVN-K VRFs in ofport-request dispatcher script

### DIFF
--- a/templates/common/_base/files/ofport-request.yaml
+++ b/templates/common/_base/files/ofport-request.yaml
@@ -21,7 +21,12 @@ contents:
     if [ "${OPERATION}" != "pre-up" ]; then
         exit 0
     fi
-    
+
+    # Skip OVN-K VRFs (they have an ovn-k8s-mp lower device) to avoid wasted nmcli calls.
+    if ls /sys/class/net/"${INTERFACE_NAME}"/ 2>/dev/null | grep -q lower_ovn-k8s-mp; then
+        exit 0
+    fi
+
     # Get the interface's NM uuid
     INTERFACE_CONNECTION_UUID=$(nmcli -t -f device,type,uuid conn | awk -F ':' '{if($1=="'${INTERFACE_NAME}'" && $2!~/^ovs*/) print $NF}')
     if [ "${INTERFACE_CONNECTION_UUID}" == "" ]; then


### PR DESCRIPTION
The pre-up dispatcher runs 10-ofport-request.sh for every device NM brings up, including OVN-K UDN VRFs. The script's first step is `nmcli -t -f device,type,uuid conn`, a full connection dump whose cost grows with the number of NM connections. OVN-K VRFs never match the ovs-port / br-ex checks, so they always fall through to `exit 0` -- but only after that scan (~2s each at a few hundred connections). With one pre-up per VRF, this is O(N^2): at scale (e.g. CUDN density tests with hundreds of VRFs per node) it consumes minutes of CPU per node and blocks device activation.

OVN-K VRFs are identifiable cheaply via sysfs: they have an ovn-k8s-mp lower device. Skip them before the nmcli calls. Same exit 0 outcome, no netlink or ovsdb access.

I considered ignoring the VRFs in NetworkManager instead, but the filter matches by interface name, and VRF names aren't predictable - short network names are used verbatim. The broader `type:vrf` unmanaged setting is too heavy-handed since it would unmanage every VRF on every node, including ones other features or admins create.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of OVN-Kubernetes VRF interfaces by preventing unnecessary network processing.
  * Preserved existing behavior for all other network interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->