### PR TITLE
OCPBUGS-100065: on-prem: tune API VIP haproxy health checks

### DIFF
--- a/templates/master/00-master/on-prem/files/haproxy-haproxy.yaml
+++ b/templates/master/00-master/on-prem/files/haproxy-haproxy.yaml
@@ -48,5 +48,5 @@ contents:
        option  httpchk GET /readyz HTTP/1.0
        balance roundrobin
     {{`{{- range .LBConfig.Backends }}
-       server {{ .Host }} {{ .Address }}:{{ .Port }} weight 1 verify none check check-ssl inter 5s fall 3 rise 1
+       server {{ .Host }} {{ .Address }}:{{ .Port }} weight 256 verify none check check-ssl inter 5s fastinter 2s fall 2 rise 3 slowstart 60s on-marked-down shutdown-sessions
     {{- end }}`}}


### PR DESCRIPTION
## What

Tunes the health-check parameters of the on-prem API VIP haproxy `masters` backend (single server-line change in the MCO template):

| knob | before | after | why |
|---|---|---|---|
| `rise` | 1 | 3 | require 3 consecutive passing `/readyz` probes (+10s buffer) before re-adding a rebooted master |
| `weight` / `slowstart` | 1 / none | 256 / 60s | ramp a newly risen server's share of **new** connections from ~4% to 100% over 60s instead of instantly taking a full round-robin share; large base weight is needed for ramp granularity (relative weights stay equal) |
| `fall` / `fastinter` | 3 / none | 2 / 2s | mark a dying master down in ~4s instead of ~15s |
| `on-marked-down shutdown-sessions` | — | added | terminate established client connections to a marked-down server so clients reconnect to healthy masters instead of timing out |

## Why

On metal-ipi upgrades, the kube-apiserver on a freshly rebooted master passes `/readyz` (core API works over host network) ~20-30s **before** the node's OVN pod network converges. With `rise 1`, haproxy re-adds it to the VIP rotation on a single passing probe and immediately routes ~1/3 of new connections to it; requests proxied to aggregated APIs (oauth-apiserver, openshift-apiserver) hang, and broken http2 backend connections stay pinned for up to 45s, producing 10-15s of `oauth-api-new-connections` disruption in ~30-50% of master-updating upgrade runs. Full analysis in [OCPBUGS-100065](https://issues.redhat.com/browse/OCPBUGS-100065).

This is a downstream mitigation for the routing half of the bug; the aggregator-side fixes are openshift/kubernetes#2730 (readyz reachability semantics) and openshift/kubernetes#2732 (fast http2 dead-connection detection, being upstreamed via kubernetes/kubernetes#141318).

## Expected impact / validation

`slowstart` reduces the probability of a new connection landing on the not-yet-converged kas during the vulnerable ~40-70s window from ~33% to a few percent early in the window. We will benchmark by running dozens of pj-rehearse runs of `e2e-metal-ipi-upgrade-ovn-ipv6` / `e2e-metal-ipi-ovn-upgrade-runc` and comparing `oauth-api-new-connections` disruption totals against baseline (baseline data in the Jira).

## Risk

- Longer re-add delay (+10s) and 60s traffic ramp slightly extend the reduced-capacity period after a master reboot (2 masters carry most new connections for ~1 min).
- `shutdown-sessions` kills established client connections when a master is marked down; clients reconnect via the VIP to healthy masters. This is intentionally aggressive to shrink VIP-failover disruption episodes and is called out for reviewer attention.
- `pkg/controller/template` render tests pass.

---
_This PR description was generated using AI. Please verify before acting on it._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved HAProxy backend server traffic distribution and health monitoring.
  * Added faster failure detection and recovery behavior.
  * Enabled gradual traffic ramp-up when servers return to service.
  * Ensured active sessions close when a server is marked unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->