### PR TITLE
OCPBUGS-109633: on-prem: resign VIPs deterministically before node shutdown

### DIFF
--- a/pkg/controller/template/render_keepalived_vip_resign_test.go
+++ b/pkg/controller/template/render_keepalived_vip_resign_test.go
@@ -1,0 +1,125 @@
+package template
+
+import (
+	"strings"
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/vincent-petithory/dataurl"
+
+	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
+)
+
+// TestKeepalivedVipResignRendering verifies that the keepalived-vip-resign
+// systemd unit and its script are rendered for on-prem platforms, that the
+// unit is only enabled when the cluster uses the OpenShift-managed load
+// balancer and VIPs are configured, and that all API and ingress VIPs end
+// up in the script, for both master and worker roles.
+// See https://issues.redhat.com/browse/OCPBUGS-109633
+func TestKeepalivedVipResignRendering(t *testing.T) {
+	controllerConfig, err := controllerConfigFromFile("test_data/controller_config_baremetal.yaml")
+	if err != nil {
+		t.Fatalf("failed to get controllerconfig config: %v", err)
+	}
+
+	tests := []struct {
+		name          string
+		apiVIPs       []string
+		ingressVIPs   []string
+		userManagedLB bool
+		wantEnabled   bool
+		wantVIPS      string
+	}{
+		{
+			name:        "no VIPs",
+			wantEnabled: false,
+			wantVIPS:    `VIPS=""`,
+		},
+		{
+			name:        "single stack",
+			apiVIPs:     []string{"10.0.0.1"},
+			ingressVIPs: []string{"10.0.0.2"},
+			wantEnabled: true,
+			wantVIPS:    `VIPS="10.0.0.1 10.0.0.2"`,
+		},
+		{
+			name:        "dual stack",
+			apiVIPs:     []string{"10.0.0.1", "fd00::1"},
+			ingressVIPs: []string{"10.0.0.2", "fd00::2"},
+			wantEnabled: true,
+			wantVIPS:    `VIPS="10.0.0.1 fd00::1 10.0.0.2 fd00::2"`,
+		},
+		{
+			name:        "ingress VIPs only",
+			ingressVIPs: []string{"10.0.0.2"},
+			wantEnabled: true,
+			wantVIPS:    `VIPS=" 10.0.0.2"`,
+		},
+		{
+			name:          "user-managed load balancer",
+			apiVIPs:       []string{"10.0.0.1"},
+			ingressVIPs:   []string{"10.0.0.2"},
+			userManagedLB: true,
+			wantEnabled:   false,
+			wantVIPS:      `VIPS="10.0.0.1 10.0.0.2"`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cc := controllerConfig.DeepCopy()
+			cc.Spec.Infra.Status.PlatformStatus.BareMetal.APIServerInternalIPs = tc.apiVIPs
+			cc.Spec.Infra.Status.PlatformStatus.BareMetal.IngressIPs = tc.ingressVIPs
+			if tc.userManagedLB {
+				cc.Spec.Infra.Status.PlatformStatus.BareMetal.LoadBalancer = &configv1.BareMetalPlatformLoadBalancer{
+					Type: configv1.LoadBalancerTypeUserManaged,
+				}
+			}
+
+			cfgs, err := generateTemplateMachineConfigs(&RenderConfig{&cc.Spec, `{"dummy":"dummy"}`, "dummy", nil, nil}, templateDir)
+			if err != nil {
+				t.Fatalf("failed to generate machine configs: %v", err)
+			}
+
+			foundUnit := map[string]bool{}
+			foundScript := map[string]bool{}
+			for _, cfg := range cfgs {
+				role := cfg.Labels["machineconfiguration.openshift.io/role"]
+				ign, err := ctrlcommon.ParseAndConvertConfig(cfg.Spec.Config.Raw)
+				if err != nil {
+					t.Fatalf("failed to parse Ignition config for %s: %v", cfg.Name, err)
+				}
+				for _, u := range ign.Systemd.Units {
+					if u.Name != "keepalived-vip-resign.service" {
+						continue
+					}
+					foundUnit[role] = true
+					if u.Enabled == nil || *u.Enabled != tc.wantEnabled {
+						t.Errorf("%s: unit enabled = %v, want %v", cfg.Name, u.Enabled, tc.wantEnabled)
+					}
+				}
+				for _, f := range ign.Storage.Files {
+					if f.Path != "/usr/local/bin/keepalived-vip-resign.sh" {
+						continue
+					}
+					foundScript[role] = true
+					contents, err := dataurl.DecodeString(*f.Contents.Source)
+					if err != nil {
+						t.Fatalf("failed to decode script contents: %v", err)
+					}
+					if !strings.Contains(string(contents.Data), tc.wantVIPS) {
+						t.Errorf("%s: script does not contain %q", cfg.Name, tc.wantVIPS)
+					}
+				}
+			}
+			for _, role := range []string{"master", "worker"} {
+				if !foundUnit[role] {
+					t.Errorf("keepalived-vip-resign.service unit not rendered for role %s", role)
+				}
+				if !foundScript[role] {
+					t.Errorf("keepalived-vip-resign.sh script not rendered for role %s", role)
+				}
+			}
+		})
+	}
+}

--- a/templates/common/on-prem/files/keepalived-vip-resign-script.yaml
+++ b/templates/common/on-prem/files/keepalived-vip-resign-script.yaml
@@ -1,0 +1,102 @@
+mode: 0755
+path: "/usr/local/bin/keepalived-vip-resign.sh"
+contents:
+  inline: |
+    #!/bin/bash
+    # Resign the on-prem VIPs before the node shuts down.
+    #
+    # During "systemctl reboot" systemd tears down all container scopes and
+    # the network stack in parallel. Whether keepalived manages to send its
+    # VRRP priority-0 resign advertisement and remove the VIPs from the
+    # interface before it is killed is a race. When it loses, the VIP stays
+    # configured on the rebooting node while its kube-apiserver is still
+    # gracefully draining (and the local haproxy redirect is already gone),
+    # so external clients are routed straight to a not-ready apiserver for
+    # up to ~70 seconds. See https://issues.redhat.com/browse/OCPBUGS-109633
+    #
+    # This script runs as ExecStop of keepalived-vip-resign.service, which
+    # is ordered to stop before crio, kubelet and NetworkManager at system
+    # shutdown. It asks keepalived to shut down cleanly (priority-0 advert
+    # + VIP removal) and waits until the VIPs are actually gone. If
+    # keepalived does not finish in time it is killed and the VIPs are
+    # removed directly, so that no stale VIP survives into the shutdown
+    # window.
+    #
+    # No "set -e": every path must fall through to the force-removal
+    # fallback and exit 0; individual failures are tolerated deliberately.
+    set -ux
+    PATH=/usr/sbin:/usr/bin
+
+    VIPS="{{- range $index, $ip := onPremPlatformAPIServerInternalIPs . }}{{ if gt $index 0 }} {{end}}{{$ip}}{{end}}
+    {{- range onPremPlatformIngressIPs . }} {{.}}{{end}}"
+
+    # Only act while the system is actually shutting down. A plain
+    # "systemctl stop/restart" of this unit on a healthy node (manual, or
+    # a MachineConfig rollout replacing the unit) must not flap the VIPs.
+    # If systemctl itself is unavailable we are deep into shutdown, so
+    # treat that as "stopping".
+    running_state=$(systemctl is-system-running 2>/dev/null) || true
+    if [ -n "${running_state}" ] && [ "${running_state}" != "stopping" ]; then
+        echo "keepalived-vip-resign: system is ${running_state}, not shutting down; nothing to do"
+        exit 0
+    fi
+
+    vip_configured() {
+        # $1 - VIP address; prints "<dev> <cidr>" if configured, else
+        # nothing. "ip addr show to" compares addresses kernel-side, so
+        # non-canonical VIP spellings (uncompressed/uppercase IPv6) still
+        # match.
+        ip -o addr show to "${1}" | awk '{print $2, $4; exit}'
+    }
+
+    any_vip_configured() {
+        for vip in ${VIPS}; do
+            [ -n "$(vip_configured "${vip}")" ] && return 0
+        done
+        return 1
+    }
+
+    if ! any_vip_configured; then
+        echo "keepalived-vip-resign: no VIP configured on this node, nothing to do"
+        exit 0
+    fi
+
+    # Ask keepalived to shut down cleanly. On SIGTERM it sends a VRRP
+    # priority-0 advertisement (instant failover on the peers) and removes
+    # the VIPs from the interface. Exact comm match (-x) is required:
+    # an unanchored "keepalived" also matches dynkeepalived (the
+    # keepalived-monitor process) and this very script's own comm
+    # ("keepalived-vip-").
+    signaled=0
+    if pid=$(pgrep -ox keepalived); then
+        echo "keepalived-vip-resign: sending SIGTERM to keepalived (pid ${pid})"
+        if kill -s TERM "${pid}"; then
+            signaled=1
+        fi
+    else
+        echo "keepalived-vip-resign: keepalived is not running"
+    fi
+
+    if [ "${signaled}" -eq 1 ]; then
+        for _ in $(seq 1 10); do
+            any_vip_configured || {
+                echo "keepalived-vip-resign: all VIPs resigned"
+                exit 0
+            }
+            sleep 1
+        done
+    fi
+
+    # Last resort: make sure keepalived cannot re-add the addresses, then
+    # remove the VIPs directly. The peers take over via the VRRP
+    # master-down timeout (~3-4s), and no stale VIP is left to route
+    # client traffic to the draining local apiserver.
+    pkill -9 -x keepalived || true
+    for vip in ${VIPS}; do
+        read -r dev cidr <<< "$(vip_configured "${vip}")"
+        if [ -n "${dev:-}" ]; then
+            echo "keepalived-vip-resign: force-removing ${cidr} from ${dev}"
+            ip addr del "${cidr}" dev "${dev}" || true
+        fi
+    done
+    exit 0

--- a/templates/common/on-prem/units/keepalived-vip-resign.service.yaml
+++ b/templates/common/on-prem/units/keepalived-vip-resign.service.yaml
@@ -1,0 +1,29 @@
+name: keepalived-vip-resign.service
+enabled: {{if and (isOpenShiftManagedDefaultLB .) (or (gt (len (onPremPlatformAPIServerInternalIPs .)) 0) (gt (len (onPremPlatformIngressIPs .)) 0))}}true{{else}}false{{end}}
+contents: |
+  [Unit]
+  Description=Resign on-prem VIPs (keepalived) before node shutdown
+  Documentation=https://issues.redhat.com/browse/OCPBUGS-109633
+  # This unit does nothing at boot. Its ExecStop runs at shutdown/reboot
+  # and, because stop order is the reverse of the After=/Before= start
+  # ordering, it runs before crio, kubelet and NetworkManager are stopped
+  # (NetworkManager ordering is inherited via network.target, and listed
+  # explicitly as well). Note this does NOT order against the transient
+  # crio-*.scope units that contain the keepalived container - those may
+  # be torn down in parallel - so the clean SIGTERM handoff below is
+  # best-effort; the hard guarantee that no stale VIP survives comes from
+  # the script's force-removal fallback.
+  After=network.target NetworkManager.service crio.service kubelet.service
+
+  [Service]
+  Type=oneshot
+  RemainAfterExit=yes
+  ExecStart=/bin/true
+  ExecStop=/usr/local/bin/keepalived-vip-resign.sh
+  # The script bounds itself (<=10s wait + kill + VIP removal); this is a
+  # safety net so a wedged script cannot block shutdown indefinitely.
+  TimeoutStopSec=20
+  SyslogIdentifier=keepalived-vip-resign
+
+  [Install]
+  WantedBy=multi-user.target


### PR DESCRIPTION
Fixes [OCPBUGS-109633](https://issues.redhat.com/browse/OCPBUGS-109633): during `systemctl reboot` (e.g. an MCD-driven config-change reboot), keepalived non-deterministically loses the race against systemd's parallel teardown of container scopes and networking. When it loses, it is killed before sending the VRRP priority-0 resign advert and before removing the VIP from the interface. The stale VIP then keeps attracting new client connections which land **directly** on the local kube-apiserver — which is still serving its ~70s graceful drain with `readyz=false` — because the local haproxy `VIP:6443→:9445` redirect is already gone. This is what the `[Monitor:audit-log-analyzer] API LBs follow /readyz ...` regression (Component Readiness regression 46508, triage 722) caught on vSphere upgrade jobs.

## What this PR does

Adds a `keepalived-vip-resign.service` oneshot unit (rendered for on-prem platforms, enabled only with the OpenShift-managed LB and configured VIPs) whose `ExecStop` runs at shutdown before crio, kubelet and NetworkManager stop. The script:

1. No-ops unless the system is actually stopping (a plain unit stop/restart on a healthy node must not flap VIPs).
2. No-ops if no VIP is configured on this node.
3. Sends SIGTERM to keepalived (exact comm match `pgrep -ox` — an unanchored match would hit `dynkeepalived` or the script itself) so the clean resign (priority-0 advert + VIP removal) happens while the network is up, and waits up to 10s.
4. Fallback: if keepalived was not running or did not finish, kill it (`pkill -9 -x`, so it cannot re-add addresses) and remove the VIPs directly via `ip addr del`. VIP presence is checked with `ip addr show to <vip>`, i.e. kernel-side address comparison, so non-canonical IPv6 spellings still match.

The clean SIGTERM handoff is best-effort (transient `crio-*.scope` units are not ordered against this unit); the hard guarantee that no stale VIP survives into the drain window comes from the fallback.

## Evidence from the failing runs

In job run [2086273547025518592](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-main-ci-5.0-e2e-vsphere-ovn-upgrade/2086273547025518592): MCD reboots master-1 at 03:46:56; master-0 keepalived takes MASTER at 03:47:00 via master-down *timeout* (no `Backup received priority 0 advertisement` — contrast the clean handoff at 03:41:05 in the same run); peers' haproxy correctly marks master-1 DOWN at 03:47:11; yet flagged requests keep terminating on master-1's draining apiserver until 03:48:06 — only possible via a stale VIP on master-1. Same signature in runs 2086092373405732864 and 2085772778182545408.

## Testing

- `go test ./pkg/controller/template/...` — includes a new table test covering unit enablement and rendered VIP list for: no VIPs, single stack, dual stack, ingress-only VIPs, and user-managed LB (disabled).
- Script logic exercised against a fake `ip`/`pgrep`/`systemctl` harness for: healthy-node stop (no-op), shutdown with dead keepalived (immediate force-removal, no wait), no VIP (no-op), deep-shutdown with systemctl unavailable (proceeds).
- Suggested cluster verification: on a VIP-holding master, loop `systemctl reboot` ~20x and confirm peers log `Backup received priority 0 advertisement` (or take over within ~4s) and `ip addr` on the rebooting node never retains the VIP into the apiserver drain; then rerun `periodic-ci-openshift-release-main-ci-5.0-e2e-vsphere-ovn-upgrade`.

Note for reviewers: this adds a new MachineConfig unit+file, so it rolls out with a drain+reboot of on-prem nodes, as usual for template changes.

## Suggested follow-ups (from panel review, non-blocking)

These were raised during a multi-specialist review of this change and are deliberately left out of this PR to keep it scoped; filing them here so they are not lost:

1. **Validate VIP strings at render time** — the Go template interpolates `PlatformStatus` VIP strings into a root-executed shell script. The trust boundary is intact today (cluster-admin-controlled, API-validated fields), but a `net.ParseIP` check in the render path (or a template helper) would make the pattern fail closed if the source fields or their validation ever change.
2. **Signal keepalived via its pod/pidfile instead of by process name** — `pgrep -ox keepalived` is an exact-comm match, but name-based targeting is still spoofable by a local process named `keepalived` and has a theoretical pgrep→kill PID-reuse window. Resolving the PID via the static pod (crictl/conmon pidfile) would close both. Impact today is degraded-cleanliness only: the force-removal fallback still removes the VIPs.
3. **Extend render-test platform matrix** — the new test mutates the BareMetal platform only. Parameterizing over `controller_config_{vsphere,openstack,nutanix,ovirt}.yaml` (incl. the vSphere-UPI nil-`PlatformStatus.VSphere` case) would exercise every `onPremPlatformAPIServerInternalIPs` switch arm. Note `controller_config_ovirt.yaml` exists in test_data but is absent from the `configs` map in `render_test.go`, so the ovirt render path is currently untested by any unit test.
4. **Shellcheck for embedded template scripts in CI** — `hack/verify-templates.sh` does not lint the bash embedded in template yamls; a small extraction+shellcheck step would catch quoting/`set -u` regressions in this and sibling scripts (`resolv-prepender.sh`, `mtu-migration.sh`, ...).
5. **e2e coverage** — no existing e2e exercises VIP behavior across a node reboot. A metal-platform extended test that reboots the VIP-holding master and asserts the VIP is absent from that node during the apiserver drain would guard against regressions. Until then, the `periodic-ci-openshift-release-main-ci-5.0-e2e-vsphere-ovn-upgrade` monitor test is the effective signal.
6. **Long-term home for this logic** — the root cause is keepalived's shutdown handling losing the reboot race. This unit is the right near-term fix at the MCO layer, but the durable owner is arguably the keepalived static pod lifecycle in baremetal-runtimecfg (where VRRP state and VIP knowledge live). Cross-link from OCPBUGS-109633 so this workaround can be retired if/when that lands.

---
This PR was generated using AI. Please verify before acting on it.
Assisted-By: Claude Fable 5



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added graceful shutdown handling for on-premises load balancers using virtual IPs.
  * Automatically removes virtual IPs during shutdown and force-cleans up when necessary.
  * Applies the shutdown behavior only to applicable managed load-balancer configurations.
* **Tests**
  * Added coverage for empty, single-stack, dual-stack, ingress-only, and user-managed configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->