### PR TITLE
[DO NOT MERGE] test: fix flaky build controller tests under -count=N

### DIFF
--- a/pkg/controller/build/ocl_metrics_test.go
+++ b/pkg/controller/build/ocl_metrics_test.go
@@ -14,14 +14,27 @@ func resetGaugeVec(g *prometheus.GaugeVec, labels prometheus.Labels) {
 	g.DeletePartialMatch(labels)
 }
 
+// clearPushStartTimes removes all entries from the package-level pushStartTimes
+// sync.Map so that stale entries do not accumulate across -count iterations.
+func clearPushStartTimes(t *testing.T) {
+	t.Helper()
+	pushStartTimes.Range(func(key, value any) bool {
+		pushStartTimes.Delete(key)
+		return true
+	})
+}
+
 func TestRecordImagePushStarted(t *testing.T) {
 	t.Parallel()
 
-	resetGaugeVec(oclImagePushState, prometheus.Labels{"pool": "worker"})
+	pool := "push-started-test-pool"
+	t.Cleanup(func() { clearPushStartTimes(t) })
 
-	RecordImagePushStarted("worker")
+	resetGaugeVec(oclImagePushState, prometheus.Labels{"pool": pool})
 
-	v := testutil.ToFloat64(oclImagePushState.WithLabelValues("worker", StatePushing))
+	RecordImagePushStarted(pool)
+
+	v := testutil.ToFloat64(oclImagePushState.WithLabelValues(pool, StatePushing))
 	if v != 1 {
 		t.Errorf("expected ocl_image_push_state{state=%q} = 1, got %v", StatePushing, v)
 	}
@@ -30,6 +43,7 @@ func TestRecordImagePushStarted(t *testing.T) {
 func TestRecordImagePushCompleted(t *testing.T) {
 	t.Parallel()
 
+	t.Cleanup(func() { clearPushStartTimes(t) })
 	resetGaugeVec(oclImagePushState, prometheus.Labels{"pool": "worker2"})
 
 	RecordImagePushStarted("worker2")
@@ -50,6 +64,7 @@ func TestRecordImagePushCompleted(t *testing.T) {
 func TestRecordImagePushFailed(t *testing.T) {
 	t.Parallel()
 
+	t.Cleanup(func() { clearPushStartTimes(t) })
 	resetGaugeVec(oclImagePushState, prometheus.Labels{"pool": "worker3"})
 
 	RecordImagePushStarted("worker3")
@@ -179,6 +194,7 @@ func TestBuildQueueDuration(t *testing.T) {
 func TestImagePushDurationRecorded(t *testing.T) {
 	t.Parallel()
 
+	t.Cleanup(func() { clearPushStartTimes(t) })
 	pool := "push-duration-pool"
 
 	before := testutil.CollectAndCount(oclImagePushDuration)
@@ -195,6 +211,7 @@ func TestImagePushDurationRecorded(t *testing.T) {
 func TestImagePushDurationOnFailure(t *testing.T) {
 	t.Parallel()
 
+	t.Cleanup(func() { clearPushStartTimes(t) })
 	pool := "push-duration-fail-pool"
 
 	before := testutil.CollectAndCount(oclImagePushDuration)

--- a/pkg/controller/build/osbuildcontroller_test.go
+++ b/pkg/controller/build/osbuildcontroller_test.go
@@ -74,12 +74,12 @@ func TestOSBuildControllerDoesNothing(t *testing.T) {
 // rendered MachineConfig is detected on the associated MachineConfigPool.
 func TestOSBuildControllerDeletesRunningBuildBeforeStartingANewOne(t *testing.T) {
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
-	t.Cleanup(cancel)
-
 	poolName := "worker"
 
 	t.Run("MachineOSConfig change", func(t *testing.T) {
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+		t.Cleanup(cancel)
 
 		kubeclient, mcfgclient, _, _, mosc, initialMosb, mcp, kubeassert, lobj, _ := setupOSBuildControllerForTestWithRunningBuild(ctx, t, poolName)
 
@@ -116,6 +116,9 @@ func TestOSBuildControllerDeletesRunningBuildBeforeStartingANewOne(t *testing.T)
 	})
 
 	t.Run("MachineConfig change", func(t *testing.T) {
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+		t.Cleanup(cancel)
 
 		_, mcfgclient, _, _, mosc, initialMosb, mcp, kubeassert, _, _ := setupOSBuildControllerForTestWithRunningBuild(ctx, t, poolName)
 
@@ -219,12 +222,12 @@ func TestOSBuildControllerLeavesSuccessfulBuildAlone(t *testing.T) {
 // MachineConfigPool.
 func TestOSBuildControllerFailure(t *testing.T) {
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
-	t.Cleanup(cancel)
-
 	poolName := "worker"
 
 	t.Run("Failed build objects remain", func(t *testing.T) {
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+		t.Cleanup(cancel)
 
 		_, _, _, _, _, failedMosb, _, kubeassert, _ := setupOSBuildControllerForTestWithFailedBuild(ctx, t, poolName)
 
@@ -233,6 +236,9 @@ func TestOSBuildControllerFailure(t *testing.T) {
 	})
 
 	t.Run("MachineOSConfig change clears failed build", func(t *testing.T) {
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+		t.Cleanup(cancel)
 
 		kubeclient, mcfgclient, _, _, mosc, failedMosb, mcp, kubeassert, lobj := setupOSBuildControllerForTestWithFailedBuild(ctx, t, poolName)
 
@@ -261,6 +267,9 @@ func TestOSBuildControllerFailure(t *testing.T) {
 	})
 
 	t.Run("MachineConfig change clears failed build", func(t *testing.T) {
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+		t.Cleanup(cancel)
 
 		_, mcfgclient, _, _, mosc, failedMosb, mcp, kubeassert, _ := setupOSBuildControllerForTestWithFailedBuild(ctx, t, poolName)
 
@@ -294,9 +303,6 @@ func TestOSBuildControllerFailure(t *testing.T) {
 
 func TestOSBuildController(t *testing.T) {
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*25)
-	t.Cleanup(cancel)
-
 	poolName := "worker"
 
 	getConfigNameForPool := func(num int) string {
@@ -304,6 +310,9 @@ func TestOSBuildController(t *testing.T) {
 	}
 
 	t.Run("MachineOSConfig changes creates a new MachineOSBuild", func(t *testing.T) {
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second*25)
+		t.Cleanup(cancel)
 
 		kubeclient, mcfgclient, _, _, mosc, _, _, lobj, kubeassert := setupOSBuildControllerForTestWithSuccessfulBuild(ctx, t, poolName)
 
@@ -350,6 +359,9 @@ func TestOSBuildController(t *testing.T) {
 	})
 
 	t.Run("MachineConfig changes creates a new MachineOSBuild", func(t *testing.T) {
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second*25)
+		t.Cleanup(cancel)
 
 		kubeclient, mcfgclient, _, _, mosc, _, mcp, _, kubeassert := setupOSBuildControllerForTestWithSuccessfulBuild(ctx, t, poolName)
 
@@ -516,8 +528,6 @@ func TestOSBuildControllerReconcilesMachineConfigPoolsAfterRestart(t *testing.T)
 // performs all of the setup steps and creates a successful Job before starting
 // the controller.
 func TestOSBuildControllerReconcilesJobsAfterRestart(t *testing.T) {
-	mainCtx, mainCancel := context.WithTimeout(context.Background(), time.Second*5)
-	t.Cleanup(mainCancel)
 
 	testCases := []struct {
 		name       string
@@ -556,7 +566,7 @@ func TestOSBuildControllerReconcilesJobsAfterRestart(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			ctx, cancel := context.WithCancel(mainCtx)
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 			t.Cleanup(cancel)
 
 			poolName := "worker"


### PR DESCRIPTION
# This PR is AI generated

Three fixes for shared mutable state causing flaky unit tests in pkg/controller/build when run with -count=N:

1. Use unique pool name "push-started-test-pool" in TestRecordImagePushStarted instead of "worker" which collides with controller reconciler tests.

2. Move context.WithTimeout from parent test functions into each individual t.Run subtest so every subtest gets its own full timeout budget instead of sharing a shrinking one:
   - TestOSBuildControllerDeletesRunningBuildBeforeStartingANewOne
   - TestOSBuildControllerFailure
   - TestOSBuildControllerReconcilesJobsAfterRestart
   - TestOSBuildController

3. Add clearPushStartTimes helper that drains the package-level pushStartTimes sync.Map, called via t.Cleanup in every metrics test that writes to it, preventing stale entries from bleeding across -count iterations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test isolation by clearing image-push state after test execution.
  * Added unique test pool naming to prevent conflicts between test cases.
  * Updated restart job tests to use independent timeout contexts, reducing interference between subtests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->