### PR TITLE
OCPBUGS-105508: Re-apply MC /etc files after OS update to fix ostree 3-way merge overwrites

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -198,6 +198,11 @@ const (
 	// currentConfigPath is where we store the current config on disk to validate
 	// against annotations changes
 	currentConfigPath = "/etc/machine-config-daemon/currentconfig"
+	// postOSUpdateEtcFilesMarkerPath is written before a reboot that follows an
+	// OS update with MC-managed /etc files. On the next first-run it signals that
+	// those files must be re-applied, because the ostree 3-way merge may have
+	// overwritten them when their content matched the old OS base.
+	postOSUpdateEtcFilesMarkerPath = "/etc/machine-config-daemon/post-os-update-etc-files"
 	// bootstrapConfigDiffPath is where we store the current config on disk to validate
 	// against annotations changes
 	bootstrapConfigDiffPath = "/etc/machine-config-daemon/bootstrapconfigdiff"
@@ -2188,6 +2193,34 @@ func (dn *Daemon) checkStateOnFirstRun() error {
 		logSystem("Skipping on-disk validation; %s present", constants.MachineConfigDaemonForceFile)
 		return dn.triggerUpdate(state.currentConfig, state.desiredConfig, state.currentImage, state.desiredImage)
 
+	}
+
+	// If a previous OS update left a marker, re-apply MC-managed /etc files
+	// before validation. The ostree 3-way merge silently overwrites MC-managed
+	// files whose content matches the old OS base, causing a spurious content
+	// mismatch. Re-applying here, after the merge has run, restores the correct
+	// content so validation passes.
+	if _, err := os.Stat(postOSUpdateEtcFilesMarkerPath); err == nil {
+		klog.Infof("Post-OS-update marker found; re-applying MC /etc files to correct 3-way merge overwrites")
+		if err := os.Remove(postOSUpdateEtcFilesMarkerPath); err != nil {
+			klog.Errorf("Failed to remove post-OS-update marker: %v", err)
+		}
+		newIgnConfig, err := ctrlcommon.ParseAndConvertConfig(state.currentConfig.Spec.Config.Raw)
+		if err != nil {
+			return fmt.Errorf("parsing current config for /etc re-apply after OS update: %w", err)
+		}
+		var etcFiles []ign3types.File
+		for _, f := range newIgnConfig.Storage.Files {
+			if strings.HasPrefix(f.Path, "/etc/") {
+				etcFiles = append(etcFiles, f)
+			}
+		}
+		if len(etcFiles) > 0 {
+			klog.Infof("Re-applying %d MC /etc files after OS update", len(etcFiles))
+			if err := dn.writeFiles(etcFiles, false); err != nil {
+				return fmt.Errorf("re-applying /etc files after OS update: %w", err)
+			}
+		}
 	}
 
 	if err := dn.validateOnDiskStateOrImage(state.currentConfig, state.currentImage); err != nil {

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -2200,7 +2200,9 @@ func (dn *Daemon) checkStateOnFirstRun() error {
 	// files whose content matches the old OS base, causing a spurious content
 	// mismatch. Re-applying here, after the merge has run, restores the correct
 	// content so validation passes.
-	if _, err := os.Stat(postOSUpdateEtcFilesMarkerPath); err == nil {
+	if _, err := os.Stat(postOSUpdateEtcFilesMarkerPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("checking post-OS-update marker: %w", err)
+	} else if err == nil {
 		klog.Infof("Post-OS-update marker found; re-applying MC /etc files to correct 3-way merge overwrites")
 		if err := os.Remove(postOSUpdateEtcFilesMarkerPath); err != nil {
 			klog.Errorf("Failed to remove post-OS-update marker: %v", err)

--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -1302,6 +1302,23 @@ func (dn *Daemon) update(oldConfig, newConfig *mcfgv1.MachineConfig, skipCertifi
 				}
 			}
 		}()
+		var etcFiles []ign3types.File
+		for _, f := range newIgnConfig.Storage.Files {
+			if strings.HasPrefix(f.Path, "/etc/") {
+				etcFiles = append(etcFiles, f)
+			}
+		}
+		if osUpdate && len(etcFiles) > 0 {
+			// Signal checkStateOnFirstRun to re-apply these files after the reboot.
+			// The ostree 3-way /etc merge runs at boot time and can overwrite
+			// MC-managed files whose content matches the old OS base; writing to
+			// the staged deployment before the reboot would not survive the merge.
+			// The marker causes a post-reboot re-apply that corrects any overwrites.
+			if err := writeFileAtomicallyWithDefaults(postOSUpdateEtcFilesMarkerPath, []byte{}); err != nil {
+				return fmt.Errorf("writing post-OS-update marker: %w", err)
+			}
+			klog.Infof("Wrote post-OS-update marker; %d managed /etc files will be re-applied on next boot", len(etcFiles))
+		}
 	} else {
 		klog.Info("updating the OS on non-CoreOS nodes is not supported")
 	}


### PR DESCRIPTION
Closes: OCPBUGS-105508

**- What I did**

During version upgrades, the ostree merge can overwrite user defined overrides of managed files when their content matches the old OS base. After reboot, when the MCD validates on-disk state against the rendered MachineConfig, it marks the node `Degraded` if the content does not match what is defined in the MC.

With this change, when an OS update includes MC-managed /etc files, write a persistent marker at /etc/machine-config-daemon/post-os-update-etc-files before rebooting. On the next first-run, `checkStateOnFirstRun()` detects the marker, re-applies all MC /etc files to the live filesystem before validation, then removes the marker. This corrects any overwrites the 3-way merge performed at boot time.

**- How to verify it**

1. Launch a 4.21 cluster.
2. Apply a MC to set the content of `/etc/ssh/sshd_config` and wait for the worker MCP to return to updated.
```
$ oc create -f - << EOF
apiVersion: machineconfiguration.openshift.io/v1
kind: MachineConfig
metadata:
  labels:
    machineconfiguration.openshift.io/role: worker
  name: 50-sshd-config-worker
spec:
  config:
    ignition:
      version: 3.4.0
    storage:
      files:
        - path: /etc/ssh/sshd_config
          mode: 0600
          overwrite: true
          contents:
            source: "data:;base64,IwkkT3BlbkJTRDogc3NoZF9jb25maWcsdiAxLjEwNCAyMDIxLzA3LzAyIDA1OjExOjIxIGR0dWNrZXIgRXhwICQKCiMgVGhpcyBpcyB0aGUgc3NoZCBzZXJ2ZXIgc3lzdGVtLXdpZGUgY29uZmlndXJhdGlvbiBmaWxlLiAgU2VlCiMgc3NoZF9jb25maWcoNSkgZm9yIG1vcmUgaW5mb3JtYXRpb24uCgojIFRoaXMgc3NoZCB3YXMgY29tcGlsZWQgd2l0aCBQQVRIPS91c3IvbG9jYWwvYmluOi91c3IvYmluOi91c3IvbG9jYWwvc2JpbjovdXNyL3NiaW4KCiMgVGhlIHN0cmF0ZWd5IHVzZWQgZm9yIG9wdGlvbnMgaW4gdGhlIGRlZmF1bHQgc3NoZF9jb25maWcgc2hpcHBlZCB3aXRoCiMgT3BlblNTSCBpcyB0byBzcGVjaWZ5IG9wdGlvbnMgd2l0aCB0aGVpciBkZWZhdWx0IHZhbHVlIHdoZXJlCiMgcG9zc2libGUsIGJ1dCBsZWF2ZSB0aGVtIGNvbW1lbnRlZC4gIFVuY29tbWVudGVkIG9wdGlvbnMgb3ZlcnJpZGUgdGhlCiMgZGVmYXVsdCB2YWx1ZS4KCiMgVG8gbW9kaWZ5IHRoZSBzeXN0ZW0td2lkZSBzc2hkIGNvbmZpZ3VyYXRpb24sIGNyZWF0ZSBhICAqLmNvbmYgIGZpbGUgdW5kZXIKIyAgL2V0Yy9zc2gvc3NoZF9jb25maWcuZC8gIHdoaWNoIHdpbGwgYmUgYXV0b21hdGljYWxseSBpbmNsdWRlZCBiZWxvdwpJbmNsdWRlIC9ldGMvc3NoL3NzaGRfY29uZmlnLmQvKi5jb25mCgojIElmIHlvdSB3YW50IHRvIGNoYW5nZSB0aGUgcG9ydCBvbiBhIFNFTGludXggc3lzdGVtLCB5b3UgaGF2ZSB0byB0ZWxsCiMgU0VMaW51eCBhYm91dCB0aGlzIGNoYW5nZS4KIyBzZW1hbmFnZSBwb3J0IC1hIC10IHNzaF9wb3J0X3QgLXAgdGNwICNQT1JUTlVNQkVSCiMKI1BvcnQgMjIKI0FkZHJlc3NGYW1pbHkgYW55CiNMaXN0ZW5BZGRyZXNzIDAuMC4wLjAKI0xpc3RlbkFkZHJlc3MgOjoKCiNIb3N0S2V5IC9ldGMvc3NoL3NzaF9ob3N0X3JzYV9rZXkKI0hvc3RLZXkgL2V0Yy9zc2gvc3NoX2hvc3RfZWNkc2Ffa2V5CiNIb3N0S2V5IC9ldGMvc3NoL3NzaF9ob3N0X2VkMjU1MTlfa2V5CgojIENpcGhlcnMgYW5kIGtleWluZwojUmVrZXlMaW1pdCBkZWZhdWx0IG5vbmUKCiMgTG9nZ2luZwojU3lzbG9nRmFjaWxpdHkgQVVUSAojTG9nTGV2ZWwgSU5GTwoKIyBBdXRoZW50aWNhdGlvbjoKCiNMb2dpbkdyYWNlVGltZSAybQojUGVybWl0Um9vdExvZ2luIHByb2hpYml0LXBhc3N3b3JkCiNTdHJpY3RNb2RlcyB5ZXMKI01heEF1dGhUcmllcyA2CiNNYXhTZXNzaW9ucyAxMAoKI1B1YmtleUF1dGhlbnRpY2F0aW9uIHllcwoKIyBUaGUgZGVmYXVsdCBpcyB0byBjaGVjayBib3RoIC5zc2gvYXV0aG9yaXplZF9rZXlzIGFuZCAuc3NoL2F1dGhvcml6ZWRfa2V5czIKIyBidXQgdGhpcyBpcyBvdmVycmlkZGVuIHNvIGluc3RhbGxhdGlvbnMgd2lsbCBvbmx5IGNoZWNrIC5zc2gvYXV0aG9yaXplZF9rZXlzCkF1dGhvcml6ZWRLZXlzRmlsZQkuc3NoL2F1dGhvcml6ZWRfa2V5cwoKI0F1dGhvcml6ZWRQcmluY2lwYWxzRmlsZSBub25lCgojQXV0aG9yaXplZEtleXNDb21tYW5kIG5vbmUKI0F1dGhvcml6ZWRLZXlzQ29tbWFuZFVzZXIgbm9ib2R5CgojIEZvciB0aGlzIHRvIHdvcmsgeW91IHdpbGwgYWxzbyBuZWVkIGhvc3Qga2V5cyBpbiAvZXRjL3NzaC9zc2hfa25vd25faG9zdHMKI0hvc3RiYXNlZEF1dGhlbnRpY2F0aW9uIG5vCiMgQ2hhbmdlIHRvIHllcyBpZiB5b3UgZG9uJ3QgdHJ1c3Qgfi8uc3NoL2tub3duX2hvc3RzIGZvcgojIEhvc3RiYXNlZEF1dGhlbnRpY2F0aW9uCiNJZ25vcmVVc2VyS25vd25Ib3N0cyBubwojIERvbid0IHJlYWQgdGhlIHVzZXIncyB+Ly5yaG9zdHMgYW5kIH4vLnNob3N0cyBmaWxlcwojSWdub3JlUmhvc3RzIHllcwoKIyBUbyBkaXNhYmxlIHR1bm5lbGVkIGNsZWFyIHRleHQgcGFzc3dvcmRzLCBjaGFuZ2UgdG8gbm8gaGVyZSEKI1Bhc3N3b3JkQXV0aGVudGljYXRpb24geWVzCiNQZXJtaXRFbXB0eVBhc3N3b3JkcyBubwoKIyBDaGFuZ2UgdG8gbm8gdG8gZGlzYWJsZSBzL2tleSBwYXNzd29yZHMKI0tiZEludGVyYWN0aXZlQXV0aGVudGljYXRpb24geWVzCgojIEtlcmJlcm9zIG9wdGlvbnMKI0tlcmJlcm9zQXV0aGVudGljYXRpb24gbm8KI0tlcmJlcm9zT3JMb2NhbFBhc3N3ZCB5ZXMKI0tlcmJlcm9zVGlja2V0Q2xlYW51cCB5ZXMKI0tlcmJlcm9zR2V0QUZTVG9rZW4gbm8KI0tlcmJlcm9zVXNlS3VzZXJvayB5ZXMKCiMgR1NTQVBJIG9wdGlvbnMKI0dTU0FQSUF1dGhlbnRpY2F0aW9uIG5vCiNHU1NBUElDbGVhbnVwQ3JlZGVudGlhbHMgeWVzCiNHU1NBUElTdHJpY3RBY2NlcHRvckNoZWNrIHllcwojR1NTQVBJS2V5RXhjaGFuZ2Ugbm8KI0dTU0FQSUVuYWJsZWs1dXNlcnMgbm8KCiMgU2V0IHRoaXMgdG8gJ3llcycgdG8gZW5hYmxlIFBBTSBhdXRoZW50aWNhdGlvbiwgYWNjb3VudCBwcm9jZXNzaW5nLAojIGFuZCBzZXNzaW9uIHByb2Nlc3NpbmcuIElmIHRoaXMgaXMgZW5hYmxlZCwgUEFNIGF1dGhlbnRpY2F0aW9uIHdpbGwKIyBiZSBhbGxvd2VkIHRocm91Z2ggdGhlIEtiZEludGVyYWN0aXZlQXV0aGVudGljYXRpb24gYW5kCiMgUGFzc3dvcmRBdXRoZW50aWNhdGlvbi4gIERlcGVuZGluZyBvbiB5b3VyIFBBTSBjb25maWd1cmF0aW9uLAojIFBBTSBhdXRoZW50aWNhdGlvbiB2aWEgS2JkSW50ZXJhY3RpdmVBdXRoZW50aWNhdGlvbiBtYXkgYnlwYXNzCiMgdGhlIHNldHRpbmcgb2YgIlBlcm1pdFJvb3RMb2dpbiB3aXRob3V0LXBhc3N3b3JkIi4KIyBJZiB5b3UganVzdCB3YW50IHRoZSBQQU0gYWNjb3VudCBhbmQgc2Vzc2lvbiBjaGVja3MgdG8gcnVuIHdpdGhvdXQKIyBQQU0gYXV0aGVudGljYXRpb24sIHRoZW4gZW5hYmxlIHRoaXMgYnV0IHNldCBQYXNzd29yZEF1dGhlbnRpY2F0aW9uCiMgYW5kIEtiZEludGVyYWN0aXZlQXV0aGVudGljYXRpb24gdG8gJ25vJy4KIyBXQVJOSU5HOiAnVXNlUEFNIG5vJyBpcyBub3Qgc3VwcG9ydGVkIGluIFJIRUwgYW5kIG1heSBjYXVzZSBzZXZlcmFsCiMgcHJvYmxlbXMuCiNVc2VQQU0gbm8KCiNBbGxvd0FnZW50Rm9yd2FyZGluZyB5ZXMKI0FsbG93VGNwRm9yd2FyZGluZyB5ZXMKI0dhdGV3YXlQb3J0cyBubwojWDExRm9yd2FyZGluZyBubwojWDExRGlzcGxheU9mZnNldCAxMAojWDExVXNlTG9jYWxob3N0IHllcwojUGVybWl0VFRZIHllcwojUHJpbnRNb3RkIHllcwojUHJpbnRMYXN0TG9nIHllcwojVENQS2VlcEFsaXZlIHllcwojUGVybWl0VXNlckVudmlyb25tZW50IG5vCiNDb21wcmVzc2lvbiBkZWxheWVkCiNDbGllbnRBbGl2ZUludGVydmFsIDAKI0NsaWVudEFsaXZlQ291bnRNYXggMwojVXNlRE5TIG5vCiNQaWRGaWxlIC92YXIvcnVuL3NzaGQucGlkCiNNYXhTdGFydHVwcyAxMDozMDoxMDAKI1Blcm1pdFR1bm5lbCBubwojQ2hyb290RGlyZWN0b3J5IG5vbmUKI1ZlcnNpb25BZGRlbmR1bSBub25lCgojIG5vIGRlZmF1bHQgYmFubmVyIHBhdGgKI0Jhbm5lciBub25lCgojIG92ZXJyaWRlIGRlZmF1bHQgb2Ygbm8gc3Vic3lzdGVtcwpTdWJzeXN0ZW0Jc2Z0cAkvdXNyL2xpYmV4ZWMvb3BlbnNzaC9zZnRwLXNlcnZlcgoKIyBFeGFtcGxlIG9mIG92ZXJyaWRpbmcgc2V0dGluZ3Mgb24gYSBwZXItdXNlciBiYXNpcwojTWF0Y2ggVXNlciBhbm9uY3ZzCiMJWDExRm9yd2FyZGluZyBubwojCUFsbG93VGNwRm9yd2FyZGluZyBubwojCVBlcm1pdFRUWSBubwojCUZvcmNlQ29tbWFuZCBjdnMgc2VydmVyCg=="
EOF
```
3. Upgrade to a 4.22 release payload built with https://github.com/openshift/machine-config-operator/pull/6410, which is a 4.22 version of this fix.
_Note:_ I used Clusterbot to create the release payload: `build 4.22.0-0.nightly-2026-08-13-103840,openshift/machine-config-operator#6410`
4. Ensure that the upgrade to 4.22 succeeds and that no nodes or MCPs degrade and check that the contents of `/etc/ssh/sshd_config` match what is expected.
```
$ oc debug node/<worker> -- chroot /host cat /etc/ssh/sshd_config
```

**- Description for the changelog**
OCPBUGS-105508: Re-apply MC /etc files after OS update to fix ostree 3-way merge overwrites

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured managed `/etc` configuration files are reapplied after an operating system update when needed.
  * Improved first-run validation to detect and recover configuration changes that may be overwritten during reboot.
  * Update processing now reports failures when post-update markers or managed files cannot be written.
  * Avoided unnecessary post-update processing when no OS update or managed `/etc` files are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->