### PR TITLE
OCPBUGS-111648: crio: drop restore support

### DIFF
--- a/templates/master/01-master-container-runtime/_base/files/crio.yaml
+++ b/templates/master/01-master-container-runtime/_base/files/crio.yaml
@@ -106,3 +106,6 @@ contents:
       "processes_defunct",
       "default_runtime"
     ]
+
+    [crio.checkpoint_restore]
+    container_level_enabled = "checkpoint_only"

--- a/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
+++ b/templates/worker/01-worker-container-runtime/_base/files/crio.yaml
@@ -17,12 +17,12 @@ contents:
     default_env = [
         "NSS_SDB_USE_CACHE=no",
     ]
+    default_runtime = "crun"
     log_level = "info"
     cgroup_manager = "systemd"
     default_sysctls = [
         "net.ipv4.ping_group_range=0 2147483647",
     ]
-    default_runtime = "crun"
     hooks_dir = [
         "/etc/containers/oci/hooks.d",
         "/run/containers/oci/hooks.d",
@@ -106,3 +106,6 @@ contents:
       "processes_defunct",
       "default_runtime"
     ]
+
+    [crio.checkpoint_restore]
+    container_level_enabled = "checkpoint_only"


### PR DESCRIPTION
for one, it doesn't work with crun, which has been the default for a while. Also, upstream will be deprecating support And finally, there are some policy and security issues with the current implementation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added container checkpoint and restore support for master and worker nodes, limited to checkpoint operations.
* **Configuration**
  * Preserved `crun` as the default container runtime for worker nodes.
  * Reorganized worker runtime settings for consistent configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->