### PR TITLE
OCPBUGS-100366: Re-queue ContainerRuntimeConfig on status update failure

### DIFF
--- a/pkg/controller/container-runtime-config/container_runtime_config_controller.go
+++ b/pkg/controller/container-runtime-config/container_runtime_config_controller.go
@@ -642,7 +642,7 @@ func generateOriginalCredentialProviderConfig(templateDir string, cc *mcfgv1.Con
 
 func (ctrl *Controller) syncStatusOnly(cfg *mcfgv1.ContainerRuntimeConfig, err error, args ...interface{}) error {
 	statusUpdateErr := retry.RetryOnConflict(updateBackoff, func() error {
-		newcfg, getErr := ctrl.mccrLister.Get(cfg.Name)
+		newcfg, getErr := ctrl.client.MachineconfigurationV1().ContainerRuntimeConfigs().Get(context.TODO(), cfg.Name, metav1.GetOptions{})
 		if getErr != nil {
 			return getErr
 		}
@@ -673,11 +673,12 @@ func (ctrl *Controller) syncStatusOnly(cfg *mcfgv1.ContainerRuntimeConfig, err e
 		_, updateErr := ctrl.client.MachineconfigurationV1().ContainerRuntimeConfigs().UpdateStatus(context.TODO(), newcfg, metav1.UpdateOptions{})
 		return updateErr
 	})
-	// If an error occurred in updating the status just log it
 	if statusUpdateErr != nil {
 		klog.Warningf("error updating container runtime config status: %v", statusUpdateErr)
+		if err == nil {
+			return statusUpdateErr
+		}
 	}
-	// Want to return the actual error received from the sync function
 	return err
 }
 
@@ -1142,13 +1143,15 @@ func (ctrl *Controller) syncCRIOCredentialProviderConfig(key string) error {
 			klog.Infof("Applied CRIOCredentialProviderConfig cluster on MachineConfigPool %v", pool.Name)
 			ctrlcommon.UpdateStateMetric(ctrlcommon.MCCSubControllerState, "machine-config-controller-container-runtime-config", "Sync CRIO Credential Provider Config", pool.Name)
 		}
-		ctrl.syncCRIOCredentialProviderConfigStatusOnly(nil, apicfgv1.ConditionTypeMachineConfigRendered, apicfgv1.ReasonMachineConfigRenderingSucceeded)
+		if statusErr := ctrl.syncCRIOCredentialProviderConfigStatusOnly(nil, apicfgv1.ConditionTypeMachineConfigRendered, apicfgv1.ReasonMachineConfigRenderingSucceeded); statusErr != nil {
+			return statusErr
+		}
 	}
 
 	return nil
 }
 
-func (ctrl *Controller) syncCRIOCredentialProviderConfigStatusOnly(err error, conditionType, reason string, args ...interface{}) {
+func (ctrl *Controller) syncCRIOCredentialProviderConfigStatusOnly(err error, conditionType, reason string, args ...interface{}) error {
 	statusUpdateErr := retry.RetryOnConflict(updateBackoff, func() error {
 		newCfg, getErr := ctrl.criocpLister.Get("cluster")
 		if getErr != nil {
@@ -1167,10 +1170,13 @@ func (ctrl *Controller) syncCRIOCredentialProviderConfigStatusOnly(err error, co
 		_, updateErr := ctrl.configClient.ConfigV1().CRIOCredentialProviderConfigs().UpdateStatus(context.TODO(), newCfg, metav1.UpdateOptions{})
 		return updateErr
 	})
-	// If an error occurred in updating the status just log it
 	if statusUpdateErr != nil {
 		klog.Warningf("error updating CRIOCredentialProviderConfig status: %v", statusUpdateErr)
+		if err == nil {
+			return statusUpdateErr
+		}
 	}
+	return nil
 }
 
 func (ctrl *Controller) syncIgnitionConfig(managedKey string, ignFile *ign3types.Config, pool *mcfgv1.MachineConfigPool, ownerRef metav1.OwnerReference) (bool, error) {

--- a/pkg/controller/container-runtime-config/container_runtime_config_controller_test.go
+++ b/pkg/controller/container-runtime-config/container_runtime_config_controller_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"k8s.io/klog/v2"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -446,6 +447,10 @@ func checkAction(expected, actual core.Action, t *testing.T, index int) {
 	}
 }
 
+func (f *fixture) expectGetContainerRuntimeConfigAction(config *mcfgv1.ContainerRuntimeConfig) {
+	f.actions = append(f.actions, core.NewRootGetAction(schema.GroupVersionResource{Resource: "containerruntimeconfigs"}, config.Name))
+}
+
 func (f *fixture) expectGetMachineConfigAction(config *mcfgv1.MachineConfig) {
 	f.actions = append(f.actions, core.NewRootGetAction(schema.GroupVersionResource{Resource: "machineconfigs"}, config.Name))
 }
@@ -739,11 +744,13 @@ func TestContainerRuntimeConfigCreate(t *testing.T) {
 			f.expectGetMachineConfigAction(mcs2)
 			f.expectGetMachineConfigAction(mcs1)
 			f.expectGetMachineConfigAction(mcs1)
+			f.expectGetContainerRuntimeConfigAction(ctrcfg1)
 			f.expectUpdateContainerRuntimeConfig(ctrcfg1)
 			f.expectUpdateContainerRuntimeConfigRoot(ctrcfg1)
 			f.expectCreateMachineConfigAction(mcs1)
 			f.expectPatchContainerRuntimeConfig(ctrcfg1, ctrcfgPatchBytes)
 			f.expectGetMachineConfigAction(mcs2)
+			f.expectGetContainerRuntimeConfigAction(ctrcfg1)
 			f.expectUpdateContainerRuntimeConfig(ctrcfg1)
 
 			f.run(getKey(ctrcfg1, t))
@@ -780,11 +787,13 @@ func TestContainerRuntimeConfigUpdate(t *testing.T) {
 			f.expectGetMachineConfigAction(mcsUpdate)
 			f.expectGetMachineConfigAction(mcs)
 			f.expectGetMachineConfigAction(mcs)
+			f.expectGetContainerRuntimeConfigAction(ctrcfg1)
 			f.expectUpdateContainerRuntimeConfig(ctrcfg1)
 			f.expectUpdateContainerRuntimeConfigRoot(ctrcfg1)
 			f.expectCreateMachineConfigAction(mcs)
 			f.expectPatchContainerRuntimeConfig(ctrcfg1, ctrcfgPatchBytes)
 			f.expectGetMachineConfigAction(mcs)
+			f.expectGetContainerRuntimeConfigAction(ctrcfg1)
 			f.expectUpdateContainerRuntimeConfig(ctrcfg1)
 
 			c := f.newController()
@@ -824,10 +833,12 @@ func TestContainerRuntimeConfigUpdate(t *testing.T) {
 
 			f.expectGetMachineConfigAction(mcsUpdate)
 			f.expectGetMachineConfigAction(mcsUpdate)
+			f.expectGetContainerRuntimeConfigAction(ctrcfgUpdate)
 			f.expectUpdateContainerRuntimeConfig(ctrcfgUpdate)
 			f.expectUpdateMachineConfigAction(mcsUpdate)
 			f.expectPatchContainerRuntimeConfig(ctrcfgUpdate, ctrcfgPatchBytes)
 			f.expectGetMachineConfigAction(mcsUpdate)
+			f.expectGetContainerRuntimeConfigAction(ctrcfgUpdate)
 			f.expectUpdateContainerRuntimeConfig(ctrcfgUpdate)
 
 			f.validateActions()
@@ -1736,6 +1747,7 @@ func TestCtrruntimeConfigMultiCreate(t *testing.T) {
 				f.expectCreateMachineConfigAction(mcs)
 				f.expectPatchContainerRuntimeConfig(ccr, []byte(expectedPatch))
 				f.expectGetMachineConfigAction(mcs)
+				f.expectGetContainerRuntimeConfigAction(ccr)
 				f.expectUpdateContainerRuntimeConfig(ccr)
 				f.run(poolName)
 			}
@@ -1846,6 +1858,7 @@ func TestAddAnnotationExistingContainerRuntimeConfig(t *testing.T) {
 			f.expectUpdateMachineConfigAction(ctrcfgMC)
 			f.expectPatchContainerRuntimeConfig(ctrc, []byte("{}"))
 			f.expectGetMachineConfigAction(ctrcfgMC)
+			f.expectGetContainerRuntimeConfigAction(ctrc)
 			f.expectUpdateContainerRuntimeConfig(ctrc)
 
 			c := f.newController()
@@ -2149,11 +2162,13 @@ func TestContainerRuntimeConfigAdditionalStorageConfig(t *testing.T) {
 			f.expectGetMachineConfigAction(mcs2)
 			f.expectGetMachineConfigAction(mcs1)
 			f.expectGetMachineConfigAction(mcs1)
+			f.expectGetContainerRuntimeConfigAction(ctrcfg)
 			f.expectUpdateContainerRuntimeConfig(ctrcfg)
 			f.expectUpdateContainerRuntimeConfigRoot(ctrcfg)
 			f.expectCreateMachineConfigAction(mcs1)
 			f.expectPatchContainerRuntimeConfig(ctrcfg, ctrcfgPatchBytes)
 			f.expectGetMachineConfigAction(mcs2)
+			f.expectGetContainerRuntimeConfigAction(ctrcfg)
 			f.expectUpdateContainerRuntimeConfig(ctrcfg)
 
 			f.run(getKey(ctrcfg, t))
@@ -2209,6 +2224,7 @@ func TestContainerRuntimeConfigAdditionalStorageConfigFeatureGateDisabled(t *tes
 			f.expectCreateMachineConfigAction(mcs1)
 			f.expectPatchContainerRuntimeConfig(ctrcfg, ctrcfgPatchBytes)
 			f.expectGetMachineConfigAction(mcs2)
+			f.expectGetContainerRuntimeConfigAction(ctrcfg)
 			f.expectUpdateContainerRuntimeConfig(ctrcfg)
 
 			f.run(getKey(ctrcfg, t))
@@ -2410,6 +2426,68 @@ func TestCrioCredentialProviderConfigCreateEmpty(t *testing.T) {
 			}
 
 			f.verifyCRIOCredentialProviderConfigContents(t, mcs.Name, criocp, verifyOpts)
+		})
+	}
+}
+
+// TestStatusUpdateConflictRequeues verifies that when the final status write
+// in syncContainerRuntimeConfig fails with a 409 Conflict error (e.g., due to
+// a concurrent finalizer update), the sync function returns an error so the
+// workqueue re-queues the item. This is a regression test for:
+// MCO render controller permanently stuck due to ContainerRuntimeConfig
+// failure during SNO bootstrap.
+// Without the fix, syncStatusOnly swallows the status update failure (logs a
+// warning and returns nil), leaving the CR with no .status and permanently
+// blocking the render controller.
+func TestStatusUpdateConflictRequeues(t *testing.T) {
+	for _, platform := range []apicfgv1.PlatformType{apicfgv1.AWSPlatformType, apicfgv1.NonePlatformType} {
+		t.Run(string(platform), func(t *testing.T) {
+			f := newFixture(t)
+			f.skipActionsValidation = true
+
+			cc := newControllerConfig(ctrlcommon.ControllerConfigName, platform)
+			mcp := helpers.NewMachineConfigPool("master", nil, helpers.MasterSelector, "v0")
+			mcp2 := helpers.NewMachineConfigPool("worker", nil, helpers.WorkerSelector, "v0")
+			ctrcfg := newContainerRuntimeConfig("enable-crun-master", &mcfgv1.ContainerRuntimeConfiguration{LogLevel: "debug"}, metav1.AddLabelToSelector(&metav1.LabelSelector{}, "pools.operator.machineconfiguration.openshift.io/master", ""))
+
+			f.ccLister = append(f.ccLister, cc)
+			f.mcpLister = append(f.mcpLister, mcp, mcp2)
+			f.mccrLister = append(f.mccrLister, ctrcfg)
+			f.objects = append(f.objects, ctrcfg)
+
+			c := f.newController()
+
+			// Inject a reactor that makes every UpdateStatus call on
+			// containerruntimeconfigs return a 409 Conflict error, simulating
+			// the race where a concurrent finalizer patch bumps the
+			// resourceVersion between the lister read and the status write.
+			ctrRuntimeResource := schema.GroupVersionResource{
+				Group:    "machineconfiguration.openshift.io",
+				Version:  "v1",
+				Resource: "containerruntimeconfigs",
+			}
+			f.client.PrependReactor("update", "containerruntimeconfigs", func(action core.Action) (bool, runtime.Object, error) {
+				if action.GetSubresource() != "status" {
+					return false, nil, nil
+				}
+				return true, nil, apierrors.NewConflict(
+					ctrRuntimeResource.GroupResource(),
+					"enable-crun-master",
+					fmt.Errorf("the object has been modified; please apply your changes to the latest version and try again"),
+				)
+			})
+
+			err := c.syncHandler(getKey(ctrcfg, t))
+
+			// The sync function should return an error when the status write
+			// fails, so the workqueue re-queues the item. If err is nil, the
+			// bug is present: the controller silently swallowed the status
+			// update failure.
+			if err == nil {
+				t.Errorf("syncHandler returned nil; expected an error when status update fails with 409 Conflict. " +
+					"This means the item will NOT be re-queued and the CR will be left without .status, " +
+					"permanently blocking the render controller.")
+			}
 		})
 	}
 }


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
Fixes: OCPBUGS-100366

**- What I did**

During SNO bootstrap, the ContainerRuntimeConfig controller's `syncStatusOnly` function silently swallows status write failures. When the status write fails with a 409 Conflict (caused by a concurrent finalizer patch bumping the `resourceVersion`), the function logs a warning but returns `nil`. The workqueue considers the item done and never re-queues it. The CR is left without `.status` (`observedGeneration=0` while `generation=1`), causing the render controller to loop forever on: `"status for ContainerRuntimeConfig enable-crun-master is being reported for 0, expecting it for 1"`.

**Fixes:**

1. **Return `statusUpdateErr` when original sync error is `nil`** - so the item is re-queued and the status write succeeds on the next attempt.
2. **Read from API server instead of lister cache inside `syncStatusOnly`'s `RetryOnConflict`** - the informer cache may still have the old `resourceVersion`, causing every retry to hit the same 409. Getting from the API server ensures each retry uses the latest object.
3. **Apply the same error-return fix to `syncCRIOCredentialProviderConfigStatusOnly`** - this function had the same silent-swallow pattern on its success path. Changed the return type to `error` so the workqueue can re-queue on status write failure.

**Note:** `addAnnotation`, `popFinalizerFromContainerRuntimeConfig`, and `addFinalizerToContainerRuntimeConfig` also use lister reads inside `RetryOnConflict` and have the same stale-cache risk. These are left as-is to keep the PR scoped to the reported bug; they can be addressed in a follow-up if desired.

**- How to verify it**

- `TestStatusUpdateConflictRequeues` — injects a 409 Conflict on `UpdateStatus` and verifies `syncHandler` returns an error (fails without the fix, passes with it)
- All existing `container-runtime-config` tests pass (no regressions)
- Deploy on a 5.0 cluster, create a ContainerRuntimeConfig, simulate stuck status with `oc patch ctrcfg <name> --type=merge --subresource=status -p '{"status":{"observedGeneration":0,"conditions":[]}}'`, verify the controller recovers

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fix ContainerRuntimeConfig controller silently swallowing status update failures, which could permanently block the render controller during SNO bootstrap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Status updates now use the latest resource state, preventing stale updates.
- Status update failures are reported instead of being silently ignored.
- Conflicts during status updates now return an error so the operation can be retried.
- Original synchronization errors are preserved when applicable.
- Runtime configuration status update failures now propagate correctly.

## Tests

- Added regression coverage for status update conflicts and related API interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->