### PR TITLE
[WIP] OCPBUGS-109739: Increase rpm-ostree rebase retry backoff and preserve error

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -2962,22 +2962,26 @@ func (dn *Daemon) updateLayeredOS(config *mcfgv1.MachineConfig) error {
 		// such that if we happen to update while the CoreDNS pod is being restarted,
 		// the next retry should succeed if no other issues are present.
 		backoff := wait.Backoff{
-			Duration: 5 * time.Second,
+			Duration: 10 * time.Second,
 			Factor:   2,
-			Steps:    5,
+			Steps:    7,
+			Cap:      60 * time.Second,
 		}
 
+		var lastRebaseErr error
 		if err := wait.ExponentialBackoff(backoff, func() (bool, error) {
 			if err := dn.NodeUpdaterClient.RebaseLayered(newURL); err != nil {
 				klog.Warningf("Failed to update OS to %s (will retry): %v", newURL, err)
+				lastRebaseErr = err
 				return false, nil
 			}
 			return true, nil
 		}); err != nil {
+			rebaseErr := fmt.Errorf("failed to update OS to %s after retries: %v: %w", newURL, lastRebaseErr, err)
 			// Report ImagePulledFromRegistry condition as false (failed)
 			if imageModeStatusReportingEnabled {
 				mcnErr := upgrademonitor.GenerateAndApplyMachineConfigNodes(
-					&upgrademonitor.Condition{State: mcfgv1.MachineConfigNodeImagePulledFromRegistry, Reason: string(mcfgv1.MachineConfigNodeImagePulledFromRegistry), Message: fmt.Sprintf("Failed to pull OS image %s from registry: %v", newURL, err)},
+					&upgrademonitor.Condition{State: mcfgv1.MachineConfigNodeImagePulledFromRegistry, Reason: string(mcfgv1.MachineConfigNodeImagePulledFromRegistry), Message: fmt.Sprintf("Failed to pull OS image %s from registry: %v", newURL, rebaseErr)},
 					nil,
 					metav1.ConditionFalse,
 					metav1.ConditionFalse,
@@ -2990,7 +2994,7 @@ func (dn *Daemon) updateLayeredOS(config *mcfgv1.MachineConfig) error {
 					klog.Errorf("Error setting ImagePulledFromRegistry condition to false: %v", mcnErr)
 				}
 			}
-			return fmt.Errorf("Failed to update OS to %s after retries: %w", newURL, err)
+			return rebaseErr
 		}
 
 		// Report ImagePulledFromRegistry condition as true (success)


### PR DESCRIPTION


During 4.21→4.22 upgrades, the rpm-ostree rebase can time out on a worker node when CoreDNS pods are rescheduled during node drain, causing transient DNS failures that outlast the current 5-attempt / 75-second retry window.

Increase the backoff from 5 attempts (5s initial, ~75s total) to 7 attempts (10s initial, 60s cap, ~250s total) to better accommodate the longer DNS disruption windows seen during major version upgrades.

Also capture the last rpm-ostree error and include it in the final error message so operators see the actual failure reason instead of just "timed out waiting for the condition".

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
