### PR TITLE
OCPBUGS-112075: skip proxy for OSImageStream discovery in HyperShift

### DIFF
--- a/pkg/controller/bootstrap/bootstrap.go
+++ b/pkg/controller/bootstrap/bootstrap.go
@@ -50,7 +50,7 @@ type Bootstrap struct {
 	// dir used to read pools and user defined machineconfigs.
 	manifestDir string
 	// pull secret file
-	pullSecretFile string
+	pullSecretFile     string
 	imageStreamFactory osimagestream.ImageStreamFactory
 	inspectorFactory   osimagestream.ImagesInspectorFactory
 }
@@ -242,21 +242,15 @@ func (b *Bootstrap) Run(destDir string) error {
 		return fmt.Errorf("error filtering pools: %w", err)
 	}
 
+	sysCtxFactory := buildSysContextFactory(pullSecret, cconfig, cconfig.Spec.Infra, imgCfg, icspRules, idmsRules, itmsRules)
+
 	// Enable OSImageStreams if the FeatureGate is active.
 	// Previously this also excluded ExternalTopologyMode (HyperShift) because
 	// HyperShift did not yet write stream selection into the synthetic MCP.
 	// Now that HyperShift writes 99_osimagestream.yaml into the MCC template
 	// directory (openshift/hypershift#8792), the guard is no longer needed.
 	if osimagestream.IsFeatureEnabled(fgHandler) {
-		osImageStream, err = b.fetchOSImageStream(
-			imageStream,
-			cconfig,
-			icspRules,
-			idmsRules,
-			itmsRules,
-			imgCfg,
-			pullSecret,
-			osImageStream)
+		osImageStream, err = b.fetchOSImageStream(sysCtxFactory, imageStream, cconfig, osImageStream)
 		if err != nil {
 			return err
 		}
@@ -367,7 +361,6 @@ func (b *Bootstrap) Run(destDir string) error {
 		klog.Infof("Successfully created %d pre-built image component MachineConfigs for hybrid OCL.", len(preBuiltImageMCs))
 	}
 
-	sysCtxFactory := buildSysContextFactory(pullSecret, cconfig, imgCfg, icspRules, idmsRules, itmsRules)
 	inspector := osimagestream.NewStreamClassInspector(b.inspectorFactory, sysCtxFactory)
 	fpools, gconfigs, err := render.RunBootstrap(context.TODO(), pools, configs, cconfig, osImageStream, inspector)
 	if err != nil {
@@ -498,20 +491,14 @@ func filterPools(pools []*mcfgv1.MachineConfigPool) ([]*mcfgv1.MachineConfigPool
 }
 
 func (b *Bootstrap) fetchOSImageStream(
+	sysCtxFactory imageutils.SysContextFactory,
 	imageStream *imagev1.ImageStream,
 	cconfig *mcfgv1.ControllerConfig,
-	icspRules []*apioperatorsv1alpha1.ImageContentSourcePolicy,
-	idmsRules []*apicfgv1.ImageDigestMirrorSet,
-	itmsRules []*apicfgv1.ImageTagMirrorSet,
-	imgCfg *apicfgv1.Image,
-	pullSecret *corev1.Secret,
 	existingOSImageStream *mcfgv1.OSImageStream,
 ) (*mcfgv1.OSImageStream, error) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
-
-	sysCtxFactory := buildSysContextFactory(pullSecret, cconfig, imgCfg, icspRules, idmsRules, itmsRules)
 
 	factory := b.imageStreamFactory
 	createOpts := osimagestream.CreateOptions{
@@ -536,6 +523,7 @@ func (b *Bootstrap) fetchOSImageStream(
 func buildSysContextFactory(
 	pullSecret *corev1.Secret,
 	cconfig *mcfgv1.ControllerConfig,
+	infra *apicfgv1.Infrastructure,
 	imgCfg *apicfgv1.Image,
 	icspRules []*apioperatorsv1alpha1.ImageContentSourcePolicy,
 	idmsRules []*apicfgv1.ImageDigestMirrorSet,
@@ -545,6 +533,12 @@ func buildSysContextFactory(
 		builder := imageutils.NewSysContextBuilder().
 			WithControllerConfig(cconfig).
 			WithSecret(pullSecret)
+
+		// In HCP the proxy config belongs to the data plane cluster and is
+		// unreachable from the management cluster where this code runs.
+		if infra != nil && infra.Status.ControlPlaneTopology == apicfgv1.ExternalTopologyMode {
+			builder.WithoutProxy()
+		}
 
 		registriesConfig, err := imageutils.GenerateRegistriesConfig(imgCfg, icspRules, idmsRules, itmsRules)
 		if err != nil {

--- a/pkg/imageutils/sys_context.go
+++ b/pkg/imageutils/sys_context.go
@@ -30,6 +30,7 @@ type SysContextBuilder struct {
 	secret           *corev1.Secret
 	controllerConfig *mcfgv1.ControllerConfig
 	registriesConfig *sysregistriesv2.V2RegistriesConf
+	skipProxy        bool
 }
 
 // NewSysContextBuilder creates a new SysContextBuilder for building SysContext instances.
@@ -46,6 +47,12 @@ func (b *SysContextBuilder) WithSecret(secret *corev1.Secret) *SysContextBuilder
 // WithControllerConfig adds certificates and proxy settings from ControllerConfig to the SysContext.
 func (b *SysContextBuilder) WithControllerConfig(cc *mcfgv1.ControllerConfig) *SysContextBuilder {
 	b.controllerConfig = cc
+	return b
+}
+
+// WithoutProxy disables proxy configuration even if the ControllerConfig has one.
+func (b *SysContextBuilder) WithoutProxy() *SysContextBuilder {
+	b.skipProxy = true
 	return b
 }
 
@@ -157,7 +164,7 @@ func (b *SysContextBuilder) buildRegistries(sysContext *SysContext) error {
 // Prioritizes HTTPS proxy over HTTP proxy when both are configured.
 // Returns early if no controller config was provided or no proxy is configured.
 func (b *SysContextBuilder) buildProxy(sysContext *SysContext) error {
-	if b.controllerConfig == nil {
+	if b.controllerConfig == nil || b.skipProxy {
 		return nil
 	}
 	// TODO: Improve when containers-libs is used with https://github.com/containers/container-libs/pull/583

--- a/pkg/imageutils/sys_context_test.go
+++ b/pkg/imageutils/sys_context_test.go
@@ -320,6 +320,7 @@ func TestSysContextBuilderWithProxy(t *testing.T) {
 		name             string
 		httpProxy        string
 		httpsProxy       string
+		skipProxy        bool
 		expectedScheme   string
 		expectedHost     string
 		expectedUsername string
@@ -376,6 +377,12 @@ func TestSysContextBuilderWithProxy(t *testing.T) {
 			expectedUsername: "user",
 			expectedPassword: "p@ssw0rd!",
 		},
+		{
+			name:       "WithoutProxy skips proxy even when configured",
+			httpsProxy: "https://proxy.example.com:3128",
+			httpProxy:  "http://proxy.example.com:8080",
+			skipProxy:  true,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -389,35 +396,41 @@ func TestSysContextBuilderWithProxy(t *testing.T) {
 				},
 			}
 
-			sysCtx, err := NewSysContextBuilder().
+			builder := NewSysContextBuilder().
 				WithSecret(secret).
-				WithControllerConfig(cc).
-				Build()
+				WithControllerConfig(cc)
+			if tc.skipProxy {
+				builder.WithoutProxy()
+			}
+
+			sysCtx, err := builder.Build()
 			require.NoError(t, err, "SysContextBuilder.Build should not fail")
 			require.NotNil(t, sysCtx, "SysContext wrapper should not be nil")
 			require.NotNil(t, sysCtx.SysContext, "Underlying SystemContext should not be nil")
 
-			// Check that proxy was set correctly
-			require.NotNil(t, sysCtx.SysContext.DockerProxyURL, "DockerProxyURL should not be nil")
-			assert.Equal(t, tc.expectedScheme, sysCtx.SysContext.DockerProxyURL.Scheme, "Proxy scheme should match")
-			assert.Equal(t, tc.expectedHost, sysCtx.SysContext.DockerProxyURL.Host, "Proxy host should match")
+			if tc.skipProxy {
+				assert.Nil(t, sysCtx.SysContext.DockerProxyURL, "DockerProxyURL should be nil when proxy is skipped")
+			} else {
+				require.NotNil(t, sysCtx.SysContext.DockerProxyURL, "DockerProxyURL should not be nil")
+				assert.Equal(t, tc.expectedScheme, sysCtx.SysContext.DockerProxyURL.Scheme, "Proxy scheme should match")
+				assert.Equal(t, tc.expectedHost, sysCtx.SysContext.DockerProxyURL.Host, "Proxy host should match")
 
-			// Check username and password if provided
-			if tc.expectedUsername != "" {
-				assert.NotNil(t, sysCtx.SysContext.DockerProxyURL.User, "Proxy user info should not be nil")
-				assert.Equal(t, tc.expectedUsername, sysCtx.SysContext.DockerProxyURL.User.Username(), "Proxy username should match")
-			}
+				if tc.expectedUsername != "" {
+					assert.NotNil(t, sysCtx.SysContext.DockerProxyURL.User, "Proxy user info should not be nil")
+					assert.Equal(t, tc.expectedUsername, sysCtx.SysContext.DockerProxyURL.User.Username(), "Proxy username should match")
+				}
 
-			if tc.expectedPassword != "" {
-				assert.NotNil(t, sysCtx.SysContext.DockerProxyURL.User, "Proxy user info should not be nil")
-				password, hasPassword := sysCtx.SysContext.DockerProxyURL.User.Password()
-				assert.True(t, hasPassword, "Proxy should have password")
-				assert.Equal(t, tc.expectedPassword, password, "Proxy password should match")
-			}
+				if tc.expectedPassword != "" {
+					assert.NotNil(t, sysCtx.SysContext.DockerProxyURL.User, "Proxy user info should not be nil")
+					password, hasPassword := sysCtx.SysContext.DockerProxyURL.User.Password()
+					assert.True(t, hasPassword, "Proxy should have password")
+					assert.Equal(t, tc.expectedPassword, password, "Proxy password should match")
+				}
 
-			if tc.expectedUsername == "" && tc.expectedPassword == "" {
-				if sysCtx.SysContext.DockerProxyURL.User != nil {
-					assert.Empty(t, sysCtx.SysContext.DockerProxyURL.User.Username(), "Proxy username should be empty")
+				if tc.expectedUsername == "" && tc.expectedPassword == "" {
+					if sysCtx.SysContext.DockerProxyURL.User != nil {
+						assert.Empty(t, sysCtx.SysContext.DockerProxyURL.User.Username(), "Proxy username should be empty")
+					}
 				}
 			}
 


### PR DESCRIPTION
## Summary

In HyperShift (ExternalTopologyMode), the ignition-server pod runs MCC bootstrap on the management cluster but inherits the guest cluster's proxy configuration via `--proxy-config-file`. When OSImageStream discovery performs network-based image inspection, it routes through that proxy which is unreachable from the management cluster network, causing all stream sources to timeout with:

```
pinging container registry quay.io:
  Get "https://quay.io/v2/": proxyconnect tcp: dial tcp 10.0.9.220:3128: i/o timeout
```

### Root cause

The proxy injection chain:
1. ignition-server passes `--proxy-config-file` to MCO bootstrap
2. MCO reads proxy into `ControllerConfig.Spec.Proxy`
3. `SysContextBuilder.WithControllerConfig()` stores the ControllerConfig
4. `buildProxy()` sets `SystemContext.DockerProxyURL` from the proxy config
5. `containers/image` routes all registry pings through the guest's proxy
6. Guest proxy IP (e.g. `10.0.9.220:3128`) is unreachable from the management cluster network
7. All stream sources fail, MCC exits with `ErrorNoOSImageStreamAvailable` (exit 255)

### Fix

- Add `WithoutProxy()` method to `SysContextBuilder` that sets a `skipProxy` flag, causing `buildProxy()` to skip proxy injection
- In `buildSysContextFactory()`, detect `ExternalTopologyMode` (HyperShift) via the Infrastructure object and call `WithoutProxy()` when active
- Consolidate the two separate `sysCtxFactory` creation sites into a single one in `Run()`, shared by both `fetchOSImageStream()` and `StreamClassInspector`

This approach is cleaner and more reusable than the previous deep-copy approach, as `WithoutProxy()` can be used by any future caller that needs to skip proxy.

### Why only `TestCreateClusterProxy`?

This is the only CI test that creates a HostedCluster with a proxy. Without proxy, image inspection goes directly to registries (which works). With proxy, all traffic routes through the guest's squid, which is unreachable from the management cluster.

## Testing

- Unit tests for `WithoutProxy()` in `TestSysContextBuilderWithProxy`
- Bootstrap HyperShift test (`TestBootstrapRunHypershift`) validates ExternalTopologyMode behavior
- Reproduced on a live HostedCluster with proxy on AWS (`TechPreviewNoUpgrade + --enable-proxy`)

## Jira

- https://issues.redhat.com/browse/CNTRLPLANE-3840
- https://issues.redhat.com/browse/CNTRLPLANE-3871

## Related PRs

- openshift/api#2993 (FG promotion, blocked on this)
- openshift/hypershift#9328 (graduation, blocked on this + API)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OS image stream processing by consistently reusing system context settings.
  * External topology deployments now bypass proxy configuration when accessing image streams.
  * Added safeguards to ensure proxy settings are omitted when proxy usage is disabled.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->