### PR TITLE
(WIP) OCPBUGS-105283

### DIFF
--- a/pkg/controller/build/buildrequest/buildrequest.go
+++ b/pkg/controller/build/buildrequest/buildrequest.go
@@ -174,6 +174,10 @@ func (br buildRequestImpl) ConfigMaps() ([]*corev1.ConfigMap, error) {
 	if err != nil {
 		return nil, fmt.Errorf("could not convert registries.conf files into ConfigMap %q: %w", br.getEtcRegistriesConfigMapName(), err)
 	}
+	etcRegistriesD, err := br.etcRegistriesDToConfigMap(br.opts.MachineConfig)
+	if err != nil {
+		return nil, fmt.Errorf("could not convert registries.d files into ConfigMap %q: %w", br.getEtcRegistriesDConfigMapName(), err)
+	}
 
 	configMaps := []*corev1.ConfigMap{containerfile, machineconfig, additionaltrustbundle}
 	if etcPolicy != nil {
@@ -185,6 +189,11 @@ func (br buildRequestImpl) ConfigMaps() ([]*corev1.ConfigMap, error) {
 		configMaps = append(configMaps, etcRegistries)
 	} else {
 		klog.Warningf("/etc/containers/registries.conf file not found in MachineConfig %q, could not create ConfigMap %q", br.opts.MachineConfig.Name, br.getEtcRegistriesConfigMapName())
+	}
+	if etcRegistriesD != nil {
+		configMaps = append(configMaps, etcRegistriesD)
+	} else {
+		klog.Warningf("/etc/containers/registries.d/ files not found in MachineConfig %q, could not create ConfigMap %q", br.opts.MachineConfig.Name, br.getEtcRegistriesDConfigMapName())
 	}
 
 	return configMaps, nil
@@ -304,6 +313,51 @@ func (br buildRequestImpl) etcRegistriesToConfigMap(mc *mcfgv1.MachineConfig) (*
 		Data:       configMapData,
 	}
 	return configmap, nil
+}
+
+func (br buildRequestImpl) etcRegistriesDToConfigMap(mc *mcfgv1.MachineConfig) (*corev1.ConfigMap, error) {
+	configMapData, err := br.ignitionFilesToConfigMapData(mc, "/etc/containers/registries.d/", "/etc/containers/registries.d/")
+	if err != nil {
+		return nil, err
+	}
+	if len(configMapData) == 0 {
+		return nil, nil
+	}
+	return &corev1.ConfigMap{
+		TypeMeta:   metav1.TypeMeta{},
+		ObjectMeta: br.getObjectMeta(br.getEtcRegistriesDConfigMapName()),
+		Data:       configMapData,
+	}, nil
+}
+
+func (br buildRequestImpl) getEtcRegistriesDConfigMapName() string {
+	return utils.GetEtcRegistriesDConfigMapName(br.opts.MachineOSBuild)
+}
+
+func (br buildRequestImpl) ignitionFilesToConfigMapData(mc *mcfgv1.MachineConfig, dirPath, prefixToTrim string) (map[string]string, error) {
+	if len(mc.Spec.Config.Raw) == 0 {
+		return nil, nil
+	}
+	ignCfg, err := ctrlcommon.ParseAndConvertConfig(mc.Spec.Config.Raw)
+	if err != nil {
+		return nil, fmt.Errorf("parsing rendered MC Ignition config failed with error: %w", err)
+	}
+	result := map[string]string{}
+	for _, file := range ignCfg.Storage.Files {
+		if !strings.HasPrefix(file.Path, dirPath) {
+			continue
+		}
+		if file.Contents.Source == nil {
+			return nil, fmt.Errorf("nil source for %s", file.Path)
+		}
+		decodedData, err := chelpers.DecodeIgnitionFileContents(file.Contents.Source, file.Contents.Compression)
+		if err != nil {
+			return nil, fmt.Errorf("error decoding %s: %w", file.Path, err)
+		}
+		fileKey := strings.TrimPrefix(file.Path, prefixToTrim)
+		result[fileKey] = string(decodedData)
+	}
+	return result, nil
 }
 
 func (br buildRequestImpl) ignitionFileToConfigMapData(mc *mcfgv1.MachineConfig, filePath, prefixToTrim string) (map[string]string, error) {
@@ -703,6 +757,10 @@ func (br buildRequestImpl) toBuildahPod() *corev1.Pod {
 			SubPath:   "registries.conf",
 		},
 		{
+			Name:      "etc-registries-d",
+			MountPath: "/etc/containers/registries.d",
+		},
+		{
 			Name:      "additional-trust-bundle",
 			MountPath: "/etc/pki/ca-trust/source/anchors",
 		},
@@ -775,6 +833,18 @@ func (br buildRequestImpl) toBuildahPod() *corev1.Pod {
 				ConfigMap: &corev1.ConfigMapVolumeSource{
 					LocalObjectReference: corev1.LocalObjectReference{
 						Name: br.getEtcRegistriesConfigMapName(),
+					},
+					Optional: &boolTrue,
+				},
+			},
+		},
+		{
+			// Provides the /etc/containers/registries.d/ content from the node
+			Name: "etc-registries-d",
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: br.getEtcRegistriesDConfigMapName(),
 					},
 					Optional: &boolTrue,
 				},

--- a/pkg/controller/build/buildrequest/buildrequest_test.go
+++ b/pkg/controller/build/buildrequest/buildrequest_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	ign3types "github.com/coreos/ignition/v2/config/v3_5/types"
 	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
 	"github.com/openshift/machine-config-operator/pkg/controller/build/constants"
 	"github.com/openshift/machine-config-operator/pkg/controller/build/fixtures"
@@ -14,6 +15,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	testhelpers "github.com/openshift/machine-config-operator/test/helpers"
 )
 
 const (
@@ -262,6 +264,30 @@ func assertBuildJobIsCorrect(t *testing.T, buildJob *batchv1.Job, opts BuildRequ
 			},
 		},
 	})
+
+	boolTrue := true
+	assertPodHasVolume(t, buildJob.Spec.Template.Spec, corev1.Volume{
+		Name: "etc-registries-d",
+		VolumeSource: corev1.VolumeSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: utils.GetEtcRegistriesDConfigMapName(opts.MachineOSBuild),
+				},
+				Optional: &boolTrue,
+			},
+		},
+	})
+
+	etcRegistriesDMount := corev1.VolumeMount{
+		Name:      "etc-registries-d",
+		MountPath: "/etc/containers/registries.d",
+	}
+	for _, container := range buildJob.Spec.Template.Spec.Containers {
+		assert.Contains(t, container.VolumeMounts, etcRegistriesDMount)
+	}
+	for _, initContainer := range buildJob.Spec.Template.Spec.InitContainers {
+		assert.Contains(t, initContainer.VolumeMounts, etcRegistriesDMount)
+	}
 }
 
 func assertPodHasVolume(t *testing.T, pod corev1.PodSpec, volume corev1.Volume) {
@@ -523,4 +549,76 @@ LABEL badlabel`,
 			}
 		})
 	}
+}
+
+// Tests that etcRegistriesDToConfigMap correctly extracts /etc/containers/registries.d/
+// files from a MachineConfig into a ConfigMap for mounting into the build pod.
+func TestEtcRegistriesDToConfigMap(t *testing.T) {
+	t.Parallel()
+
+	sigstoreYAML := `docker:
+  registry.example.com:
+    use-sigstore-attachments: true`
+
+	t.Run("returns nil when no registries.d files are present in MachineConfig", func(t *testing.T) {
+		t.Parallel()
+		mc := testhelpers.NewMachineConfig("test-mc", map[string]string{}, "", []ign3types.File{})
+		br := buildRequestImpl{opts: getBuildRequestOpts()}
+		cm, err := br.etcRegistriesDToConfigMap(mc)
+		assert.NoError(t, err)
+		assert.Nil(t, cm)
+	})
+
+	t.Run("creates ConfigMap with sigstore-registries.yaml from MachineConfig", func(t *testing.T) {
+		t.Parallel()
+		mc := testhelpers.NewMachineConfig("test-mc", map[string]string{}, "", []ign3types.File{
+			ctrlcommon.NewIgnFile("/etc/containers/registries.d/sigstore-registries.yaml", sigstoreYAML),
+		})
+		opts := getBuildRequestOpts()
+		br := buildRequestImpl{opts: opts}
+		cm, err := br.etcRegistriesDToConfigMap(mc)
+		assert.NoError(t, err)
+		assert.NotNil(t, cm)
+		assert.Equal(t, utils.GetEtcRegistriesDConfigMapName(opts.MachineOSBuild), cm.Name)
+		assert.Equal(t, sigstoreYAML, cm.Data["sigstore-registries.yaml"])
+	})
+
+	t.Run("creates ConfigMap with multiple registries.d files from MachineConfig", func(t *testing.T) {
+		t.Parallel()
+		file1 := `docker:
+  registry1.example.com:
+    use-sigstore-attachments: true`
+		file2 := `docker:
+  registry2.example.com:
+    use-sigstore-attachments: true`
+		mc := testhelpers.NewMachineConfig("test-mc", map[string]string{}, "", []ign3types.File{
+			ctrlcommon.NewIgnFile("/etc/containers/registries.d/file1.yaml", file1),
+			ctrlcommon.NewIgnFile("/etc/containers/registries.d/file2.yaml", file2),
+		})
+		opts := getBuildRequestOpts()
+		br := buildRequestImpl{opts: opts}
+		cm, err := br.etcRegistriesDToConfigMap(mc)
+		assert.NoError(t, err)
+		assert.NotNil(t, cm)
+		assert.Equal(t, file1, cm.Data["file1.yaml"])
+		assert.Equal(t, file2, cm.Data["file2.yaml"])
+	})
+
+	t.Run("does not include files outside registries.d in ConfigMap", func(t *testing.T) {
+		t.Parallel()
+		mc := testhelpers.NewMachineConfig("test-mc", map[string]string{}, "", []ign3types.File{
+			ctrlcommon.NewIgnFile("/etc/containers/registries.d/sigstore-registries.yaml", sigstoreYAML),
+			ctrlcommon.NewIgnFile("/etc/containers/registries.conf", "unversioned-schema = true"),
+			ctrlcommon.NewIgnFile("/etc/containers/policy.json", `{"default":[{"type":"insecureAcceptAnything"}]}`),
+		})
+		opts := getBuildRequestOpts()
+		br := buildRequestImpl{opts: opts}
+		cm, err := br.etcRegistriesDToConfigMap(mc)
+		assert.NoError(t, err)
+		assert.NotNil(t, cm)
+		assert.Equal(t, 1, len(cm.Data))
+		assert.Contains(t, cm.Data, "sigstore-registries.yaml")
+		assert.NotContains(t, cm.Data, "registries.conf")
+		assert.NotContains(t, cm.Data, "policy.json")
+	})
 }

--- a/pkg/controller/build/utils/helpers.go
+++ b/pkg/controller/build/utils/helpers.go
@@ -77,6 +77,10 @@ func GetEtcRegistriesConfigMapName(mosb *mcfgv1.MachineOSBuild) string {
 	return fmt.Sprintf("etc-registries-%s", getFieldFromMachineOSBuild(mosb))
 }
 
+func GetEtcRegistriesDConfigMapName(mosb *mcfgv1.MachineOSBuild) string {
+	return fmt.Sprintf("etc-registries-d-%s", getFieldFromMachineOSBuild(mosb))
+}
+
 // Computes the build job name.
 func GetBuildJobName(mosb *mcfgv1.MachineOSBuild) string {
 	return fmt.Sprintf("build-%s", getFieldFromMachineOSBuild(mosb))


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Build configurations now support optional container registry configuration files from MachineConfig data.
  * Build pods automatically mount these files at the standard container registry configuration path.
  * Multiple registry configuration files are supported, with invalid or missing content handled appropriately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->