### PR TITLE
OCPBUGS-112465: Update the MachineOSBuild event and condition functionality to more clearly handle pod failures with retries

### DIFF
--- a/pkg/controller/build/imagebuilder/jobimagebuilder.go
+++ b/pkg/controller/build/imagebuilder/jobimagebuilder.go
@@ -326,6 +326,34 @@ func (j *jobImageBuilder) validateBuilderType(builder buildrequest.Builder) erro
 	return fmt.Errorf("invalid type %T from builder, expected %T", j.builder, &batchv1.Job{})
 }
 
+// buildFailedConditionsFromJob returns MachineOSBuild failed conditions populated with the
+// failure reason and message from the job's Failed condition, falling back to generic values.
+func buildFailedConditionsFromJob(job *batchv1.Job) []metav1.Condition {
+	reason := "Failed"
+	message := "Build Failed"
+	for _, cond := range job.Status.Conditions {
+		if cond.Type == batchv1.JobFailed && cond.Status == corev1.ConditionTrue {
+			if cond.Reason != "" {
+				reason = cond.Reason
+			}
+			if cond.Message != "" {
+				message = cond.Message
+			}
+			break
+		}
+	}
+	message = fmt.Sprintf("Job %q failed after %d attempt(s): %s", job.Name, job.Status.Failed, message)
+	conditions := apihelpers.MachineOSBuildFailedConditions()
+	for i := range conditions {
+		if conditions[i].Type == string(mcfgv1.MachineOSBuildFailed) {
+			conditions[i].Reason = reason
+			conditions[i].Message = message
+			break
+		}
+	}
+	return conditions
+}
+
 // Maps a given batchv1.Job to a given MachineOSBuild status. Exported so that it can be used in e2e tests.
 func MapJobStatusToBuildStatus(job *batchv1.Job) (mcfgv1.BuildProgress, []metav1.Condition) {
 	// If the job is being deleted and it was not in either a successful or failed state
@@ -356,7 +384,7 @@ func MapJobStatusToBuildStatus(job *batchv1.Job) (mcfgv1.BuildProgress, []metav1
 				return mcfgv1.MachineOSBuildSucceeded, apihelpers.MachineOSBuildSucceededConditions()
 			}
 			if condition.Type == batchv1.JobFailed && condition.Status == corev1.ConditionTrue {
-				return mcfgv1.MachineOSBuildFailed, apihelpers.MachineOSBuildFailedConditions()
+				return mcfgv1.MachineOSBuildFailed, buildFailedConditionsFromJob(job)
 			}
 		}
 		// If we have succeeded pods but no completion condition, we're still building
@@ -365,7 +393,7 @@ func MapJobStatusToBuildStatus(job *batchv1.Job) (mcfgv1.BuildProgress, []metav1
 
 	// Only return failed if there have been 4 pod failures as the backoffLimit is set to 3
 	if job.Status.Failed > constants.JobMaxRetries {
-		return mcfgv1.MachineOSBuildFailed, apihelpers.MachineOSBuildFailedConditions()
+		return mcfgv1.MachineOSBuildFailed, buildFailedConditionsFromJob(job)
 	}
 
 	return "", apihelpers.MachineOSBuildInitialConditions()

--- a/pkg/controller/build/ocl_events.go
+++ b/pkg/controller/build/ocl_events.go
@@ -24,6 +24,7 @@ const (
 	EventJobCreated   = "JobCreated"
 	EventJobStarted   = "JobStarted"
 	EventJobCompleted = "JobCompleted"
+	EventJobPodFailed = "JobPodFailed"
 	EventJobFailed    = "JobFailed"
 	EventJobDeleted   = "JobDeleted"
 
@@ -120,10 +121,23 @@ func (r *OCLEventRecorder) RecordJobCompleted(mosb *mcfgv1.MachineOSBuild, job *
 		fmt.Sprintf("Build job completed: %s", job.Name))
 }
 
-// RecordJobFailed records when a build job fails
+// RecordJobPodFailed records when a build pod fails but the job is still retrying
+func (r *OCLEventRecorder) RecordJobPodFailed(mosb *mcfgv1.MachineOSBuild, job *batchv1.Job, maxRetries int32) {
+	r.recorder.Event(mosb, corev1.EventTypeWarning, EventJobPodFailed,
+		fmt.Sprintf("Build pod failed (attempt %d of %d); build job is retrying", job.Status.Failed, maxRetries+1))
+}
+
+// RecordJobFailed records when a build job has exhausted all retries and finally failed
 func (r *OCLEventRecorder) RecordJobFailed(mosb *mcfgv1.MachineOSBuild, job *batchv1.Job) {
+	reason := "unknown"
+	for _, cond := range job.Status.Conditions {
+		if cond.Type == batchv1.JobFailed && cond.Status == corev1.ConditionTrue && cond.Message != "" {
+			reason = cond.Message
+			break
+		}
+	}
 	r.recorder.Event(mosb, corev1.EventTypeWarning, EventJobFailed,
-		fmt.Sprintf("Build job %q failed; see MachineOSBuild %q status conditions for details", job.Name, mosb.Name))
+		fmt.Sprintf("Build job %q failed after %d attempt(s): %s", job.Name, job.Status.Failed, reason))
 }
 
 // RecordJobDeleted records when a build job is deleted

--- a/pkg/controller/build/ocl_events_test.go
+++ b/pkg/controller/build/ocl_events_test.go
@@ -117,6 +117,7 @@ func TestJobEvents(t *testing.T) {
 		{"JobCreated", func(r *OCLEventRecorder) { r.RecordJobCreated(mosb, job) }, "Normal", EventJobCreated},
 		{"JobStarted", func(r *OCLEventRecorder) { r.RecordJobStarted(mosb, job) }, "Normal", EventJobStarted},
 		{"JobCompleted", func(r *OCLEventRecorder) { r.RecordJobCompleted(mosb, job) }, "Normal", EventJobCompleted},
+		{"JobPodFailed", func(r *OCLEventRecorder) { r.RecordJobPodFailed(mosb, job, 3) }, "Warning", EventJobPodFailed},
 		{"JobFailed", func(r *OCLEventRecorder) { r.RecordJobFailed(mosb, job) }, "Warning", EventJobFailed},
 		{"JobDeleted", func(r *OCLEventRecorder) { r.RecordJobDeleted(mosb, job.Name) }, "Normal", EventJobDeleted},
 	}

--- a/pkg/controller/build/reconciler.go
+++ b/pkg/controller/build/reconciler.go
@@ -259,7 +259,11 @@ func (b *buildReconciler) UpdateJob(ctx context.Context, oldJob, curJob *batchv1
 				b.eventRecorder.RecordJobCompleted(mosb, curJob)
 			}
 
-			if curJob.Status.Failed > 0 && (oldJob.Status.Failed == 0) {
+			if curJob.Status.Failed > oldJob.Status.Failed && curJob.Status.Failed <= constants.JobMaxRetries {
+				b.eventRecorder.RecordJobPodFailed(mosb, curJob, constants.JobMaxRetries)
+			}
+
+			if curJob.Status.Failed > constants.JobMaxRetries && oldJob.Status.Failed <= constants.JobMaxRetries {
 				b.eventRecorder.RecordJobFailed(mosb, curJob)
 			}
 
@@ -614,7 +618,6 @@ func (b *buildReconciler) startBuild(ctx context.Context, mosb *mcfgv1.MachineOS
 // Retrieves a deep-copy of the MachineOSConfig from the lister so that the cache is not mutated during the update.
 func (b *buildReconciler) getMachineOSConfigForUpdate(mosc *mcfgv1.MachineOSConfig) (*mcfgv1.MachineOSConfig, error) {
 	out, err := b.machineOSConfigLister.Get(mosc.Name)
-
 	if err != nil {
 		return nil, err
 	}
@@ -635,7 +638,6 @@ func (b *buildReconciler) getMachineOSBuildForJob(job *batchv1.Job) (*mcfgv1.Mac
 // Retrieves a deep-copy of the MachineOSBuild from the lister so that the cache is not mutated during the update.
 func (b *buildReconciler) getMachineOSBuildForUpdate(mosb *mcfgv1.MachineOSBuild) (*mcfgv1.MachineOSBuild, error) {
 	out, err := b.machineOSBuildLister.Get(mosb.Name)
-
 	if err != nil {
 		return nil, err
 	}
@@ -730,7 +732,6 @@ func (b *buildReconciler) createNewMachineOSBuildOrReuseExisting(ctx context.Con
 		MachineOSConfig:   mosc,
 		MachineConfigPool: mcp,
 	})
-
 	if err != nil {
 		return fmt.Errorf("could not instantiate new MachineOSBuild: %w", err)
 	}
@@ -1212,7 +1213,6 @@ func (b *buildReconciler) syncAll(ctx context.Context) error {
 
 		return nil
 	})
-
 	if err != nil {
 		return fmt.Errorf("could not sync all: %w", err)
 	}
@@ -1236,7 +1236,6 @@ func (b *buildReconciler) syncMachineOSBuilds(ctx context.Context) error {
 
 		return nil
 	})
-
 	if err != nil {
 		return fmt.Errorf("could not sync MachineOSBuilds: %w", err)
 	}
@@ -1249,7 +1248,6 @@ func (b *buildReconciler) syncMachineOSBuilds(ctx context.Context) error {
 // builder associated with it that one should be created.
 func (b *buildReconciler) syncMachineOSBuild(ctx context.Context, mosb *mcfgv1.MachineOSBuild) error {
 	return b.timeObjectOperation(mosb, syncingVerb, func() error {
-
 		// It could be the case that the MCP the mosb in queue was targeting no longer is valid
 		mcp, err := b.machineConfigPoolLister.Get(mosb.ObjectMeta.Labels[constants.TargetMachineConfigPoolLabelKey])
 		if err != nil {
@@ -1392,7 +1390,6 @@ func (b *buildReconciler) syncMachineOSConfigs(ctx context.Context) error {
 
 		return nil
 	})
-
 	if err != nil {
 		return fmt.Errorf("could not sync MachineOSConfigs: %w", err)
 	}
@@ -1476,7 +1473,6 @@ func (b *buildReconciler) syncMachineConfigPools(ctx context.Context) error {
 
 		return nil
 	})
-
 	if err != nil {
 		return fmt.Errorf("could not sync MachineConfigPools: %w", err)
 	}
@@ -1612,7 +1608,6 @@ func (b *buildReconciler) reconcilePoolChange(ctx context.Context, mcp *mcfgv1.M
 		return b.reuseImageForNewMOSB(ctx, mosc, oldMOSB)
 	}
 	return b.createNewMachineOSBuildOrReuseExisting(ctx, mosc, needsImageRebuild)
-
 }
 
 // reuseImageForNewMOSB creates a new MOSB (for the new rendered-MC name)
@@ -1637,7 +1632,6 @@ func (b *buildReconciler) reuseImageForNewMOSB(ctx context.Context, mosc *mcfgv1
 			MachineOSConfig:   mosc,
 			MachineConfigPool: mcp,
 		})
-
 	if err != nil {
 		return err
 	}
@@ -1805,7 +1799,6 @@ func (b *buildReconciler) shouldPreventBuildDueToDegradation(mcp *mcfgv1.Machine
 // reconcileImageRebuild calls RequiresRebuild to see if an MC changes the kernel args, ext, or osimageurl.
 // if it does, we build a new image in our new MOSB
 func (b *buildReconciler) reconcileImageRebuild(oldMCP, curMCP *mcfgv1.MachineConfigPool) (bool, error) {
-
 	curr, err := b.machineConfigLister.Get(oldMCP.Spec.Configuration.Name)
 	if err != nil {
 		return false, err
@@ -1982,7 +1975,6 @@ func (b *buildReconciler) seedMachineOSConfigWithExistingImage(ctx context.Conte
 		MachineConfigPool: mcp,
 		MachineOSConfig:   mosc,
 	})
-
 	if err != nil {
 		return fmt.Errorf("could not generate MachineOSBuild template for MachineOSConfig %q: %w", mosc.Name, err)
 	}


### PR DESCRIPTION
Closes: OCPBUGS-112465

**- What I did**
This updates the MachineOSBuild event and condition setting functions to handle pod building failures that will retry.

**- How to verify it**

1. Launch a 5.1 cluster with this PR included.
2. Enable OCL in a pool with a MachineOSConfig that will cause a MachineOSBuild failure. An example of how to do this is below.
```
$ oc create secret docker-registry quay-push-secret \
    -n openshift-machine-config-operator \
    --docker-server=quay.io \
    --docker-username=<>
    --docker-password=<>
$ oc create -f - << EOF
apiVersion: machineconfiguration.openshift.io/v1
kind: MachineConfigPool
metadata:
 name: layered
spec:
 machineConfigSelector:
  matchExpressions:
   - {key: machineconfiguration.openshift.io/role, operator: In, values: [worker,layered]}
 nodeSelector:
  matchLabels:
   node-role.kubernetes.io/layered: ""
EOF
$ oc label node <node> node-role.kubernetes.io/layered=
$ oc apply -f - << EOF
apiVersion: machineconfiguration.openshift.io/v1
kind: MachineOSConfig
metadata:
  name: layered
spec:
  machineConfigPool:
    name: layered
  containerFile:
  - containerfileArch: NoArch
    content: |-
      FROM configs AS final
      RUN dnf install -y nmap && \
        dnf clean all && \
        bootc container lint
  imageBuilder:
    imageBuilderType: Job
  renderedImagePushSecret:
    name: quay-push-secret
  renderedImagePushSpec: "quay.io/<repo-path>:ocl-testing"
EOF
```
3. Track the MachineOSBuild events and status conditions to ensure information is clearly reflected to users.
```
$ oc get machineosbuild
NAME                                       PREPARED   BUILDING   SUCCEEDED   INTERRUPTED   FAILED   AGE
layered-98de2be95c396582cd0aa9fe1de74879   False      False      False       False         True     49m
$ oc describe machineosbuild
Name:         layered-98de2be95c396582cd0aa9fe1de74879
Namespace:    
Labels:       machineconfiguration.openshift.io/machine-os-config=layered
              machineconfiguration.openshift.io/rendered-machine-config=rendered-layered-ac3e12d52c46ffe383e5d3d1c15ad120
              machineconfiguration.openshift.io/target-machine-config-pool=layered
Annotations:  machineconfiguration.openshift.io/job-uid: ce1f72d5-285d-4b45-969c-bf49e9655fcb
              machineconfiguration.openshift.io/rendered-image-push-secret: quay-push-secret
API Version:  machineconfiguration.openshift.io/v1
Kind:         MachineOSBuild
Metadata:
  Creation Timestamp:  2026-08-24T14:24:40Z
  Finalizers:
    foregroundDeletion
  Generation:  1
  Owner References:
    API Version:           machineconfiguration.openshift.io/v1
    Block Owner Deletion:  true
    Controller:            true
    Kind:                  MachineOSConfig
    Name:                  layered
    UID:                   6c2167e6-6dbb-478b-9010-fd4ff55f55b6
  Resource Version:        49538
  UID:                     be3b3af9-ad2e-4d1c-bde2-286a112a5c10
Spec:
  Machine Config:
    Name:  rendered-layered-ac3e12d52c46ffe383e5d3d1c15ad120
  Machine Os Config:
    Name:                    layered
  Rendered Image Push Spec:  quay.io/rh-ee-ijanssen/machine-config-operator:layered-98de2be95c396582cd0aa9fe1de74879
Status:
  Build End:    2026-08-24T15:11:32Z
  Build Start:  2026-08-24T14:24:51Z
  Builder:
    Image Builder Type:  Job
    Job:
      Group:      batch
      Name:       build-layered-98de2be95c396582cd0aa9fe1de74879
      Namespace:  openshift-machine-config-operator
      Resource:   jobs
  Conditions:
    Last Transition Time:  2026-08-24T14:24:51Z
    Message:               Build Interrupted
    Reason:                Interrupted
    Status:                False
    Type:                  Interrupted
    Last Transition Time:  2026-08-24T14:24:51Z
    Message:               Build Ready
    Reason:                Ready
    Status:                False
    Type:                  Succeeded
    Last Transition Time:  2026-08-24T14:24:51Z
    Message:               Build Prepared and Pending
    Reason:                Prepared
    Status:                False
    Type:                  Prepared
    Last Transition Time:  2026-08-24T15:11:32Z
    Message:               Image Build In Progress
    Reason:                Building
    Status:                False
    Type:                  Building
    Last Transition Time:  2026-08-24T15:11:32Z
    Message:               Job "build-layered-98de2be95c396582cd0aa9fe1de74879" failed after 4 attempt(s): Job has reached the specified backoff limit
    Reason:                BackoffLimitExceeded
    Status:                True
    Type:                  Failed
Events:
  Type     Reason          Age    From              Message
  ----     ------          ----   ----              -------
  Normal   BuildStarted    49m    machineosbuilder  Started build for pool "layered" with config "rendered-layered-ac3e12d52c46ffe383e5d3d1c15ad120"
  Normal   BuildPreparing  49m    machineosbuilder  Preparing build: creating build job for pool "layered"
  Normal   JobCreated      49m    machineosbuilder  Created build job: build-layered-98de2be95c396582cd0aa9fe1de74879
  Normal   JobStarted      49m    machineosbuilder  Build job started: build-layered-98de2be95c396582cd0aa9fe1de74879
  Normal   BuildBuilding   49m    machineosbuilder  Build is now in progress
  Warning  JobPodFailed    38m    machineosbuilder  Build pod failed (attempt 1 of 4); build job is retrying
  Warning  JobPodFailed    27m    machineosbuilder  Build pod failed (attempt 2 of 4); build job is retrying
  Warning  JobPodFailed    15m    machineosbuilder  Build pod failed (attempt 3 of 4); build job is retrying
  Warning  JobFailed       2m41s  machineosbuilder  Build job "build-layered-98de2be95c396582cd0aa9fe1de74879" failed after 4 attempt(s): Job has reached the specified backoff limit
```

**- Description for the changelog**
OCPBUGS-112465: Update the MachineOSBuild event and condition functionality to more clearly handle pod failures with retries


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Diagnostics**
  * Improved error-level logging for Machine OS build reconciliation and status updates.
  * Added clearer details for state transitions, build conditions, configuration lookups, status retrieval failures, and update decisions.
  * Corrected diagnostic formatting for more accurate status information.
* **Behavior**
  * Build status decisions and update behavior remain unchanged.
  * No public interfaces or end-user workflows were modified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->