### PR TITLE
OCPBUGS-69681: limit ContainerRuntimeConfig status condition to 3

### DIFF
--- a/pkg/controller/container-runtime-config/container_runtime_config_controller.go
+++ b/pkg/controller/container-runtime-config/container_runtime_config_controller.go
@@ -676,6 +676,16 @@ func (ctrl *Controller) syncStatusOnly(cfg *mcfgv1.ContainerRuntimeConfig, err e
 		} else if newcfg.Status.Conditions[len(newcfg.Status.Conditions)-1].Message == newStatusCondition.Message {
 			newcfg.Status.Conditions[len(newcfg.Status.Conditions)-1] = newStatusCondition
 		}
+		// Keep at most three conditions to avoid an unbounded list. Copy into a
+		// freshly allocated slice rather than reslicing in place, so the discarded
+		// conditions' backing array can be garbage collected instead of lingering
+		// in memory (e.g. in the informer cache).
+		const statusLimit = 3
+		if len(newcfg.Status.Conditions) > statusLimit {
+			trimmed := make([]mcfgv1.ContainerRuntimeConfigCondition, statusLimit)
+			copy(trimmed, newcfg.Status.Conditions[len(newcfg.Status.Conditions)-statusLimit:])
+			newcfg.Status.Conditions = trimmed
+		}
 		_, updateErr := ctrl.client.MachineconfigurationV1().ContainerRuntimeConfigs().UpdateStatus(context.TODO(), newcfg, metav1.UpdateOptions{})
 		return updateErr
 	})


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"
Fixes: https://issues.redhat.com/browse/OCPBUGS-69681
Please provide the following information:
-->
Fixes: https://redhat.atlassian.net/browse/OCPBUGS-69681


**- What I did**

The `ContainerRuntimeConfig` controller preserves all status conditions indefinitely instead of bounding the list. Over time this causes the conditions slice to grow unbounded (observed with 3313 `Failure`/`Success` conditions on a 
single object), eventually triggering a gRPC `ResourceExhausted` error when updating status:
   

> W1216 08:55:50.750828       1 container_runtime_config_controller.go:557] error updating container runtime config status: rpc error: code = ResourceExhausted desc = trying to send message larger than max (2526542 vs. 2097152)

This change trims `newcfg.Status.Conditions` in `syncStatusOnly` to keep only the most recent 3 entries whenever the list grows beyond that limit, preventing unbounded growth.

**- How to verify it**

1. Trigger repeated `ContainerRuntimeConfig` status updates (e.g. by causing the config to alternate between success and failure) so multiple conditions accumulate.
2. Check `oc get containerruntimeconfig <name> -o json | jq '.status.conditions | length'` and confirm it never exceeds 3, even after many sync cycles.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Limit ContainerRuntimeConfig status conditions to the 3 most recent entries to prevent unbounded growth and ResourceExhausted errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Limited stored container runtime configuration status conditions to the three most recent entries, keeping status information concise and current.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->