### PR TITLE
OCPBUGS-74136: Split wait-for-ipsec-connect into two services to avoid ipsec restart

### DIFF
--- a/templates/common/_base/files/configure-ipsec-connect.yaml
+++ b/templates/common/_base/files/configure-ipsec-connect.yaml
@@ -1,0 +1,33 @@
+mode: 0755
+path: "/usr/local/bin/ipsec-connect-configure.sh"
+contents:
+  inline: |
+    #!/bin/bash
+    set -x
+    set -o pipefail
+
+    if [ ! -e "/etc/ipsec.d/openshift.conf" ]; then
+      exit 0
+    fi
+
+    # If "openshift.conf" is referenced in /etc/sysconfig/openvswitch,
+    # the openvswitch-ipsec service handles IPsec connections, so no
+    # config update is needed here.
+    if grep -q "openshift.conf" /etc/sysconfig/openvswitch; then
+      exit 0
+    fi
+
+    # Modify existing IPsec out connection entries with "auto=start"
+    # option before ipsec service starts. This helps to establish IKE
+    # SAs for the existing IPsec connections with peer nodes on the
+    # initial ipsec start, avoiding the need for a restart.
+    # This option will be deleted from connections once
+    # ovs-monitor-ipsec process spinned up on the node by
+    # ovn-ipsec-host pod, but still it won't reestablish IKE SAs
+    # again with peer nodes, so it shouldn't be a problem.
+    # We are updating only out connections with "auto=start" to
+    # avoid cross stream issue with Libreswan 5.2.
+    # The in connections use default auto=route parameter.
+    if ! grep -q "auto=start" /etc/ipsec.d/openshift.conf; then
+      sed -i '/^.*conn ovn.*-out-1$/a\    auto=start' /etc/ipsec.d/openshift.conf
+    fi

--- a/templates/common/_base/files/wait-for-ipsec-connect.yaml
+++ b/templates/common/_base/files/wait-for-ipsec-connect.yaml
@@ -22,23 +22,6 @@ contents:
         echo "Failed to enable and start $ovsipsecsvc"
         exit 1
       fi
-    else
-      echo "$ovsipsecsvc is not configured, so make pluto to establish IKE SAs"
-
-      # Modify existing IPsec out connection entries with "auto=start"
-      # option and restart ipsec systemd service. This helps to
-      # establish IKE SAs for the existing IPsec connections with
-      # peer nodes. This option will be deleted from connections
-      # once ovs-monitor-ipsec process spinned up on the node by
-      # ovn-ipsec-host pod, but still it won't reestablish IKE SAs
-      # again with peer nodes, so it shouldn't be a problem.
-      # We are updating only out connections with "auto=start" to
-      # avoid cross stream issue with Libreswan 5.2.
-      # The in connections use default auto=route parameter.
-      if ! grep -q "auto=start" /etc/ipsec.d/openshift.conf; then
-        sed -i '/^.*conn ovn.*-out-1$/a\    auto=start' /etc/ipsec.d/openshift.conf
-      fi
-      chroot /proc/1/root ipsec restart
     fi
 
     # Wait for upto 60s to get IPsec SAs to establish with peer nodes.

--- a/templates/common/_base/units/configure-ipsec-connect.service.yaml
+++ b/templates/common/_base/units/configure-ipsec-connect.service.yaml
@@ -1,0 +1,16 @@
+name: configure-ipsec-connect.service
+enabled: true
+contents: |
+  [Unit]
+  Description=Configure IPsec connections before ipsec service starts.
+  Before=ipsec.service
+  After=ovs-configuration.service
+
+  [Service]
+  Type=oneshot
+  ExecStart=/usr/local/bin/ipsec-connect-configure.sh
+  StandardOutput=journal+console
+  StandardError=journal+console
+
+  [Install]
+  WantedBy=ipsec.service


### PR DESCRIPTION
Move the openshift.conf config update (adding auto=start to outbound connections) into a new configure-ipsec-connect.service that runs before ipsec.service. This eliminates the unnecessary ipsec restart that was previously done in wait-for-ipsec-connect.service after ipsec had already started.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic configuration for OVN outbound IPsec connections to start when the IPsec service launches.
  * Added a startup service to apply this configuration before IPsec begins.

* **Bug Fixes**
  * Removed legacy fallback behavior that modified configuration files and restarted IPsec when Open vSwitch IPsec was not configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->