### PR TITLE
[release-4.22] Split wait-for-ipsec-connect into two services to avoid ipsec restart

### DIFF
--- a/templates/common/_base/files/configure-ipsec-connect.yaml
+++ b/templates/common/_base/files/configure-ipsec-connect.yaml
@@ -1,0 +1,26 @@
+mode: 0755
+path: "/usr/local/bin/ipsec-connect-configure.sh"
+contents:
+  inline: |
+    #!/bin/bash
+    set -x
+    set -o pipefail
+
+    if [ ! -e "/etc/ipsec.d/openshift.conf" ]; then
+      exit 0
+    fi
+
+    # Modify existing IPsec out connection entries with "auto=start"
+    # option before ipsec service starts. This helps to establish IKE
+    # SAs for the existing IPsec connections with peer nodes on the
+    # initial ipsec start, avoiding the need for a restart.
+    # This option will be deleted from connections once
+    # ovs-monitor-ipsec process spinned up on the node by
+    # ovn-ipsec-host pod, but still it won't reestablish IKE SAs
+    # again with peer nodes, so it shouldn't be a problem.
+    # We are updating only out connections with "auto=start" to
+    # avoid cross stream issue with Libreswan 5.2.
+    # The in connections use default auto=route parameter.
+    if ! grep -q "auto=start" /etc/ipsec.d/openshift.conf; then
+      sed -i '/^.*conn ovn.*-out-1$/a\    auto=start' /etc/ipsec.d/openshift.conf
+    fi

--- a/templates/common/_base/files/wait-for-ipsec-connect.yaml
+++ b/templates/common/_base/files/wait-for-ipsec-connect.yaml
@@ -9,21 +9,6 @@ contents:
       exit 0
     fi
 
-    # Modify existing IPsec out connection entries with "auto=start"
-    # option and restart ipsec systemd service. This helps to
-    # establish IKE SAs for the existing IPsec connections with
-    # peer nodes. This option will be deleted from connections
-    # once ovs-monitor-ipsec process spinned up on the node by
-    # ovn-ipsec-host pod, but still it won't reestablish IKE SAs
-    # again with peer nodes, so it shouldn't be a problem.
-    # We are updating only out connections with "auto=start" to
-    # avoid cross stream issue with Libreswan 5.2.
-    # The in connections use default auto=route parameter.
-    if ! grep -q "auto=start" /etc/ipsec.d/openshift.conf; then
-      sed -i '/^.*conn ovn.*-out-1$/a\    auto=start' /etc/ipsec.d/openshift.conf
-    fi
-    chroot /proc/1/root ipsec restart
-
     # Wait for upto 60s to get IPsec SAs to establish with peer nodes.
     timeout=60
     elapsed=0

--- a/templates/common/_base/units/configure-ipsec-connect.service.yaml
+++ b/templates/common/_base/units/configure-ipsec-connect.service.yaml
@@ -1,0 +1,16 @@
+name: configure-ipsec-connect.service
+enabled: true
+contents: |
+  [Unit]
+  Description=Configure IPsec connections before ipsec service starts.
+  Before=ipsec.service
+  After=ovs-configuration.service
+
+  [Service]
+  Type=oneshot
+  ExecStart=/usr/local/bin/ipsec-connect-configure.sh
+  StandardOutput=journal+console
+  StandardError=journal+console
+
+  [Install]
+  WantedBy=ipsec.service


### PR DESCRIPTION
Manual cherry-pick of https://github.com/openshift/machine-config-operator/pull/6440.