### PR TITLE
OCPBUGS-64623: Use kubernetes scheme in drain controller event recorder

### DIFF
--- a/pkg/controller/drain/drain_controller.go
+++ b/pkg/controller/drain/drain_controller.go
@@ -9,11 +9,11 @@ import (
 
 	v1 "github.com/openshift/api/machineconfiguration/v1"
 	mcfgclientset "github.com/openshift/client-go/machineconfiguration/clientset/versioned"
-	"github.com/openshift/client-go/machineconfiguration/clientset/versioned/scheme"
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
 	daemonconsts "github.com/openshift/machine-config-operator/pkg/daemon/constants"
 	"github.com/openshift/machine-config-operator/pkg/helpers"
 	"github.com/openshift/machine-config-operator/pkg/upgrademonitor"
+	kubescheme "k8s.io/client-go/kubernetes/scheme"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -127,7 +127,7 @@ func New(
 	ctrl := &Controller{
 		client:        mcfgClient,
 		kubeClient:    kubeClient,
-		eventRecorder: ctrlcommon.NamespacedEventRecorder(eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: "machineconfigcontroller-nodecontroller"})),
+		eventRecorder: ctrlcommon.NamespacedEventRecorder(eventBroadcaster.NewRecorder(kubescheme.Scheme, corev1.EventSource{Component: "machineconfigcontroller-nodecontroller"})),
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
 			workqueue.TypedRateLimitingQueueConfig[string]{Name: "machineconfigcontroller-draincontroller"}),


### PR DESCRIPTION
Fixes OCPBUGS-64623: Drain-failure Events should be successfully emitted

**- What I did**
Use kubernetes scheme in drain controller event recorder

**- How to verify it**
1- Apply a PodDisruptionBudget that prevent drain:
```
apiVersion: policy/v1
kind: PodDisruptionBudget
metadata:
  namespace: openshift-ingress
  name: test
spec:
  maxUnavailable: 0
  selector:
    matchLabels:
      ingresscontroller.operator.openshift.io/deployment-ingresscontroller: default
```
2- Add a MachineConfig that bumps the worker MachineConfigPool
```
apiVersion: machineconfiguration.openshift.io/v1
kind: MachineConfig
metadata:
  name: 99-worker-drain-test
  labels:
    machineconfiguration.openshift.io/role: worker
spec:
  config:
    ignition:
      version: 3.4.0
    storage:
      files:
        - path: /etc/drain-test-trigger
          mode: 0644
          contents:
            source: data:,drain-test
```
3 - Logs should not report the following log `should not construct reference, will not report event" err="no kind is registered for the type v1.Node in scheme`
```
$ oc logs -n openshift-machine-config-operator -l k8s-app=machine-config-controller -c machine-config-controller -f \
  | grep -E "DrainThresholdExceeded|will not report event"
``` 

4 - Check for Events about the failed Node drain
```
$ oc get events -n default | grep DrainThresholdExceeded # OR all namespaces
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event recording compatibility by using the standard Kubernetes client scheme.
  * Updated controller initialization to ensure events are registered correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->