### PR TITLE
OPNET-679: grant NET_ADMIN capability to coredns-monitor

### DIFF
--- a/templates/common/on-prem/files/coredns.yaml
+++ b/templates/common/on-prem/files/coredns.yaml
@@ -94,6 +94,9 @@ contents:
         terminationMessagePolicy: FallbackToLogsOnError
         imagePullPolicy: IfNotPresent
       - name: coredns-monitor
+        securityContext:
+          capabilities:
+            add: ["NET_ADMIN"]
         image: {{ .Images.baremetalRuntimeCfgImage }}
         command:
         - corednsmonitor


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Added the NET_ADMIN capability to the coredns-monitor container's                                                                                                    
  securityContext in the on-prem CoreDNS static pod template. This is in                                                                                               
  preparation for enabling/disabling external access to CoreDNS on on-prem                                                                                             
  clusters, which will be done via nftables rules that the coredns-monitor                                                                                             
  sidecar manages at runtime (CAP_NET_ADMIN is required for that).

**- How to verify it**
On an on-prem cluster, exec into the coredns-monitor container of a                                                                                                  
  coredns static pod and confirm CAP_NET_ADMIN is present:                                                                                                             
                                                                                                                                                                       
      grep CapEff /proc/1/status                                                                                                                                       
                                                                                                                                                                       
  Decode with `capsh --decode=<value>` and verify cap_net_admin is listed.                                                                                             
  Also confirm the coredns static pods roll out and become healthy after                                                                                               
  the MachineConfig update.

**- Description for the changelog**
Grant the NET_ADMIN capability to the coredns-monitor container so it can                                                                                            
  manage nftables rules controlling external access to CoreDNS on on-prem                                                                                              
  clusters.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Updated the CoreDNS monitoring component’s permissions to support required network administration operations in on-premises deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->