### PR TITLE
OCPBUGS-105283: Mount /etc/container in mosb

### DIFF
--- a/pkg/controller/build/buildrequest/buildrequest.go
+++ b/pkg/controller/build/buildrequest/buildrequest.go
@@ -5,9 +5,11 @@ import (
 	_ "embed"
 	"encoding/json"
 	"fmt"
+	"path"
 	"regexp"
 	"strings"
 	"text/template"
+	"unicode/utf8"
 
 	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
 	mcfgclientset "github.com/openshift/client-go/machineconfiguration/clientset/versioned"
@@ -40,9 +42,13 @@ var podmanBuildScript string
 const (
 	// Filename for the machineconfig JSON tarball expected by the build job
 	machineConfigJSONFilename string = "machineconfig.json.gz"
+
+	etcContainersPrefix = "/etc/containers/"
 )
 
 var basicSyntaxRegex = regexp.MustCompile(`(?m)(?i)^\s*FROM`)
+
+var validConfigMapKeyChars = regexp.MustCompile(`[^-._a-zA-Z0-9]`)
 
 // ContainerfileValidationError is returned when a rendered Containerfile fails
 // syntax validation. It is a permanent error — the build should not be retried.
@@ -166,25 +172,20 @@ func (br buildRequestImpl) ConfigMaps() ([]*corev1.ConfigMap, error) {
 
 	additionaltrustbundle := br.additionaltrustbundleToConfigMap()
 
-	etcPolicy, err := br.etcPolicyToConfigMap(br.opts.MachineConfig)
+	etcContainers, err := br.etcContainersToConfigMap(br.opts.MachineConfig)
 	if err != nil {
-		return nil, fmt.Errorf("could not convert etc/containers registries files into ConfigMap %q: %w", br.getEtcPolicyConfigMapName(), err)
-	}
-	etcRegistries, err := br.etcRegistriesToConfigMap(br.opts.MachineConfig)
-	if err != nil {
-		return nil, fmt.Errorf("could not convert registries.conf files into ConfigMap %q: %w", br.getEtcRegistriesConfigMapName(), err)
+		return nil, fmt.Errorf("could not convert /etc/containers/ files into ConfigMap %q: %w", br.getEtcContainersConfigMapName(), err)
 	}
 
 	configMaps := []*corev1.ConfigMap{containerfile, machineconfig, additionaltrustbundle}
-	if etcPolicy != nil {
-		configMaps = append(configMaps, etcPolicy)
+	if etcContainers != nil {
+		configMaps = append(configMaps, etcContainers)
 	} else {
-		klog.Warningf("/etc/containers/policy.json file not found in MachineConfig %q, could not create ConfigMap %q", br.opts.MachineConfig.Name, br.getEtcPolicyConfigMapName())
-	}
-	if etcRegistries != nil {
-		configMaps = append(configMaps, etcRegistries)
-	} else {
-		klog.Warningf("/etc/containers/registries.conf file not found in MachineConfig %q, could not create ConfigMap %q", br.opts.MachineConfig.Name, br.getEtcRegistriesConfigMapName())
+		mcName := ""
+		if br.opts.MachineConfig != nil {
+			mcName = br.opts.MachineConfig.Name
+		}
+		klog.Warningf("No /etc/containers/ files found in MachineConfig %q, could not create ConfigMap %q", mcName, br.getEtcContainersConfigMapName())
 	}
 
 	return configMaps, nil
@@ -268,74 +269,83 @@ func (br buildRequestImpl) additionaltrustbundleToConfigMap() *corev1.ConfigMap 
 	return configmap
 }
 
-func (br buildRequestImpl) etcPolicyToConfigMap(mc *mcfgv1.MachineConfig) (*corev1.ConfigMap, error) {
-	// Build the ConfigMap data
-	configMapData, err := br.ignitionFileToConfigMapData(mc, "/etc/containers/policy.json", "/etc/containers/")
-	if err != nil {
-		return nil, err
-	}
-	if len(configMapData) == 0 {
-		return nil, nil
-	}
-
-	// Create the ConfigMap
-	configmap := &corev1.ConfigMap{
-		TypeMeta:   metav1.TypeMeta{},
-		ObjectMeta: br.getObjectMeta(br.getEtcPolicyConfigMapName()),
-		Data:       configMapData,
-	}
-	return configmap, nil
+type etcContainersFile struct {
+	path    string
+	key     string
+	content string
 }
 
-func (br buildRequestImpl) etcRegistriesToConfigMap(mc *mcfgv1.MachineConfig) (*corev1.ConfigMap, error) {
-	// Build the ConfigMap data
-	configMapData, err := br.ignitionFileToConfigMapData(mc, "/etc/containers/registries.conf", "/etc/containers/")
-	if err != nil {
-		return nil, err
-	}
-	if len(configMapData) == 0 {
+func (br buildRequestImpl) getEtcContainersFiles(mc *mcfgv1.MachineConfig) ([]etcContainersFile, error) {
+	if mc == nil || len(mc.Spec.Config.Raw) == 0 {
 		return nil, nil
 	}
 
-	// Create the ConfigMap
-	configmap := &corev1.ConfigMap{
-		TypeMeta:   metav1.TypeMeta{},
-		ObjectMeta: br.getObjectMeta(br.getEtcRegistriesConfigMapName()),
-		Data:       configMapData,
-	}
-	return configmap, nil
-}
-
-func (br buildRequestImpl) ignitionFileToConfigMapData(mc *mcfgv1.MachineConfig, filePath, prefixToTrim string) (map[string]string, error) {
-	if len(mc.Spec.Config.Raw) == 0 {
-		return nil, nil
-	}
-	// Build the ConfigMap data
 	ignCfg, err := ctrlcommon.ParseAndConvertConfig(mc.Spec.Config.Raw)
 	if err != nil {
 		return nil, fmt.Errorf("parsing rendered MC Ignition config failed with error: %w", err)
 	}
 
+	seen := map[string]string{}
+	var files []etcContainersFile
 	for _, file := range ignCfg.Storage.Files {
-		if file.Path != filePath {
+		cleanPath := path.Clean(file.Path)
+		if !strings.HasPrefix(cleanPath, etcContainersPrefix) {
 			continue
 		}
 		if file.Contents.Source == nil {
-			return nil, fmt.Errorf("nil source for %s", file.Path)
+			klog.Warningf("Ignition file under %s has nil source, skipping", etcContainersPrefix)
+			continue
 		}
 
-		// Extract and decode the encoded data
 		decodedData, err := chelpers.DecodeIgnitionFileContents(file.Contents.Source, file.Contents.Compression)
 		if err != nil {
-			return nil, fmt.Errorf("error decoding %s: %w", file.Path, err)
+			return nil, fmt.Errorf("error decoding Ignition file contents under %s: %w", etcContainersPrefix, err)
 		}
 
-		// Key in the configmap is the path without the prefix
-		fileKey := strings.TrimPrefix(file.Path, prefixToTrim)
-		return map[string]string{fileKey: string(decodedData)}, nil
+		if !utf8.Valid(decodedData) {
+			klog.Warningf("Ignition file under %s contains non-UTF-8 data, skipping", etcContainersPrefix)
+			continue
+		}
+
+		relativePath := strings.TrimPrefix(cleanPath, etcContainersPrefix)
+		relativePath = strings.TrimPrefix(relativePath, "/")
+		key := strings.ReplaceAll(relativePath, "/", "__")
+		key = validConfigMapKeyChars.ReplaceAllString(key, "_")
+
+		if _, exists := seen[key]; exists {
+			return nil, fmt.Errorf("ConfigMap key collision for key %q", key)
+		}
+		seen[key] = cleanPath
+
+		files = append(files, etcContainersFile{
+			path:    cleanPath,
+			key:     key,
+			content: string(decodedData),
+		})
 	}
-	klog.Infof("Could not find %s in MachineConfig %s, skipping configmap creation....", filePath, mc.Name)
-	return nil, nil
+
+	return files, nil
+}
+
+func (br buildRequestImpl) etcContainersToConfigMap(mc *mcfgv1.MachineConfig) (*corev1.ConfigMap, error) {
+	files, err := br.getEtcContainersFiles(mc)
+	if err != nil {
+		return nil, err
+	}
+	if len(files) == 0 {
+		return nil, nil
+	}
+
+	data := make(map[string]string, len(files))
+	for _, f := range files {
+		data[f.key] = f.content
+	}
+
+	return &corev1.ConfigMap{
+		TypeMeta:   metav1.TypeMeta{},
+		ObjectMeta: br.getObjectMeta(br.getEtcContainersConfigMapName()),
+		Data:       data,
+	}, nil
 }
 
 // Renders our Containerfile template.
@@ -693,16 +703,6 @@ func (br buildRequestImpl) toBuildahPod() *corev1.Pod {
 			MountPath: "/tmp/containerfile",
 		},
 		{
-			Name:      "etc-policy",
-			MountPath: "/etc/containers/policy.json",
-			SubPath:   "policy.json",
-		},
-		{
-			Name:      "etc-registries",
-			MountPath: "/etc/containers/registries.conf",
-			SubPath:   "registries.conf",
-		},
-		{
 			Name:      "additional-trust-bundle",
 			MountPath: "/etc/pki/ca-trust/source/anchors",
 		},
@@ -718,6 +718,18 @@ func (br buildRequestImpl) toBuildahPod() *corev1.Pod {
 			Name:      "done",
 			MountPath: "/tmp/done",
 		},
+	}
+
+	etcContainersFiles, err := br.getEtcContainersFiles(br.opts.MachineConfig)
+	if err != nil {
+		klog.Warningf("Could not discover /etc/containers/ files from MachineConfig: %v", err)
+	}
+	for _, f := range etcContainersFiles {
+		volumeMounts = append(volumeMounts, corev1.VolumeMount{
+			Name:      "etc-containers",
+			MountPath: f.path,
+			SubPath:   f.key,
+		})
 	}
 
 	boolTrue := true
@@ -753,30 +765,6 @@ func (br buildRequestImpl) toBuildahPod() *corev1.Pod {
 					LocalObjectReference: corev1.LocalObjectReference{
 						Name: br.getAdditionalTrustBundleConfigMapName(),
 					},
-				},
-			},
-		},
-		{
-			// Provides the /etc/containers/policy.json content from the node
-			Name: "etc-policy",
-			VolumeSource: corev1.VolumeSource{
-				ConfigMap: &corev1.ConfigMapVolumeSource{
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: br.getEtcPolicyConfigMapName(),
-					},
-					Optional: &boolTrue,
-				},
-			},
-		},
-		{
-			// Provides the /etc/containers/registries.conf content from the node
-			Name: "etc-registries",
-			VolumeSource: corev1.VolumeSource{
-				ConfigMap: &corev1.ConfigMapVolumeSource{
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: br.getEtcRegistriesConfigMapName(),
-					},
-					Optional: &boolTrue,
 				},
 			},
 		},
@@ -834,6 +822,20 @@ func (br buildRequestImpl) toBuildahPod() *corev1.Pod {
 				EmptyDir: &corev1.EmptyDirVolumeSource{},
 			},
 		},
+	}
+
+	if len(etcContainersFiles) > 0 {
+		volumes = append(volumes, corev1.Volume{
+			Name: "etc-containers",
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: br.getEtcContainersConfigMapName(),
+					},
+					Optional: &boolTrue,
+				},
+			},
+		})
 	}
 
 	// If the etc-pki-entitlement secret is found, mount it into the build pod.
@@ -975,12 +977,8 @@ func (br buildRequestImpl) getMCConfigMapName() string {
 	return utils.GetMCConfigMapName(br.opts.MachineOSBuild)
 }
 
-func (br buildRequestImpl) getEtcPolicyConfigMapName() string {
-	return utils.GetEtcPolicyConfigMapName(br.opts.MachineOSBuild)
-}
-
-func (br buildRequestImpl) getEtcRegistriesConfigMapName() string {
-	return utils.GetEtcRegistriesConfigMapName(br.opts.MachineOSBuild)
+func (br buildRequestImpl) getEtcContainersConfigMapName() string {
+	return utils.GetEtcContainersConfigMapName(br.opts.MachineOSBuild)
 }
 
 // Computes the build name based upon the MachineConfigPool name.

--- a/pkg/controller/build/utils/helpers.go
+++ b/pkg/controller/build/utils/helpers.go
@@ -69,12 +69,8 @@ func GetMCConfigMapName(mosb *mcfgv1.MachineOSBuild) string {
 	return fmt.Sprintf("mc-%s", getFieldFromMachineOSBuild(mosb))
 }
 
-func GetEtcPolicyConfigMapName(mosb *mcfgv1.MachineOSBuild) string {
-	return fmt.Sprintf("etc-policy-%s", getFieldFromMachineOSBuild(mosb))
-}
-
-func GetEtcRegistriesConfigMapName(mosb *mcfgv1.MachineOSBuild) string {
-	return fmt.Sprintf("etc-registries-%s", getFieldFromMachineOSBuild(mosb))
+func GetEtcContainersConfigMapName(mosb *mcfgv1.MachineOSBuild) string {
+	return fmt.Sprintf("etc-containers-%s", getFieldFromMachineOSBuild(mosb))
 }
 
 // Computes the build job name.

--- a/test/e2e-ocl-1of2/onclusterlayering_test.go
+++ b/test/e2e-ocl-1of2/onclusterlayering_test.go
@@ -497,16 +497,14 @@ func assertBuildObjectsAreCreated(t *testing.T, kubeassert *helpers.Assertions, 
 	kubeassert.JobExists(utils.GetBuildJobName(mosb))
 	kubeassert.ConfigMapExists(utils.GetContainerfileConfigMapName(mosb))
 	kubeassert.ConfigMapExists(utils.GetMCConfigMapName(mosb))
-	kubeassert.ConfigMapExists(utils.GetEtcPolicyConfigMapName(mosb))
-	kubeassert.ConfigMapExists(utils.GetEtcRegistriesConfigMapName(mosb))
+	kubeassert.ConfigMapExists(utils.GetEtcContainersConfigMapName(mosb))
 	kubeassert.SecretExists(utils.GetBasePullSecretName(mosb))
 	kubeassert.SecretExists(utils.GetFinalPushSecretName(mosb))
 
 	// Check that ownerReferences are set as well
 	kubeassert.ConfigMapHasOwnerSet(utils.GetContainerfileConfigMapName(mosb))
 	kubeassert.ConfigMapHasOwnerSet(utils.GetMCConfigMapName(mosb))
-	kubeassert.ConfigMapHasOwnerSet(utils.GetEtcPolicyConfigMapName(mosb))
-	kubeassert.ConfigMapHasOwnerSet(utils.GetEtcRegistriesConfigMapName(mosb))
+	kubeassert.ConfigMapHasOwnerSet(utils.GetEtcContainersConfigMapName(mosb))
 	kubeassert.SecretHasOwnerSet(utils.GetBasePullSecretName(mosb))
 	kubeassert.SecretHasOwnerSet(utils.GetFinalPushSecretName(mosb))
 }
@@ -517,8 +515,7 @@ func assertBuildObjectsAreDeleted(t *testing.T, kubeassert *helpers.Assertions, 
 	kubeassert.JobDoesNotExist(utils.GetBuildJobName(mosb))
 	kubeassert.ConfigMapDoesNotExist(utils.GetContainerfileConfigMapName(mosb))
 	kubeassert.ConfigMapDoesNotExist(utils.GetMCConfigMapName(mosb))
-	kubeassert.ConfigMapDoesNotExist(utils.GetEtcPolicyConfigMapName(mosb))
-	kubeassert.ConfigMapDoesNotExist(utils.GetEtcRegistriesConfigMapName(mosb))
+	kubeassert.ConfigMapDoesNotExist(utils.GetEtcContainersConfigMapName(mosb))
 	kubeassert.SecretDoesNotExist(utils.GetBasePullSecretName(mosb))
 	kubeassert.SecretDoesNotExist(utils.GetFinalPushSecretName(mosb))
 }

--- a/test/e2e-ocl-2of2/onclusterlayering_test.go
+++ b/test/e2e-ocl-2of2/onclusterlayering_test.go
@@ -950,16 +950,14 @@ func assertBuildObjectsAreCreated(t *testing.T, kubeassert *helpers.Assertions, 
 	kubeassert.JobExists(utils.GetBuildJobName(mosb))
 	kubeassert.ConfigMapExists(utils.GetContainerfileConfigMapName(mosb))
 	kubeassert.ConfigMapExists(utils.GetMCConfigMapName(mosb))
-	kubeassert.ConfigMapExists(utils.GetEtcPolicyConfigMapName(mosb))
-	kubeassert.ConfigMapExists(utils.GetEtcRegistriesConfigMapName(mosb))
+	kubeassert.ConfigMapExists(utils.GetEtcContainersConfigMapName(mosb))
 	kubeassert.SecretExists(utils.GetBasePullSecretName(mosb))
 	kubeassert.SecretExists(utils.GetFinalPushSecretName(mosb))
 
 	// Check that ownerReferences are set as well
 	kubeassert.ConfigMapHasOwnerSet(utils.GetContainerfileConfigMapName(mosb))
 	kubeassert.ConfigMapHasOwnerSet(utils.GetMCConfigMapName(mosb))
-	kubeassert.ConfigMapHasOwnerSet(utils.GetEtcPolicyConfigMapName(mosb))
-	kubeassert.ConfigMapHasOwnerSet(utils.GetEtcRegistriesConfigMapName(mosb))
+	kubeassert.ConfigMapHasOwnerSet(utils.GetEtcContainersConfigMapName(mosb))
 	kubeassert.SecretHasOwnerSet(utils.GetBasePullSecretName(mosb))
 	kubeassert.SecretHasOwnerSet(utils.GetFinalPushSecretName(mosb))
 }
@@ -970,8 +968,7 @@ func assertBuildObjectsAreDeleted(t *testing.T, kubeassert *helpers.Assertions, 
 	kubeassert.JobDoesNotExist(utils.GetBuildJobName(mosb))
 	kubeassert.ConfigMapDoesNotExist(utils.GetContainerfileConfigMapName(mosb))
 	kubeassert.ConfigMapDoesNotExist(utils.GetMCConfigMapName(mosb))
-	kubeassert.ConfigMapDoesNotExist(utils.GetEtcPolicyConfigMapName(mosb))
-	kubeassert.ConfigMapDoesNotExist(utils.GetEtcRegistriesConfigMapName(mosb))
+	kubeassert.ConfigMapDoesNotExist(utils.GetEtcContainersConfigMapName(mosb))
 	kubeassert.SecretDoesNotExist(utils.GetBasePullSecretName(mosb))
 	kubeassert.SecretDoesNotExist(utils.GetFinalPushSecretName(mosb))
 }

--- a/test/extended-priv/mco_ocb_longduration.go
+++ b/test/extended-priv/mco_ocb_longduration.go
@@ -1,6 +1,7 @@
 package extended
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -688,11 +689,18 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/longdurati
 			moscName = mcp.GetName()
 		)
 
+		exutil.By("Enable default ClusterImagePolicy")
+		restoreCVO := enableDefaultClusterImagePolicy(oc.AsAdmin(), mcp)
+		defer restoreCVO()
+
 		exutil.By("Configure OCB functionality using external registry (Quay)")
 		mosc, err := CreateMachineOSConfigUsingExternalRegistry(oc.AsAdmin(), moscName, mcp.GetName(), nil, false, false)
 		defer DisableOCL(mosc)
 		o.Expect(err).NotTo(o.HaveOccurred(), "Error creating the MachineOSConfig resource")
 		logger.Infof("OK!\n")
+
+		exutil.By("Verify build Job mounts sigstore-registries.yaml")
+		verifyBuildJobMountsSigstoreRegistries(mosc)
 
 		ValidateNewNodesBootDirectlyWithOCLImage(oc.AsAdmin(), mosc, mcp)
 	})
@@ -804,6 +812,10 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/longdurati
 		o.Expect(err).NotTo(o.HaveOccurred(), "Error creating a new custom pool: %s", infraMcpName)
 		logger.Infof("OK!\n")
 
+		exutil.By("Enable default ClusterImagePolicy")
+		restoreCVO := enableDefaultClusterImagePolicy(oc.AsAdmin(), infraMcp)
+		defer restoreCVO()
+
 		exutil.By("Create MOSC for custom MCP using external registry")
 		moscName := infraMcp.GetName()
 		mosc, err := CreateMachineOSConfigUsingExternalRegistry(oc.AsAdmin(), moscName, infraMcp.GetName(),
@@ -811,6 +823,9 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/longdurati
 		defer DisableOCL(mosc)
 		o.Expect(err).NotTo(o.HaveOccurred(), "Error creating MOSC")
 		logger.Infof("OK!\n")
+
+		exutil.By("Verify build Job mounts sigstore-registries.yaml")
+		verifyBuildJobMountsSigstoreRegistries(mosc)
 
 		exutil.By("Validate initial MOSC and wait for MOSB-1 to succeed")
 		ValidateSuccessfulMOSC(mosc, nil)
@@ -1140,4 +1155,93 @@ func verifyMOSBRebuildAfterImageDeletion(mcp *MachineConfigPool, mosc *MachineOS
 	o.Expect(currentMosb.GetName()).To(o.Or(o.Equal(mosb1.GetName()), o.Equal(mosb2.GetName())),
 		"Current MOSB should be either MOSB-1 or MOSB-2, no new MOSB-3 should be triggered")
 	logger.Infof("OK!\n")
+}
+
+// enableDefaultClusterImagePolicy enables the default ClusterImagePolicy on nightly/CI builds
+// by removing only the ClusterImagePolicy override from the CVO, leaving other overrides intact.
+// On GA builds where the CIP already exists, this is a no-op.
+// Returns a cleanup function that restores the removed override.
+func enableDefaultClusterImagePolicy(oc *exutil.CLI, mcps ...*MachineConfigPool) func() {
+	cip := NewResource(oc, "clusterimagepolicy", "openshift")
+
+	if cip.Exists() {
+		logger.Infof("ClusterImagePolicy 'openshift' already exists, no CVO patching needed")
+		return func() {}
+	}
+
+	cv := NewResource(oc, "clusterversion", "version")
+	overridesJSON, err := cv.Get(`{.spec.overrides}`)
+	o.Expect(err).NotTo(o.HaveOccurred(), "Error getting CVO overrides")
+
+	if overridesJSON == "" || !strings.Contains(overridesJSON, "ClusterImagePolicy") {
+		logger.Infof("No ClusterImagePolicy override found in CVO, skipping")
+		return func() {}
+	}
+
+	var overrides []map[string]interface{}
+	o.Expect(json.Unmarshal([]byte(overridesJSON), &overrides)).NotTo(o.HaveOccurred(),
+		"Error parsing CVO overrides JSON")
+
+	cipIndex := -1
+	for i, override := range overrides {
+		if override["kind"] == "ClusterImagePolicy" && override["name"] == "openshift" {
+			cipIndex = i
+			break
+		}
+	}
+
+	if cipIndex == -1 {
+		logger.Infof("No ClusterImagePolicy 'openshift' override found in CVO, skipping")
+		return func() {}
+	}
+
+	logger.Infof("Removing ClusterImagePolicy override at index %d from CVO", cipIndex)
+	err = cv.Patch("json", fmt.Sprintf(`[{"op": "remove", "path": "/spec/overrides/%d"}]`, cipIndex))
+	o.Expect(err).NotTo(o.HaveOccurred(), "Error removing ClusterImagePolicy override from CVO")
+
+	o.Eventually(cip, "5m", "20s").Should(Exist(),
+		"ClusterImagePolicy 'openshift' should be created after removing CVO override")
+	logger.Infof("ClusterImagePolicy 'openshift' created successfully")
+
+	for _, mcp := range mcps {
+		logger.Infof("Waiting for MCP %s to complete after CIP update", mcp)
+		mcp.waitForComplete()
+	}
+	logger.Infof("OK!\n")
+
+	cipOverrideJSON, marshalErr := json.Marshal(overrides[cipIndex])
+	o.Expect(marshalErr).NotTo(o.HaveOccurred(), "Error marshalling CIP override for cleanup")
+
+	return func() {
+		logger.Infof("Restoring ClusterImagePolicy CVO override")
+		err := cv.Patch("json", fmt.Sprintf(`[{"op": "add", "path": "/spec/overrides/-", "value": %s}]`, string(cipOverrideJSON)))
+		if err != nil {
+			logger.Errorf("Error restoring ClusterImagePolicy CVO override: %v", err)
+		}
+	}
+}
+
+// verifyBuildJobMountsSigstoreRegistries waits for the MOSB build to start and then verifies
+// that the build Job's pod spec includes a volume mount for sigstore-registries.yaml.
+// This must be called BEFORE the build succeeds, because both the Job and its ConfigMaps
+// are cleaned up as ephemeral objects once the build transitions to Succeeded.
+func verifyBuildJobMountsSigstoreRegistries(mosc *MachineOSConfig) {
+	o.Eventually(mosc.GetCurrentMachineOSBuild, "5m", "20s").Should(Exist(),
+		"No MOSB was created for the MOSC")
+	mosb, err := mosc.GetCurrentMachineOSBuild()
+	o.Expect(err).NotTo(o.HaveOccurred(), "Error getting current MOSB")
+
+	o.Eventually(mosb, "5m", "20s").Should(HaveConditionField("Building", "status", TrueString),
+		"MachineOSBuild didn't report that the build has begun")
+
+	o.Eventually(mosb.GetJob, "2m", "20s").Should(Exist(),
+		"No build Job was created for MOSB %s", mosb.GetName())
+	job, err := mosb.GetJob()
+	o.Expect(err).NotTo(o.HaveOccurred(), "Error getting build Job for MOSB %s", mosb.GetName())
+
+	volumeMounts, err := job.Get(`{.spec.template.spec.containers[*].volumeMounts[*].mountPath}`)
+	o.Expect(err).NotTo(o.HaveOccurred(), "Error getting volume mounts from build Job")
+	o.Expect(volumeMounts).To(o.ContainSubstring("sigstore-registries.yaml"),
+		"Build Job should mount sigstore-registries.yaml when ClusterImagePolicy is active")
+	logger.Infof("OK! Build Job %s mounts sigstore-registries.yaml\n", job.GetName())
 }


### PR DESCRIPTION
Closes: [#OCPBUGS-105283](https://redhat.atlassian.net/browse/OCPBUGS-105283)

**- What I did**

This change makes sure that all the /etc/container content is pushed to a CM that the MOSB Pod mounts, instead of the previous explicit approach that only mounted specific known files.

**- How to verify it**

**- Description for the changelog**

Mount all the /etc/containers content of the rendered MC in the MOSB Pod.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Consolidated container policy, registry, and other matching configuration files into a single ConfigMap.
  * Build pods now dynamically mount discovered `/etc/containers/` configuration files when available.
* **Bug Fixes**
  * Improved handling of missing, invalid, and non-UTF-8 configuration files during builds.
  * Sanitized configuration keys and detected naming conflicts.
  * Ensured consolidated configuration is correctly created, mounted, owned, and removed with the build.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->