### PR TITLE
[release-5.0] CORS-4441: Bootimage controller should gracefully handle Azure gen1 image removal

### DIFF
--- a/pkg/controller/bootimage/boot_image_controller_test.go
+++ b/pkg/controller/bootimage/boot_image_controller_test.go
@@ -14,6 +14,7 @@ import (
 	opv1 "github.com/openshift/api/operator/v1"
 	configlistersv1 "github.com/openshift/client-go/config/listers/config/v1"
 	fakemcopclient "github.com/openshift/client-go/operator/clientset/versioned/fake"
+	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -25,7 +26,6 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
-	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
 )
 
 func TestIsClusterStable(t *testing.T) {
@@ -546,14 +546,14 @@ func TestReconcileAzureProviderSpec(t *testing.T) {
 	fakeClient := fake.NewClientset(testSecret)
 
 	tests := []struct {
-		name            string
-		arch            string
-		currentImage    machinev1beta1.Image
-		expectedImage   machinev1beta1.Image
-		expectPatch     bool
-		expectSkip      bool
-		streamData      *stream.Stream                  // Custom stream data for specific tests
-		securityProfile *machinev1beta1.SecurityProfile // Custom security profile for specific tests
+		name                   string
+		arch                   string
+		currentImage           machinev1beta1.Image
+		expectedImage          machinev1beta1.Image
+		expectPatch            bool
+		expectReconcileSkipped bool
+		streamData             *stream.Stream                  // Custom stream data for specific tests
+		securityProfile        *machinev1beta1.SecurityProfile // Custom security profile for specific tests
 	}{
 		{
 			name: "Legacy Gen1 upload image transitions to marketplace Gen1",
@@ -682,7 +682,6 @@ func TestReconcileAzureProviderSpec(t *testing.T) {
 				Version:    "419.94.20250101",
 				Type:       machinev1beta1.AzureImageTypeMarketplaceNoPlan,
 			},
-			expectSkip: true,
 		},
 		{
 			name: "Skip unsupported architecture s390x",
@@ -695,7 +694,6 @@ func TestReconcileAzureProviderSpec(t *testing.T) {
 				Version:    "419.94.20250101",
 				Type:       machinev1beta1.AzureImageTypeMarketplaceNoPlan,
 			},
-			expectSkip: true,
 		},
 		{
 			name: "Paid OCP Gen1 image updates to newer version",
@@ -813,7 +811,7 @@ func TestReconcileAzureProviderSpec(t *testing.T) {
 				Version:    "419.94.20250101",
 				Type:       machinev1beta1.AzureImageTypeMarketplaceNoPlan,
 			},
-			expectSkip: true,
+			expectReconcileSkipped: true,
 			streamData: &stream.Stream{
 				Architectures: map[string]stream.Arch{
 					"x86_64": {
@@ -835,13 +833,91 @@ func TestReconcileAzureProviderSpec(t *testing.T) {
 				Version:    "419.94.20250101",
 				Type:       machinev1beta1.AzureImageTypeMarketplaceNoPlan,
 			},
-			expectSkip: true,
+			expectReconcileSkipped: true,
 			streamData: &stream.Stream{
 				Architectures: map[string]stream.Arch{
 					"x86_64": {
 						RHELCoreOSExtensions: &rhcos.Extensions{
 							Marketplace: &rhcos.Marketplace{
 								Azure: nil, // Azure marketplace is nil
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Skip when Gen1 Azure marketplace image is unavailable (Gen1 removal)",
+			arch: "x86_64",
+			currentImage: machinev1beta1.Image{
+				Offer:      "aro4",
+				Publisher:  "azureopenshift",
+				ResourceID: "",
+				SKU:        "aro_418",
+				Version:    "418.94.20241201",
+				Type:       machinev1beta1.AzureImageTypeMarketplaceNoPlan,
+			},
+			expectReconcileSkipped: true,
+			streamData: &stream.Stream{
+				Architectures: map[string]stream.Arch{
+					"x86_64": {
+						RHELCoreOSExtensions: &rhcos.Extensions{
+							Marketplace: &rhcos.Marketplace{
+								Azure: &rhcos.AzureMarketplace{
+									NoPurchasePlan: &rhcos.AzureMarketplaceImages{
+										// Gen1 intentionally omitted, mirroring the stream once
+										// Gen1 Azure images are removed upstream (CORS-4441).
+										Gen2: &rhcos.AzureMarketplaceImage{
+											Offer:     "aro4",
+											Publisher: "azureopenshift",
+											SKU:       "aro_50-x64",
+											Version:   "50.0.20260601",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Post-Gen1-removal Gen2 SKU ('gen2' suffix) still updates",
+			arch: "x86_64",
+			currentImage: machinev1beta1.Image{
+				Offer:      "aro4",
+				Publisher:  "azureopenshift",
+				ResourceID: "",
+				SKU:        "aro_5-0_x86_gen2",
+				Version:    "50.0.20260601",
+				Type:       machinev1beta1.AzureImageTypeMarketplaceNoPlan,
+			},
+			expectedImage: machinev1beta1.Image{
+				Offer:      "aro4",
+				Publisher:  "azureopenshift",
+				ResourceID: "",
+				SKU:        "aro_5-0_x86_gen2",
+				Version:    "50.0.20260701",
+				Type:       machinev1beta1.AzureImageTypeMarketplaceNoPlan,
+			},
+			expectPatch: true,
+			streamData: &stream.Stream{
+				Architectures: map[string]stream.Arch{
+					"x86_64": {
+						RHELCoreOSExtensions: &rhcos.Extensions{
+							Marketplace: &rhcos.Marketplace{
+								Azure: &rhcos.AzureMarketplace{
+									NoPurchasePlan: &rhcos.AzureMarketplaceImages{
+										// Gen1 intentionally omitted, mirroring the stream once
+										// Gen1 Azure images are removed upstream (CORS-4441).
+										Gen2: &rhcos.AzureMarketplaceImage{
+											Offer:     "aro4",
+											Publisher: "azureopenshift",
+											SKU:       "aro_5-0_x86_gen2",
+											Version:   "50.0.20260701",
+										},
+									},
+								},
 							},
 						},
 					},
@@ -859,7 +935,7 @@ func TestReconcileAzureProviderSpec(t *testing.T) {
 				Version:    "419.94.20250101",
 				Type:       machinev1beta1.AzureImageTypeMarketplaceNoPlan,
 			},
-			expectSkip: true,
+			expectReconcileSkipped: true,
 			securityProfile: &machinev1beta1.SecurityProfile{
 				Settings: machinev1beta1.SecuritySettings{
 					SecurityType: "ConfidentialVM",
@@ -877,7 +953,7 @@ func TestReconcileAzureProviderSpec(t *testing.T) {
 				Version:    "419.94.20250101",
 				Type:       machinev1beta1.AzureImageTypeMarketplaceNoPlan,
 			},
-			expectSkip: true,
+			expectReconcileSkipped: true,
 			securityProfile: &machinev1beta1.SecurityProfile{
 				Settings: machinev1beta1.SecuritySettings{
 					SecurityType: "TrustedLaunch",
@@ -954,7 +1030,7 @@ func TestReconcileAzureProviderSpec(t *testing.T) {
 				testStreamData = tt.streamData
 			}
 
-			patchRequired, _, updatedProviderSpec, _, err := reconcileAzureProviderSpec(
+			patchRequired, reconcileSkipped, updatedProviderSpec, _, err := reconcileAzureProviderSpec(
 				testStreamData,
 				tt.arch,
 				infra,
@@ -965,11 +1041,7 @@ func TestReconcileAzureProviderSpec(t *testing.T) {
 
 			require.NoError(t, err)
 
-			if tt.expectSkip {
-				assert.False(t, patchRequired, "Expected no patch for skipped case")
-				return
-			}
-
+			assert.Equal(t, tt.expectReconcileSkipped, reconcileSkipped, "Reconcile skipped mismatch")
 			assert.Equal(t, tt.expectPatch, patchRequired, "Patch required mismatch")
 
 			if tt.expectPatch {

--- a/pkg/controller/bootimage/platform_helpers.go
+++ b/pkg/controller/bootimage/platform_helpers.go
@@ -326,7 +326,8 @@ func reconcileAzureProviderSpec(streamData *stream.Stream, arch string, _ *oscon
 	// Uploaded images(legacy) have a "gen2" in the resourceID field to indicate hyperGenV2
 	//
 	// Unpaid marketplace images:
-	// - have a "v2" in the SKU field to indicate hyperGenV2
+	// - have a "v2" in the SKU field to indicate hyperGenV2 (e.g. "aro_422-v2")
+	// - have a "gen2" in the SKU field to indicate hyperGenV2 (5.0+, e.g. "aro_5-0_x86_gen2")
 	// - aarch64 machinesets can only use hyperGenV2 images
 	//
 	// Paid marketplace images(MCO-1790):
@@ -337,15 +338,19 @@ func reconcileAzureProviderSpec(streamData *stream.Stream, arch string, _ *oscon
 	case usesLegacyImageUpload:
 		usesHyperVGen2 = strings.Contains(currentImage.ResourceID, "gen2")
 	case providerSpec.Image.Type == machinev1beta1.AzureImageTypeMarketplaceNoPlan:
-		usesHyperVGen2 = strings.Contains(currentImage.SKU, "v2") || arch == "aarch64"
+		usesHyperVGen2 = strings.Contains(currentImage.SKU, "v2") || strings.Contains(currentImage.SKU, "gen2") || arch == "aarch64"
 	default:
 		usesHyperVGen2 = !strings.Contains(currentImage.SKU, "gen1")
 	}
 
 	// Determine target image from RHCOS stream
-	targetImage, err := getTargetImageFromStream(streamArch, azureVariant, usesHyperVGen2, arch)
+	targetImage, reconcileSkipped, err := getTargetImageFromStream(streamArch, azureVariant, usesHyperVGen2, arch)
 	if err != nil {
 		return false, false, nil, "", err
+	}
+	if reconcileSkipped {
+		klog.Infof("Skipping machineset %s, no Gen1 Azure marketplace image available for architecture %s", machineSetName, arch)
+		return false, true, nil, "", nil
 	}
 
 	// If the current image matches, nothing to do here
@@ -415,8 +420,11 @@ func determineAzureVariant(usesLegacyImageUpload bool, currentImage machinev1bet
 	return "", fmt.Errorf("could not determine azure marketplace variant, cannot update boot images")
 }
 
-// getTargetImageFromStream determines the correct Azure marketplace image based on architecture and variant
-func getTargetImageFromStream(streamArch *stream.Arch, variant AzureVariant, usesHyperVGen2 bool, arch string) (machinev1beta1.Image, error) {
+// getTargetImageFromStream determines the correct Azure marketplace image based on architecture and variant.
+// Returns reconcileSkipped=true (with no error) when a Gen1 image is requested but the stream no longer
+// publishes one, e.g. once Gen1 Azure images are removed upstream (see CORS-4441): the boot image update is
+// skipped for this MachineSet rather than treated as an error, so skew enforcement can flag it as out of date.
+func getTargetImageFromStream(streamArch *stream.Arch, variant AzureVariant, usesHyperVGen2 bool, arch string) (machinev1beta1.Image, bool, error) {
 	marketplace := streamArch.RHELCoreOSExtensions.Marketplace.Azure
 
 	var imageSet *rhcos.AzureMarketplaceImages
@@ -438,11 +446,11 @@ func getTargetImageFromStream(streamArch *stream.Arch, variant AzureVariant, use
 	case AzureVariantOKEEMEA:
 		imageSet = marketplace.OKEEMEA
 	default:
-		return machinev1beta1.Image{}, fmt.Errorf("unsupported Azure variant")
+		return machinev1beta1.Image{}, false, fmt.Errorf("unsupported Azure variant")
 	}
 
 	if imageSet == nil {
-		return machinev1beta1.Image{}, fmt.Errorf("no Azure marketplace images available for variant %s", variant)
+		return machinev1beta1.Image{}, false, fmt.Errorf("no Azure marketplace images available for variant %s", variant)
 	}
 
 	var streamImage *rhcos.AzureMarketplaceImage
@@ -450,12 +458,12 @@ func getTargetImageFromStream(streamArch *stream.Arch, variant AzureVariant, use
 	// arm64 only uses hyperGenV2
 	if usesHyperVGen2 {
 		if imageSet.Gen2 == nil {
-			return machinev1beta1.Image{}, fmt.Errorf("no Gen2 Azure marketplace image available for architecture %s", arch)
+			return machinev1beta1.Image{}, false, fmt.Errorf("no Gen2 Azure marketplace image available for architecture %s", arch)
 		}
 		streamImage = imageSet.Gen2
 	} else {
 		if imageSet.Gen1 == nil {
-			return machinev1beta1.Image{}, fmt.Errorf("no Gen1 Azure marketplace image available for architecture %s", arch)
+			return machinev1beta1.Image{}, true, nil
 		}
 		streamImage = imageSet.Gen1
 	}
@@ -464,5 +472,5 @@ func getTargetImageFromStream(streamArch *stream.Arch, variant AzureVariant, use
 	// Convert stream image to Azure machine image
 	targetImage := getAzureImageFromStreamImage(*streamImage, isPaidImage)
 
-	return targetImage, nil
+	return targetImage, false, nil
 }


### PR DESCRIPTION
Backport of https://github.com/openshift/machine-config-operator/pull/6404/changes/e308231cc50715755cdbcf716a26a301619c6532 into 5.0; should help with failures that caused https://redhat.atlassian.net/browse/TRT-2925
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
