### PR TITLE
OCPBUGS-109659: Check conddegraded nil before dereference in TestCalculateStatus

### DIFF
--- a/pkg/controller/node/status_test.go
+++ b/pkg/controller/node/status_test.go
@@ -410,7 +410,7 @@ func TestCalculateStatus(t *testing.T) {
 			}
 
 			conddegraded := apihelpers.GetMachineConfigPoolCondition(status, mcfgv1.MachineConfigPoolDegraded)
-			if condupdating == nil {
+			if conddegraded == nil {
 				t.Fatal("degraded condition not found")
 			}
 


### PR DESCRIPTION
Closes: [OCPBUGS-109659](https://redhat.atlassian.net/browse/OCPBUGS-109659)

**- What I did**
Fixed a copy-paste error in `TestCalculateStatus` so the degraded-condition nil guard checks `conddegraded` instead of `condupdating`. If the degraded condition is missing, the test now fails with `"degraded condition not found"` instead of panicking on `conddegraded.Status`.

**- How to verify it**
```
go test ./pkg/controller/node/ -run TestCalculateStatus
```

**- Description for the changelog**
Fix TestCalculateStatus nil check so a missing degraded condition fails cleanly instead of panicking.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected a test assertion for node status calculations to properly validate the absence of a degraded condition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->