### PR TITLE
OCPBUGS-115123: Replace wildcard permissions with explicit verbs in MachineConfigServer ClusterRole

### DIFF
--- a/manifests/machineconfigserver/clusterrole.yaml
+++ b/manifests/machineconfigserver/clusterrole.yaml
@@ -5,7 +5,7 @@ metadata:
 rules:
 - apiGroups: ["machineconfiguration.openshift.io"]
   resources: ["machineconfigs", "machineconfigpools"]
-  verbs: ["*"]
+  verbs: ["get", "list", "watch"]
 - apiGroups: ["machineconfiguration.openshift.io"]
   resources: ["controllerconfigs"]
   verbs: ["get", "watch", "list"]


### PR DESCRIPTION
Closes: OCPBUGS-115123

**- What I did**
This replaces the wildcard verb in the MachineConfigServer for the MachineConfig and MachineConfigPool resources explicitly to the necessary verbs.

**- How to verify it**
No functionality should be impacted, so CI tests should continue running as expected.

**- Description for the changelog**
OCPBUGS-115123: Replace wildcard permissions with explicit verbs in MachineConfigServer ClusterRole

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Improvements**
  * Restricted machine configuration access to read-only operations: get, list, and watch.
  * Prevented unrestricted modification of machine configurations and machine configuration pools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->