### PR TITLE
OCPBUGS-114737: updateLayeredOS deploy-from-self when skopeo < 1.22.2

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -2872,8 +2872,10 @@ func (dn *Daemon) updateLayeredOS(config *mcfgv1.MachineConfig) error {
 	}
 	// If the host isn't new enough to understand the new container model natively, run as a privileged container.
 	// See https://github.com/coreos/rpm-ostree/pull/3961 and https://issues.redhat.com/browse/MCO-356
-	if !newEnough {
-		logSystem("rpm-ostree is not new enough for layering; forcing an update via container")
+	// If skopeo is < 1.22.2 on a multi-arch image, run as a privileged container which has updated skopeo.
+	// See https://redhat.atlassian.net/browse/OCPBUGS-83826 and https://redhat.atlassian.net/browse/OCPBUGS-81187
+	if !newEnough || !skopeoSupportsMultiArchSigstore(newURL) {
+		logSystem("rpm-ostree or skopeo is not new enough for layering; forcing an update via container")
 		return dn.InplaceUpdateViaNewContainer(newURL)
 	}
 


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

Fix 
- [OCPBUGS-114737 4.21.16 → 4.22.8 worker OS pivot fails: rpm-ostree rebase "A signature was required, but no signature exists" on older boot images (standalone cluster)](https://redhat.atlassian.net/browse/OCPBUGS-114737)

**- What I did**
Skopeo versions < 1.22.2 have a known issue with multi-arch images (https://redhat.atlassian.net/browse/OCPBUGS-83826)
This PR updates `updateLayeredOS` using deploy-from-self to avoid that issue during cluster upgrades (rpm-ostree uses a background skopeo proxy process).

OCP 4.21 rhel 9.6 --> skopeo 1.18.1
OCP 4.21 rhel 10.2 --> skopeo 1.22.0

The skopeo multi-arch sigstore verification fix (OCPBUGS-83826) was only
wired into the firstboot path (RunFirstbootCompleteMachineconfig), so the
in-place upgrade path was left unprotected. skopeo < 1.22.2 fails to verify
sigstore signatures on multi-arch images, so an oc adm upgrade could still
fail when the host skopeo is too old.

See https://redhat.atlassian.net/browse/OCPBUGS-83826 and
https://redhat.atlassian.net/browse/OCPBUGS-81187

**- How to verify it**

While I cannot reproduce the issue, the sosreport `Running: rpm-ostree rebase --experimental` executed without a skopeo version check that confirms the gap needs to be fixed:

```
2026-09-01T17:53:31.774862982+00:00 stderr F I0901 17:53:31.774850 3043584 command_runner.go:24] Running captured: mokutil --sb-state
2026-09-01T17:53:31.783085208+00:00 stderr F I0901 17:53:31.783069 3043584 update.go:3165] "runBootloaderUpdate: Secure Boot not enabled, bootloader update not required"
2026-09-01T17:53:31.784891330+00:00 stderr F I0901 17:53:31.784854 3043584 command_runner.go:24] Running captured: rpm-ostree --version
2026-09-01T17:53:31.803858391+00:00 stderr F I0901 17:53:31.803838 3043584 image_manager_helper.go:126] Linking rpm-ostree authfile to /etc/mco/internal-registry-pull-secret.json
2026-09-01T17:53:31.803880691+00:00 stderr F I0901 17:53:31.803871 3043584 rpm-ostree.go:201] Executing rebase to quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:3b414c9764ada1667b5b1098ddcf60cf4787c1108838c761d76bf2757c1b54fb
2026-09-01T17:53:31.803880691+00:00 stderr F I0901 17:53:31.803877 3043584 update.go:3048] Running: rpm-ostree rebase --experimental ostree-unverified-registry:quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:3b414c9764ada1667b5b1098ddcf60cf4787c1108838c761d76bf2757c1b54fb
2026-09-01T17:53:31.837049552+00:00 stdout F Pulling manifest: ostree-unverified-registry:quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:3b414c9764ada1667b5b1098ddcf60cf4787c1108838c761d76bf2757c1b54fb
2026-09-01T17:53:32.479234596+00:00 stderr F W0901 17:53:32.479201 3043584 update.go:2972] Failed to update OS to quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:3b414c9764ada1667b5b1098ddcf60cf4787c1108838c761d76bf2757c1b54fb (will retry): error running rpm-ostree rebase --experimental ostree-unverified-registry:quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:3b414c9764ada1667b5b1098ddcf60cf4787c1108838c761d76bf2757c1b54fb: error: Creating importer: failed to invoke method OpenImage: failed to invoke method OpenImage: A signature was required, but no signature exists
2026-09-01T17:53:32.479234596+00:00 stderr F : exit status 1

```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved layered OS updates by using a safer update path when multi-architecture Sigstore images cannot be handled reliably.
  * Preserved compatibility with systems that lack native container update support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->