### PR TITLE
[release-4.22] OCPBUGS-115401: Update message for MachineOSBuildFailed condition

### DIFF
--- a/pkg/controller/build/imagebuilder/jobimagebuilder.go
+++ b/pkg/controller/build/imagebuilder/jobimagebuilder.go
@@ -326,6 +326,34 @@ func (j *jobImageBuilder) validateBuilderType(builder buildrequest.Builder) erro
 	return fmt.Errorf("invalid type %T from builder, expected %T", j.builder, &batchv1.Job{})
 }
 
+// buildFailedConditionsFromJob returns MachineOSBuild failed conditions populated with the
+// failure reason and message from the job's Failed condition, falling back to generic values.
+func buildFailedConditionsFromJob(job *batchv1.Job) []metav1.Condition {
+	reason := "Failed"
+	message := "Build Failed"
+	for _, cond := range job.Status.Conditions {
+		if cond.Type == batchv1.JobFailed && cond.Status == corev1.ConditionTrue {
+			if cond.Reason != "" {
+				reason = cond.Reason
+			}
+			if cond.Message != "" {
+				message = cond.Message
+			}
+			break
+		}
+	}
+	message = fmt.Sprintf("Job %q failed after %d attempt(s): %s", job.Name, job.Status.Failed, message)
+	conditions := apihelpers.MachineOSBuildFailedConditions()
+	for i := range conditions {
+		if conditions[i].Type == string(mcfgv1.MachineOSBuildFailed) {
+			conditions[i].Reason = reason
+			conditions[i].Message = message
+			break
+		}
+	}
+	return conditions
+}
+
 // Maps a given batchv1.Job to a given MachineOSBuild status. Exported so that it can be used in e2e tests.
 func MapJobStatusToBuildStatus(job *batchv1.Job) (mcfgv1.BuildProgress, []metav1.Condition) {
 	// If the job is being deleted and it was not in either a successful or failed state
@@ -356,7 +384,7 @@ func MapJobStatusToBuildStatus(job *batchv1.Job) (mcfgv1.BuildProgress, []metav1
 				return mcfgv1.MachineOSBuildSucceeded, apihelpers.MachineOSBuildSucceededConditions()
 			}
 			if condition.Type == batchv1.JobFailed && condition.Status == corev1.ConditionTrue {
-				return mcfgv1.MachineOSBuildFailed, apihelpers.MachineOSBuildFailedConditions()
+				return mcfgv1.MachineOSBuildFailed, buildFailedConditionsFromJob(job)
 			}
 		}
 		// If we have succeeded pods but no completion condition, we're still building
@@ -365,7 +393,7 @@ func MapJobStatusToBuildStatus(job *batchv1.Job) (mcfgv1.BuildProgress, []metav1
 
 	// Only return failed if there have been 4 pod failures as the backoffLimit is set to 3
 	if job.Status.Failed > constants.JobMaxRetries {
-		return mcfgv1.MachineOSBuildFailed, apihelpers.MachineOSBuildFailedConditions()
+		return mcfgv1.MachineOSBuildFailed, buildFailedConditionsFromJob(job)
 	}
 
 	return "", apihelpers.MachineOSBuildInitialConditions()


### PR DESCRIPTION
Closes: OCPBUGS-115401

**- What I did**
This is a manual backport for https://github.com/openshift/machine-config-operator/pull/6463. OCL events were added in 5.0 as part of https://github.com/openshift/machine-config-operator/pull/6252, so event fixes are not necessary for 4.22. However, on MOSB failures, the message was always being set as `Build Failed`, so this updates the message to be clearer.

**- How to verify it**
1. Launch a 4.22 cluster with this PR included.
2. Enable OCL in a pool with a MachineOSConfig that will cause a MachineOSBuild failure. I do this by setting `docker-password` to an invalid value in the following flow.
```
$ oc create secret docker-registry quay-push-secret \
    -n openshift-machine-config-operator \
    --docker-server=quay.io \
    --docker-username=<>
    --docker-password=<>
$ oc create -f - << EOF
apiVersion: machineconfiguration.openshift.io/v1
kind: MachineConfigPool
metadata:
 name: layered
spec:
 machineConfigSelector:
  matchExpressions:
   - {key: machineconfiguration.openshift.io/role, operator: In, values: [worker,layered]}
 nodeSelector:
  matchLabels:
   node-role.kubernetes.io/layered: ""
EOF
$ oc label node <node> node-role.kubernetes.io/layered=
$ oc apply -f - << EOF
apiVersion: machineconfiguration.openshift.io/v1
kind: MachineOSConfig
metadata:
  name: layered
spec:
  machineConfigPool:
    name: layered
  containerFile:
  - containerfileArch: NoArch
    content: |-
      FROM configs AS final
      RUN dnf install -y nmap && \
        dnf clean all && \
        bootc container lint
  imageBuilder:
    imageBuilderType: Job
  renderedImagePushSecret:
    name: quay-push-secret
  renderedImagePushSpec: "quay.io/<repo-path>:ocl-testing"
EOF
```
3. Once the MachineOSBuild fails, check that the `Message` field for the `Failed` condition is being set to a clear value.

**- Description for the changelog**
OCPBUGS-115401: Update message for MachineOSBuildFailed condition