### PR TITLE
OCPBUGS-109657: Assert errors in TestGetPrimaryPoolForNode

### DIFF
--- a/pkg/controller/node/node_controller_test.go
+++ b/pkg/controller/node/node_controller_test.go
@@ -422,11 +422,13 @@ func TestGetPrimaryPoolForNode(t *testing.T) {
 			expected: nil,
 			err:      true,
 		}, {
+			// Two custom pools share the same node selector; the node must match
+			// that selector so getPrimaryPoolForNode returns an error.
 			pools: []*mcfgv1.MachineConfigPool{
 				helpers.NewMachineConfigPool("test-cluster-pool-1", nil, helpers.MasterSelector, machineConfigV0),
 				helpers.NewMachineConfigPool("test-cluster-pool-2", nil, helpers.MasterSelector, machineConfigV0),
 			},
-			nodeLabel: map[string]string{"node-role": "master"},
+			nodeLabel: map[string]string{"node-role/master": ""},
 
 			expected: nil,
 			err:      true,
@@ -460,8 +462,10 @@ func TestGetPrimaryPoolForNode(t *testing.T) {
 			c := f.newController()
 
 			got, err := c.getPrimaryPoolForNode(node)
-			if err != nil && !test.err {
-				t.Fatal("expected non-nil error")
+			if test.err {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
 			}
 
 			if got != nil {


### PR DESCRIPTION
Fixes: https://redhat.atlassian.net/browse/OCPBUGS-109657

**- What I did**

`TestGetPrimaryPoolForNode` only failed on unexpected errors. Cases with `err: true` could still pass when `getPrimaryPoolForNode` returned `(nil, nil)`, so they did not protect the ambiguous-pool error path.

The test loop now asserts an error when `test.err` is true and no error otherwise. The duplicate-selector fixture used `node-role: master`, which does not match `node-role/master`, so it never hit that error path. The node labels now match the shared selector so both custom pools apply.

**- How to verify it**

```
go test ./pkg/controller/node/ -run TestGetPrimaryPoolForNode
```

**- Description for the changelog**
Assert errors in TestGetPrimaryPoolForNode so ambiguous-pool cases cannot pass on a nil error.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved coverage for node pool selection when multiple custom pools share the master selector.
  * Strengthened test assertions to verify both expected errors and successful outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->