### PR TITLE
OCPBUGS-116490: remove nft chains before checking the ignition config

### DIFF
--- a/test/extended-priv/machineconfigpool.go
+++ b/test/extended-priv/machineconfigpool.go
@@ -400,6 +400,13 @@ func (mcp *MachineConfigPool) GetMCSIgnitionConfig(secure bool, ignitionVersion 
 		return "", err
 	}
 
+	logger.Infof("Flush nftables rules that block the ignition config")
+	savedNftRules, err := master.FlushNftablesMCSBlockingRules()
+	defer master.RestoreNftablesMCSBlockingRules(savedNftRules)
+	if err != nil {
+		return "", err
+	}
+
 	cmd := []string{"curl", "-s"}
 	if secure {
 		cmd = append(cmd, "-k")

--- a/test/extended-priv/mco_security.go
+++ b/test/extended-priv/mco_security.go
@@ -770,6 +770,11 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/longdurati
 		removed6Rules, err := node.RemoveIP6TablesRulesByRegexp(fmt.Sprintf("%d", port))
 		o.Expect(err).NotTo(o.HaveOccurred(), "Error removing the IPv6 iptables rules for port %s in node %s", port, node.GetName())
 		defer node.ExecIP6Tables(removed6Rules)
+
+		logger.Infof("Flush nftables rules that block the ignition config")
+		savedNftRules, err := node.FlushNftablesMCSBlockingRules()
+		o.Expect(err).NotTo(o.HaveOccurred(), "Error flushing nftables mcs-blocking rules in node %s", node.GetName())
+		defer node.RestoreNftablesMCSBlockingRules(savedNftRules)
 		logger.Infof("OK!\n")
 
 		internalAPIServerURI, err := GetAPIServerInternalURI(mcp.oc)

--- a/test/extended-priv/mco_storage.go
+++ b/test/extended-priv/mco_storage.go
@@ -31,6 +31,12 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/longdurati
 
 		exutil.By("get one master node to do mc query")
 		masterNode := NewNodeList(oc.AsAdmin()).GetAllMasterNodesOrFail()[0]
+
+		logger.Infof("Flush nftables rules that block the ignition config")
+		savedNftRules, nftErr := masterNode.FlushNftablesMCSBlockingRules()
+		o.Expect(nftErr).NotTo(o.HaveOccurred(), "Error flushing nftables mcs-blocking rules in node %s", masterNode.GetName())
+		defer masterNode.RestoreNftablesMCSBlockingRules(savedNftRules)
+
 		stdout, err := masterNode.DebugNode("curl", "-w", "'Total: %{time_total}'", "-k", "-s", "-o", "/dev/null", "https://localhost:22623/config/worker")
 		o.Expect(err).NotTo(o.HaveOccurred())
 

--- a/test/extended-priv/node.go
+++ b/test/extended-priv/node.go
@@ -1196,6 +1196,43 @@ func (n *Node) ExecIP6Tables(rules []string) error {
 	return n.execIPTables(true, rules)
 }
 
+// FlushNftablesMCSBlockingRules saves and then flushes the mcs-blocking chain in the inet ovn-kubernetes nftables table.
+// Returns the original rules so they can be restored later with RestoreNftablesMCSBlockingRules.
+func (n *Node) FlushNftablesMCSBlockingRules() (string, error) {
+	savedRules, stderr, err := n.DebugNodeWithChrootStd("nft", "list", "chain", "inet", "ovn-kubernetes", "mcs-blocking")
+	if err != nil {
+		logger.Warnf("nft mcs-blocking chain not found (nftables may not be in use). Stderr: %s", stderr)
+		return "", nil
+	}
+
+	logger.Infof("%s. Flushing nftables mcs-blocking chain", n.GetName())
+	output, flushErr := n.DebugNodeWithChroot("nft", "flush", "chain", "inet", "ovn-kubernetes", "mcs-blocking")
+	if flushErr != nil {
+		logger.Errorf("Output: %s", output)
+		return savedRules, flushErr
+	}
+
+	return savedRules, nil
+}
+
+// RestoreNftablesMCSBlockingRules restores the mcs-blocking chain rules that were saved by FlushNftablesMCSBlockingRules.
+// Using echo piped to `nft -f -` is the simplest approach. If we find problems with echo (e.g. special characters
+// in the rules), we can use the RemoteFile.Create approach to write the rules to a file on the node and then
+// run `nft -f <file>` instead.
+func (n *Node) RestoreNftablesMCSBlockingRules(savedRules string) error {
+	if savedRules == "" {
+		return nil
+	}
+
+	logger.Infof("%s. Restoring nftables mcs-blocking chain rules", n.GetName())
+	output, err := n.DebugNodeWithChroot("bash", "-c",
+		fmt.Sprintf("echo '%s' | nft -f -", savedRules))
+	if err != nil {
+		logger.Errorf("Output: %s", output)
+	}
+	return err
+}
+
 // GetArchitecture get the architecture used in the node
 func (n *Node) GetArchitecture() (architecture.Architecture, error) {
 	arch, err := n.Get(`{.status.nodeInfo.architecture}`)


### PR DESCRIPTION
**- What I did**
Remove the nft chain blocking the access to the ports 22623 and 22624 before getting the ignition config served by the MCS.


**- How to verify it**

Test PolarionID:85749 should pass.
Test PolarionID:42520 should pass.
Test PolarionID:76587 should pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved extended validation for retrieving ignition configurations when network firewall rules may block access.
  * Added coverage for scenarios involving nftables-based firewall rules.
  * Firewall rules are preserved and restored safely during test execution.
  * Test environments without the relevant firewall configuration are handled gracefully.
  * Failures while clearing blocking rules are now reported explicitly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->