### PR TITLE
[release-4.22] OCPBUGS-120671: Skip vsphere fd-unmatched machinesets for bootimage updates

### DIFF
--- a/pkg/controller/bootimage/platform_helpers.go
+++ b/pkg/controller/bootimage/platform_helpers.go
@@ -107,8 +107,12 @@ func reconcilePlatform[T any](
 	return patchRequired, false, newMachineSet, nil
 }
 
-// reconcileGCPProviderSpec reconciles the GCP provider spec by updating boot images
-// Returns whether a patch is required, the updated provider spec, and any error
+// reconcileGCPProviderSpec reconciles the GCP provider spec by updating boot images.
+// Returns:
+//   - patchRequired: true when the MachineSet's providerSpec.Disks[].Image must be updated
+//   - reconcileSkipped: true when the current image is custom/unrecognised and cannot be managed automatically; see reconcilePlatform
+//   - newProviderSpec: updated copy of providerSpec; nil when patchRequired=false
+//   - err: non-nil for stream or ignition errors that should degrade the CO
 func reconcileGCPProviderSpec(streamData *stream.Stream, arch string, _ *osconfigv1.Infrastructure, providerSpec *machinev1beta1.GCPMachineProviderSpec, machineSetName string, secretClient clientset.Interface) (bool, bool, *machinev1beta1.GCPMachineProviderSpec, error) {
 
 	// Construct the new target bootimage from the configmap
@@ -150,8 +154,12 @@ func reconcileGCPProviderSpec(streamData *stream.Stream, arch string, _ *osconfi
 	return patchRequired, false, newProviderSpec, nil
 }
 
-// reconcileAWSProviderSpec reconciles the AWS provider spec by updating AMIs
-// Returns whether a patch is required, the updated provider spec, and any error
+// reconcileAWSProviderSpec reconciles the AWS provider spec by updating AMIs.
+// Returns:
+//   - patchRequired: true when the MachineSet's AMI.ID must be updated
+//   - reconcileSkipped: true when the current AMI is unrecognised or the region image is unavailable; see reconcilePlatform
+//   - newProviderSpec: updated copy of providerSpec; nil when patchRequired=false
+//   - err: non-nil for AWS API or ignition errors that should degrade the CO
 func reconcileAWSProviderSpec(streamData *stream.Stream, arch string, _ *osconfigv1.Infrastructure, providerSpec *machinev1beta1.AWSMachineProviderConfig, machineSetName string, secretClient clientset.Interface) (bool, bool, *machinev1beta1.AWSMachineProviderConfig, error) {
 
 	// Extract the region from the Placement field
@@ -208,6 +216,12 @@ func reconcileAWSProviderSpec(streamData *stream.Stream, arch string, _ *osconfi
 	return true, false, newProviderSpec, nil
 }
 
+// reconcileVSphereProviderSpec reconciles the vSphere provider spec by finding or creating the RHCOS template VM.
+// Returns:
+//   - patchRequired: true when the MachineSet's providerSpec.Template must be updated to the resolved template name
+//   - reconcileSkipped: true when the workspace does not match any failure domain and cannot be managed automatically; see reconcilePlatform
+//   - newProviderSpec: updated copy of providerSpec; nil when patchRequired=false or reconcileSkipped=true
+//   - err: non-nil for vSphere API, credential, or ignition errors that should degrade the CO
 func reconcileVSphereProviderSpec(streamData *stream.Stream, arch string, infra *osconfigv1.Infrastructure, providerSpec *machinev1beta1.VSphereMachineProviderSpec, _ string, kubeClient clientset.Interface) (bool, bool, *machinev1beta1.VSphereMachineProviderSpec, error) {
 
 	if infra.Spec.PlatformSpec.VSphere == nil {
@@ -233,9 +247,12 @@ func reconcileVSphereProviderSpec(streamData *stream.Stream, arch string, infra 
 		return false, false, nil, fmt.Errorf("failed to fetch vsphere-creds Secret during machineset sync: %w", err)
 	}
 
-	newBootImg, patchRequired, err := createNewVMTemplate(streamData, providerSpec, infra, credsSc, kubeClient, arch, artifacts.Release)
+	newBootImg, patchRequired, reconcileSkipped, err := createNewVMTemplate(streamData, providerSpec, infra, credsSc, kubeClient, arch, artifacts.Release)
 	if err != nil {
 		return false, false, nil, err
+	}
+	if reconcileSkipped {
+		return false, true, nil, nil
 	}
 
 	// If patch is required, marshal the new providerspec into the machineset
@@ -250,8 +267,12 @@ func reconcileVSphereProviderSpec(streamData *stream.Stream, arch string, infra 
 	return patchRequired, false, newProviderSpec, nil
 }
 
-// reconcileAzureProviderSpec reconciles the Azure provider spec by updating AMIs
-// Returns whether a patch is required, the updated provider spec, and any error
+// reconcileAzureProviderSpec reconciles the Azure provider spec by updating boot images.
+// Returns:
+//   - patchRequired: true when the MachineSet's Image must be updated to the target marketplace image
+//   - reconcileSkipped: true when the image type or architecture is unsupported (e.g. ppc64le, SecurityType set, Gen1 unavailable); see reconcilePlatform
+//   - newProviderSpec: updated copy of providerSpec; nil when patchRequired=false or reconcileSkipped=true
+//   - err: non-nil for stream, variant-detection, or ignition errors that should degrade the CO
 func reconcileAzureProviderSpec(streamData *stream.Stream, arch string, _ *osconfigv1.Infrastructure, providerSpec *machinev1beta1.AzureMachineProviderSpec, machineSetName string, secretClient clientset.Interface) (bool, bool, *machinev1beta1.AzureMachineProviderSpec, error) {
 
 	if arch == "ppc64le" || arch == "s390x" {

--- a/pkg/controller/bootimage/vsphere_helpers.go
+++ b/pkg/controller/bootimage/vsphere_helpers.go
@@ -702,8 +702,37 @@ func getClientsFromServerURL(ctx context.Context, server, username, password str
 	return client, tagManager, nil
 }
 
-// Creates a Template VM which has the relevant OVA/OVF file
-func createNewVMTemplate(streamData *stream.Stream, providerSpec *machinev1beta1.VSphereMachineProviderSpec, infra *osconfigv1.Infrastructure, credsSc *corev1.Secret, kubeClient clientset.Interface, arch, release string) (string, bool, error) {
+// hasMatchingFailureDomain reports whether any failure domain in the list matches
+// the providerSpec workspace fields for the given vcenter. Mirrors the match
+// criteria used in the createNewVMTemplate inner loop.
+func hasMatchingFailureDomain(providerSpec *machinev1beta1.VSphereMachineProviderSpec, vcenter osconfigv1.VSpherePlatformVCenterSpec, failureDomains []osconfigv1.VSpherePlatformFailureDomainSpec) bool {
+	for _, fd := range failureDomains {
+		vmGroup := ""
+		if fd.ZoneAffinity != nil && fd.ZoneAffinity.HostGroup != nil {
+			vmGroup = fd.ZoneAffinity.HostGroup.VMGroup
+		}
+		if providerSpec.Workspace.Datacenter == fd.Topology.Datacenter &&
+			providerSpec.Workspace.Datastore == fd.Topology.Datastore &&
+			vcenter.Server == fd.Server &&
+			providerSpec.Workspace.VMGroup == vmGroup &&
+			path.Clean(providerSpec.Workspace.ResourcePool) == path.Clean(fd.Topology.ResourcePool) {
+			return true
+		}
+	}
+	return false
+}
+
+// createNewVMTemplate finds or creates the RHCOS template VM for the MachineSet's vSphere workspace.
+// It matches the providerSpec workspace against the Infrastructure failure domains to locate the
+// correct vCenter context, then delegates to resolveExistingTemplateVM / createNewVMTemplateWithNameForFailureDomain.
+//
+// Returns:
+//   - resolvedName: the inventory name of the template VM (empty when no update is needed or the MachineSet is skipped)
+//   - patchRequired: true when the MachineSet's providerSpec.Template must be updated to resolvedName
+//   - reconcileSkipped: true when the workspace does not match any failure domain — the MachineSet
+//     is functional but cannot be managed for boot image updates; the caller should skip without degrading
+//   - err: non-nil for real vSphere or infrastructure errors that should degrade the CO
+func createNewVMTemplate(streamData *stream.Stream, providerSpec *machinev1beta1.VSphereMachineProviderSpec, infra *osconfigv1.Infrastructure, credsSc *corev1.Secret, kubeClient clientset.Interface, arch, release string) (resolvedName string, patchRequired, reconcileSkipped bool, err error) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -712,11 +741,17 @@ func createNewVMTemplate(streamData *stream.Stream, providerSpec *machinev1beta1
 			continue
 		}
 
+		// Pre-validate that at least one failure domain matches the workspace before
+		// authenticating. Avoids creating a vCenter session that will never be used.
+		if !hasMatchingFailureDomain(providerSpec, vcenter, infra.Spec.PlatformSpec.VSphere.FailureDomains) {
+			continue
+		}
+
 		username := string(credsSc.Data[fmt.Sprintf("%s.username", vcenter.Server)])
 		password := string(credsSc.Data[fmt.Sprintf("%s.password", vcenter.Server)])
 		client, tagManager, err := getClientsFromServerURL(ctx, vcenter.Server, username, password)
 		if err != nil {
-			return "", false, fmt.Errorf("failed in getClientsFromServerURL: %w", err)
+			return "", false, false, fmt.Errorf("failed in getClientsFromServerURL: %w", err)
 		}
 
 		finder := find.NewFinder(client.Client, false)
@@ -745,31 +780,31 @@ func createNewVMTemplate(streamData *stream.Stream, providerSpec *machinev1beta1
 
 			datacenter, err := finder.Datacenter(ctx, failureDomain.Topology.Datacenter)
 			if err != nil {
-				return "", false, fmt.Errorf("failed to find datacenter: %w", err)
+				return "", false, false, fmt.Errorf("failed to find datacenter: %w", err)
 			}
 			finder = finder.SetDatacenter(datacenter)
 
 			existingTemplateVM, resolvedName, created, err := resolveExistingTemplateVM(ctx, finder, providerSpec, failureDomain, streamData, client, tagManager, kubeClient, infraID, arch)
 			if err != nil {
-				return "", false, err
+				return "", false, false, err
 			}
 			if created {
-				return resolvedName, true, nil
+				return resolvedName, true, false, nil
 			}
 
 			var vmMo mo.VirtualMachine
 			err = existingTemplateVM.Properties(ctx, existingTemplateVM.Reference(), nil, &vmMo)
 			if err != nil {
-				return "", false, fmt.Errorf("Unable to extract properties from existing Template VM: %w", err)
+				return "", false, false, fmt.Errorf("unable to extract properties from existing Template VM: %w", err)
 			}
 
 			if vmMo.Summary.Config.Product == nil {
-				return "", false, fmt.Errorf("unable to determine RHCOS version of virtual machine: %s", providerSpec.Template)
+				return "", false, false, fmt.Errorf("unable to determine RHCOS version of virtual machine: %s", providerSpec.Template)
 			}
 
 			templateProductVersion := vmMo.Summary.Config.Product.Version
 			if templateProductVersion == "" {
-				return "", false, fmt.Errorf("unable to determine RHCOS version of virtual machine: %s", providerSpec.Template)
+				return "", false, false, fmt.Errorf("unable to determine RHCOS version of virtual machine: %s", providerSpec.Template)
 			}
 
 			if templateProductVersion != release {
@@ -780,39 +815,39 @@ func createNewVMTemplate(streamData *stream.Stream, providerSpec *machinev1beta1
 				// find the template already up to date and silently drop the error (see
 				// reconcileVSphereProviderSpec).
 				if err := upgradeStubIgnitionIfRequired(providerSpec.UserDataSecret.Name, kubeClient); err != nil {
-					return "", false, err
+					return "", false, false, err
 				}
 
 				// Find and download the relevant OVA file
 				ova, err := streamData.QueryDisk(arch, "vmware", "ova")
 				if err != nil {
-					return "", false, err
+					return "", false, false, err
 				}
 
 				ovaPath, err := cache.DownloadOva(ova)
 				if err != nil {
-					return "", false, fmt.Errorf("failed to download %s: %w", ova.Location, err)
+					return "", false, false, fmt.Errorf("failed to download %s: %w", ova.Location, err)
 				}
 
 				if len(resolvedName) > 80 {
-					return "", false, fmt.Errorf("length of VM template name `%s` exceeds the permitted limit of 80 characters", resolvedName)
+					return "", false, false, fmt.Errorf("length of VM template name `%s` exceeds the permitted limit of 80 characters", resolvedName)
 				}
 
 				diskType := getDiskTypeFromExistingVM(vmMo)
 
 				err = createNewVMTemplateWithNameForFailureDomain(ctx, providerSpec, failureDomain, finder, client, tagManager, resolvedName, ovaPath, infraID, diskType)
 				if err != nil {
-					return "", false, err
+					return "", false, false, err
 				}
-				return resolvedName, true, nil
+				return resolvedName, true, false, nil
 			}
 
 			klog.Infof("Existing RHCOS v%s does match current RHCOS v%s. Skipping reconciliation process using govmomi.", templateProductVersion, release)
 			if providerSpec.Template != resolvedName {
 				klog.Infof("ProviderSpec template name: %s has diverged from the VM Template of name: %s that exists in VSphere. Reconciling the name change.", providerSpec.Template, resolvedName)
-				return resolvedName, true, nil
+				return resolvedName, true, false, nil
 			}
-			return resolvedName, false, nil
+			return resolvedName, false, false, nil
 		}
 	}
 
@@ -824,5 +859,9 @@ func createNewVMTemplate(streamData *stream.Stream, providerSpec *machinev1beta1
 	if providerSpec.Workspace.VMGroup != "" {
 		workspaceDetails += fmt.Sprintf(", vmGroup: %s", providerSpec.Workspace.VMGroup)
 	}
-	return "", false, fmt.Errorf("providerSpec workspace (%s) does not match any vCenter/failure domain in the Infrastructure object", workspaceDetails)
+	// The MachineSet's workspace does not correspond to any failure domain in the Infrastructure
+	// object. This is a valid topology-unaware configuration — the MachineSet provisions nodes
+	// successfully but cannot be managed for boot image updates. Skip without degrading.
+	klog.Warningf("Skipping boot image update: providerSpec workspace (%s) does not match any vCenter/failure domain in the Infrastructure object. Boot image must be updated manually for this MachineSet.", workspaceDetails)
+	return "", false, true, nil
 }

--- a/pkg/controller/bootimage/vsphere_helpers_test.go
+++ b/pkg/controller/bootimage/vsphere_helpers_test.go
@@ -15,10 +15,9 @@ import (
 
 // TestCreateNewVMTemplate_NoMatchingFailureDomain verifies that when a MachineSet's
 // providerSpec.Workspace doesn't match any vCenter/failure domain in the Infrastructure object,
-// createNewVMTemplate returns a descriptive error instead of silently no-op'ing. This is the
-// degrade-on-no-match behavior added in "bootimage: degrade when vsphere fd not found" — it never
-// reaches getClientsFromServerURL (no real vCenter connectivity needed), since the outer loop over
-// infra.Spec.PlatformSpec.VSphere.VCenters has nothing to match against.
+// createNewVMTemplate skips without error rather than degrading the CO. This covers topology-unaware
+// clusters where machinesets span datastores not present in the Infrastructure failure domains.
+// The function never reaches getClientsFromServerURL (no real vCenter connectivity needed).
 func TestCreateNewVMTemplate_NoMatchingFailureDomain(t *testing.T) {
 	providerSpec := &machinev1beta1.VSphereMachineProviderSpec{
 		Workspace: &machinev1beta1.Workspace{
@@ -40,13 +39,56 @@ func TestCreateNewVMTemplate_NoMatchingFailureDomain(t *testing.T) {
 		},
 	}
 
-	resolvedName, patchRequired, err := createNewVMTemplate(nil, providerSpec, infra, nil, nil, "x86_64", "9.6.20260210-0")
+	resolvedName, patchRequired, reconcileSkipped, err := createNewVMTemplate(nil, providerSpec, infra, nil, nil, "x86_64", "9.6.20260210-0")
 
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "does not match any vCenter/failure domain")
-	assert.Contains(t, err.Error(), "vcenter.example.com")
+	require.NoError(t, err)
 	assert.Empty(t, resolvedName)
 	assert.False(t, patchRequired)
+	assert.True(t, reconcileSkipped)
+}
+
+// TestCreateNewVMTemplate_MatchingServerNoMatchingFD verifies that when the providerSpec server
+// matches a vCenter entry but the workspace fields don't match any failure domain, we return
+// reconcileSkipped=true without attempting vCenter authentication.
+func TestCreateNewVMTemplate_MatchingServerNoMatchingFD(t *testing.T) {
+	providerSpec := &machinev1beta1.VSphereMachineProviderSpec{
+		Workspace: &machinev1beta1.Workspace{
+			Server:       "vcenter.example.com",
+			Datacenter:   "dc1",
+			Datastore:    "unregistered-datastore",
+			ResourcePool: "/dc1/host/cluster1/Resources",
+		},
+	}
+
+	infra := &osconfigv1.Infrastructure{
+		Spec: osconfigv1.InfrastructureSpec{
+			PlatformSpec: osconfigv1.PlatformSpec{
+				VSphere: &osconfigv1.VSpherePlatformSpec{
+					VCenters: []osconfigv1.VSpherePlatformVCenterSpec{
+						{Server: "vcenter.example.com"},
+					},
+					FailureDomains: []osconfigv1.VSpherePlatformFailureDomainSpec{
+						{
+							Server: "vcenter.example.com",
+							Topology: osconfigv1.VSpherePlatformTopology{
+								Datacenter:   "dc1",
+								Datastore:    "registered-datastore", // different from providerSpec
+								ResourcePool: "/dc1/host/cluster1/Resources",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// credsSc is nil — if getClientsFromServerURL were called it would panic.
+	resolvedName, patchRequired, reconcileSkipped, err := createNewVMTemplate(nil, providerSpec, infra, nil, nil, "x86_64", "9.6.20260210-0")
+
+	require.NoError(t, err)
+	assert.Empty(t, resolvedName)
+	assert.False(t, patchRequired)
+	assert.True(t, reconcileSkipped)
 }
 
 func newTestVM(inventoryPath string) *object.VirtualMachine {


### PR DESCRIPTION
Manual cherry-pick of https://github.com/openshift/machine-config-operator/pull/6477/; it conflicted because 4.22 does not support the AWS marketplace. 