### PR TITLE
Add fix for failing TC 76587

### DIFF
--- a/test/extended-priv/mco_security.go
+++ b/test/extended-priv/mco_security.go
@@ -758,6 +758,9 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/longdurati
 			node            = mcp.GetSortedNodesOrFail()[0]
 			port            = 22623
 			insecureCiphers = []string{"TLS_RSA_WITH_AES_128_GCM_SHA256", "TLS_RSA_WITH_AES_256_GCM_SHA384"}
+			// On newer releases the MCS port is blocked via a native nftables chain instead of iptables
+			nftBlockTable = "inet ovn-kubernetes"
+			nftBlockChain = "mcs-blocking"
 		)
 
 		exutil.By("Remove iptable rules")
@@ -772,6 +775,16 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/longdurati
 		defer node.ExecIP6Tables(removed6Rules)
 		logger.Infof("OK!\n")
 
+		exutil.By("Remove nftables rules that block the ignition config")
+		logger.Infof("Remove the native nftables rules (chain %q in table %q) that block the MCS port", nftBlockChain, nftBlockTable)
+		removedNFTRules, err := node.RemoveNFTablesRulesFromChain(nftBlockTable, nftBlockChain)
+		o.Expect(err).NotTo(o.HaveOccurred(), "Error removing the nftables MCS-block rules in node %s", node.GetName())
+		defer func() {
+			o.Expect(node.RestoreNFTablesRulesInChain(nftBlockTable, nftBlockChain, removedNFTRules)).NotTo(o.HaveOccurred(),
+				"Error restoring the nftables MCS-block rules in node %s", node.GetName())
+		}()
+		logger.Infof("OK!\n")
+
 		internalAPIServerURI, err := GetAPIServerInternalURI(mcp.oc)
 		o.Expect(err).NotTo(o.HaveOccurred(), "Error getting the internal apiserver URL")
 
@@ -780,6 +793,13 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/longdurati
 		cipherOutput, cipherErr := node.DebugNodeWithOptions([]string{"--image=" + TestSSLImage, "-n", MachineConfigNamespace}, "testssl.sh", "--color", "0", url)
 		logger.Infof("test ssh script output:\n %s", cipherOutput)
 		o.Expect(cipherErr).NotTo(o.HaveOccurred())
+
+		// Fail honestly if testssl.sh could not reach the MCS port instead of misreporting the connection
+		// problem as a cipher/SWEET32 vulnerability further down. This happens when the port block was not
+		// actually removed (e.g. the block is enforced by a mechanism this test does not clean up).
+		o.Expect(cipherOutput).NotTo(o.MatchRegexp("(?i)(can.t connect|connection refused|Fatal error|Unable to open a socket)"),
+			"testssl.sh could not connect to the MCS port at %s. The MCS port block was not fully removed:\n%s", url, cipherOutput)
+
 		for _, insecureCipher := range insecureCiphers {
 			logger.Infof("Verify %s", insecureCipher)
 			o.Expect(cipherOutput).NotTo(o.ContainSubstring(insecureCipher),

--- a/test/extended-priv/node.go
+++ b/test/extended-priv/node.go
@@ -1658,3 +1658,67 @@ func RestoreRpm(node *Node) error {
 			"rm -f /var/tmp/rpm-real "+fakeRpmRemotePath)
 	return err
 }
+
+// RemoveNFTablesRulesFromChain flushes all the rules in the given nftables chain and returns the
+// removed rules so that they can be restored later with RestoreNFTablesRulesInChain.
+// The "table" parameter is the full table specification (family and name), e.g. "inet ovn-kubernetes".
+// On newer releases the MCS port (22623/22624) is blocked via a native nftables chain
+// ("mcs-blocking" in table "inet ovn-kubernetes") instead of the old iptables OPENSHIFT-BLOCK-OUTPUT
+// rules, so RemoveIPTablesRulesByRegexp is a no-op there and this function must be used instead.
+// If the chain does not exist (e.g. older releases still using iptables) it returns an empty slice
+// and no error.
+func (n *Node) RemoveNFTablesRulesFromChain(table, chain string) ([]string, error) {
+	removedRules := []string{}
+
+	listArgs := append([]string{"nft", "list", "chain"}, strings.Fields(table)...)
+	listArgs = append(listArgs, chain)
+	out, stderr, err := n.DebugNodeWithChrootStd(listArgs...)
+	if err != nil {
+		// If the chain or the table does not exist there is nothing to remove
+		if strings.Contains(stderr, "No such file or directory") || strings.Contains(stderr, "does not exist") {
+			logger.Infof("nftables chain %q in table %q does not exist in node %s. Nothing to remove", chain, table, n.GetName())
+			return removedRules, nil
+		}
+		logger.Errorf("Error listing nftables chain %q in table %q. Stderr: %s", chain, table, stderr)
+		return nil, err
+	}
+
+	for _, line := range strings.Split(out, "\n") {
+		rule := strings.TrimSpace(line)
+		// Skip empty lines, the chain header, the closing brace and the chain type/hook definition
+		if rule == "" || rule == "}" || strings.HasPrefix(rule, "chain ") || strings.HasPrefix(rule, "type ") {
+			continue
+		}
+		removedRules = append(removedRules, rule)
+	}
+
+	if len(removedRules) == 0 {
+		logger.Infof("No rules found in nftables chain %q of table %q in node %s", chain, table, n.GetName())
+		return removedRules, nil
+	}
+
+	logger.Infof("%s. Flushing nftables chain %q in table %q. Rules: %v", n.GetName(), chain, table, removedRules)
+	flushArgs := append([]string{"nft", "flush", "chain"}, strings.Fields(table)...)
+	flushArgs = append(flushArgs, chain)
+	if _, err := n.DebugNodeWithChroot(flushArgs...); err != nil {
+		return removedRules, err
+	}
+
+	return removedRules, nil
+}
+
+// RestoreNFTablesRulesInChain re-adds the given rules to the nftables chain. It is meant to restore
+// the rules removed by RemoveNFTablesRulesFromChain. Each rule is the rule body as printed by
+// `nft list chain` (without the "add rule <table> <chain>" prefix).
+func (n *Node) RestoreNFTablesRulesInChain(table, chain string, rules []string) error {
+	for _, rule := range rules {
+		logger.Infof("%s. Restoring nftables rule in table %q chain %q: %s", n.GetName(), table, chain, rule)
+		addArgs := append([]string{"nft", "add", "rule"}, strings.Fields(table)...)
+		addArgs = append(addArgs, chain)
+		addArgs = append(addArgs, strings.Fields(rule)...)
+		if _, err := n.DebugNodeWithChroot(addArgs...); err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Added fix for this TC 76587 for below failure 

```
{  fail [github.com/openshift/machine-config-operator/test/extended-priv/mco_security.go:790]: api-int.ci-op-s2kpvw2i-31c09.ocp-mco-qe.devcluster.openshift.com is vulnerable to SWEET32
Expected
    <string>: ###########################################################
        testssl.sh       3.1dev from https://testssl.sh/dev/
    
          This program is free software. Distribution and
                 modification under GPLv2 permitted.
          USAGE w/o ANY WARRANTY. USE IT AT YOUR OWN RISK!
    
           Please file bugs @ https://testssl.sh/bugs/
    
    ###########################################################
    
     Using "OpenSSL 1.1.1q  5 Jul 2022 (Library: OpenSSL 1.1.1l  24 Aug 2021)" [~94 ciphers]
     on ip-10-0-59-70:/usr/bin/openssl
     (built: "Aug 24 15:52:24 2021", platform: "linux-x86_64")
    
    
    Testing all IPv4 addresses (port 22623): 10.0.68.254 10.0.63.130
    -----------------------------------------------------
     Start 2026-08-31 20:37:26        -->> 10.0.68.254:22623 (api-int.ci-op-s2kpvw2i-31c09.ocp-mco-qe.devcluster.openshift.com) <<--
    
     Further IP addresses:   10.0.63.130 
     rDNS (10.0.68.254):     ip-10-0-68-254.us-west-2.compute.internal./usr/local/bin/testssl.sh: connect: Connection refused
    /usr/local/bin/testssl.sh: line 11174: /dev/tcp/10.0.68.254/22623: Connection refused
     Oops: TCP connect problem
    
    Unable to open a socket to 10.0.68.254:22623. 
    Fatal error: Couldn't connect to 10.0.68.254:22623, proceeding with next IP (if any)
    
    
     Done 2026-08-31 20:37:27 [   4s] -->> 10.0.68.254:22623 (api-int.ci-op-s2kpvw2i-31c09.ocp-mco-qe.devcluster.openshift.com) <<--
    
    -----------------------------------------------------
     Start 2026-08-31 20:37:27        -->> 10.0.63.130:22623 (api-int.ci-op-s2kpvw2i-31c09.ocp-mco-qe.devcluster.openshift.com) <<--
    
     Further IP addresses:   10.0.68.254 
     rDNS (10.0.63.130):     ip-10-0-63-130.us-west-2.compute.internal./usr/local/bin/testssl.sh: connect: Connection refused
    /usr/local/bin/testssl.sh: line 11174: /dev/tcp/10.0.63.130/22623: Connection refused
     Oops: TCP connect problem
    
    Unable to open a socket to 10.0.63.130:22623. 
    Fatal error: Couldn't connect to 10.0.63.130:22623, proceeding with next IP (if any)
    
    
     Done 2026-08-31 20:37:28 [   5s] -->> 10.0.63.130:22623 (api-int.ci-op-s2kpvw2i-31c09.ocp-mco-qe.devcluster.openshift.com) <<--
    
    -----------------------------------------------------
    Done testing now all IP addresses (on port 22623): 10.0.68.254 10.0.63.130
    Starting pod/ip-10-0-59-70us-west-2computeinternal-debug-k54mv ...
    To use host binaries, run `chroot /host`. Instead, if you need to access host namespaces, run `nsenter -a -t 1`.
    
    Removing debug pod ...
to match regular expression
    <string>: SWEET32 .*not vulnerable \(OK\)}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved weak-cipher security test reliability by handling native firewall rules that could block access to the tested port.
  * Added clearer failure reporting when the security scanner cannot connect, preventing connection issues from being misreported as cipher vulnerabilities.
  * Ensured temporarily modified firewall rules are restored after testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->