### PR TITLE
OCPBUGS-112721: Retry on conflict in syncMachineConfigNodes

### DIFF
--- a/lib/resourceapply/machineconfig_test.go
+++ b/lib/resourceapply/machineconfig_test.go
@@ -10,8 +10,10 @@ import (
 	"github.com/openshift/client-go/machineconfiguration/clientset/versioned/fake"
 	"github.com/openshift/machine-config-operator/test/helpers"
 	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/diff"
 	clienttesting "k8s.io/client-go/testing"
 )
@@ -294,5 +296,95 @@ func TestApplyMachineConfig(t *testing.T) {
 			}
 			test.verifyActions(client.Actions(), t)
 		})
+	}
+}
+
+// TestIsApplyErrorRetriable verifies all cases that IsApplyErrorRetriable considers retriable,
+// and that unrelated errors are not.
+func TestIsApplyErrorRetriable(t *testing.T) {
+	mcnGR := schema.GroupResource{Group: "machineconfiguration.openshift.io", Resource: "machineconfignodes"}
+
+	tests := []struct {
+		name      string
+		err       error
+		retriable bool
+	}{
+		{
+			name:      "conflict error is retriable",
+			err:       apierrors.NewConflict(mcnGR, "node-1", fmt.Errorf("the object has been modified")),
+			retriable: true,
+		},
+		{
+			name:      "timeout error is retriable",
+			err:       apierrors.NewTimeoutError("request timed out", 10),
+			retriable: true,
+		},
+		{
+			name:      "rpc error is retriable",
+			err:       fmt.Errorf("rpc error: code = Unavailable desc = transport is closing"),
+			retriable: true,
+		},
+		{
+			name:      "not found error is not retriable",
+			err:       apierrors.NewNotFound(mcnGR, "node-1"),
+			retriable: false,
+		},
+		{
+			name:      "forbidden error is not retriable",
+			err:       apierrors.NewForbidden(mcnGR, "node-1", fmt.Errorf("access denied")),
+			retriable: false,
+		},
+		{
+			name:      "unrelated error is not retriable",
+			err:       fmt.Errorf("something went wrong"),
+			retriable: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsApplyErrorRetriable(tc.err); got != tc.retriable {
+				t.Errorf("IsApplyErrorRetriable(%v) = %v, want %v", tc.err, got, tc.retriable)
+			}
+		})
+	}
+}
+
+// TestApplyMachineConfigNodeConflictIsRetriable verifies that ApplyMachineConfigNode surfaces a
+// conflict error that IsApplyErrorRetriable recognises, so the retry.OnError wrapper in
+// syncMachineConfigNodes can retry it correctly.
+func TestApplyMachineConfigNodeConflictIsRetriable(t *testing.T) {
+	existing := &mcfgv1.MachineConfigNode{
+		ObjectMeta: metav1.ObjectMeta{Name: "node-1", ResourceVersion: "100"},
+		Spec: mcfgv1.MachineConfigNodeSpec{
+			Pool: mcfgv1.MCOObjectReference{Name: "worker"},
+		},
+	}
+	required := &mcfgv1.MachineConfigNode{
+		ObjectMeta: metav1.ObjectMeta{Name: "node-1"},
+		Spec: mcfgv1.MachineConfigNodeSpec{
+			Pool: mcfgv1.MCOObjectReference{Name: "master"},
+		},
+	}
+
+	client := fake.NewSimpleClientset(existing)
+	conflictErr := apierrors.NewConflict(
+		schema.GroupResource{Group: "machineconfiguration.openshift.io", Resource: "machineconfignodes"},
+		"node-1",
+		fmt.Errorf("the object has been modified; please apply your changes to the latest version and try again"),
+	)
+	client.PrependReactor("update", "machineconfignodes", func(_ clienttesting.Action) (bool, runtime.Object, error) {
+		return true, nil, conflictErr
+	})
+
+	_, _, err := ApplyMachineConfigNode(client.MachineconfigurationV1(), required)
+	if err == nil {
+		t.Fatal("expected conflict error, got nil")
+	}
+	if !apierrors.IsConflict(err) {
+		t.Fatalf("expected conflict error, got: %v", err)
+	}
+	if !IsApplyErrorRetriable(err) {
+		t.Fatal("conflict error should be retriable via IsApplyErrorRetriable")
 	}
 }

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -892,8 +892,12 @@ func (optr *Operator) syncMachineConfigNodes(_ *renderConfig, _ *configv1.Cluste
 			return err
 		}
 		p := mcoResourceRead.ReadMachineConfigNodeV1OrDie(mcsBytes)
-		mcn, _, err := mcoResourceApply.ApplyMachineConfigNode(optr.client.MachineconfigurationV1(), p)
-		if err != nil {
+		var mcn *mcfgv1.MachineConfigNode
+		if err := retry.OnError(retry.DefaultRetry, mcoResourceApply.IsApplyErrorRetriable, func() error {
+			var applyErr error
+			mcn, _, applyErr = mcoResourceApply.ApplyMachineConfigNode(optr.client.MachineconfigurationV1(), p)
+			return applyErr
+		}); err != nil {
 			return err
 		}
 		// if this is the first time we are applying the MCN and the node is ready, set the config version probably


### PR DESCRIPTION
This is based on https://github.com/openshift/machine-config-operator/pull/6466 with additional unit test cases. Following description is pulled from #6446.

- What I did

Wrapped the ApplyMachineConfigNode call in syncMachineConfigNodes with retry.OnError using the existing IsApplyErrorRetriable predicate and DefaultRetry backoff.

The MachineConfigNode controller's resync loop performs a Get-then-Update on MCN objects without any conflict retry. When concurrent writes from the daemon or drain controller change the object's resourceVersion between Get and Update, the update fails with an optimistic-concurrency conflict. This error propagates through syncAll to syncDegradedStatus, which surfaces a transient Degraded=True condition with reason MachineConfigNodeFailed — tripping the CVO invariant monitor in CI even though the condition self-clears.

This matches the retry pattern already used by applyManifests and other sync functions in the same file.

- How to verify it

Run the existing unit tests for the operator package.
In a cluster with the MachineConfigNode feature gate enabled, trigger concurrent MCN updates (e.g. by rebooting a node while the daemon is also updating MCN status). Verify no transient Degraded=True condition appears on the machine-config ClusterOperator.
- Description for the changelog

Retry on conflict in MachineConfigNode sync to prevent transient Degraded=True conditions caused by optimistic-concurrency errors.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * MachineConfigNode updates now automatically retry transient failures, including conflicts, timeouts, and RPC errors.
  * Configuration version handling now continues correctly after a successful update.
  * Non-retriable errors are still reported without unnecessary retries.
  * Failed updates provide more reliable results when temporary API or communication issues occur.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->