### PR TITLE
OCPBUGS-120711: Fix vsphere network absolute paths

### DIFF
--- a/pkg/controller/bootimage/vsphere_helpers.go
+++ b/pkg/controller/bootimage/vsphere_helpers.go
@@ -190,8 +190,9 @@ func findAllRequiredResources(ctx context.Context, finder *find.Finder, provider
 	if err != nil {
 		return nil, fmt.Errorf("failed to find resource pool: %w", err)
 	}
-	networkPath := path.Join(vr.cluster.InventoryPath, failureDomain.Topology.Networks[0])
-	vr.networkRef, err = finder.Network(ctx, networkPath)
+	// finder.Network handles the discovery of the network no matter
+	// the format of the string (absolute, relative, uuid, etc)
+	vr.networkRef, err = finder.Network(ctx, failureDomain.Topology.Networks[0])
 	if err != nil {
 		return nil, fmt.Errorf("failed to find network: %w", err)
 	}


### PR DESCRIPTION
Closes: [#OCPBUGS-120711](https://redhat.atlassian.net/browse/OCPBUGS-120711)

**- What I did**

Despite the API docs says that the networks should be in an absolute format, our code and CI was using the relative name of the network and performing some string joinning to make the path absolute before delegating the call to the vmware lib.
Given that the underlaying vmware library properly handles all the formats this change removes the path manling and passes the name directly to the library like other operators do.

**- How to verify it**

TBD

**- Description for the changelog**

Fix vsphere network name handling to allow absolute names, that are the oficailly supported ones.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved vSphere network resource discovery for failure domains.
  - Network identifiers in finder-supported formats are now handled directly, improving compatibility with supported network references.
  - Existing network lookup error reporting remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->