### PR TITLE
[release-4.19] OCPBUGS-120741: [manual cherry-pick of #6446] Use kubernetes scheme in drain controller event recorder

### DIFF
--- a/pkg/controller/drain/drain_controller.go
+++ b/pkg/controller/drain/drain_controller.go
@@ -9,12 +9,12 @@ import (
 
 	v1 "github.com/openshift/api/machineconfiguration/v1"
 	mcfgclientset "github.com/openshift/client-go/machineconfiguration/clientset/versioned"
-	"github.com/openshift/client-go/machineconfiguration/clientset/versioned/scheme"
 	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
 	daemonconsts "github.com/openshift/machine-config-operator/pkg/daemon/constants"
 	"github.com/openshift/machine-config-operator/pkg/helpers"
 	"github.com/openshift/machine-config-operator/pkg/upgrademonitor"
+	kubescheme "k8s.io/client-go/kubernetes/scheme"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -128,7 +128,7 @@ func New(
 	ctrl := &Controller{
 		client:        mcfgClient,
 		kubeClient:    kubeClient,
-		eventRecorder: ctrlcommon.NamespacedEventRecorder(eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: "machineconfigcontroller-nodecontroller"})),
+		eventRecorder: ctrlcommon.NamespacedEventRecorder(eventBroadcaster.NewRecorder(kubescheme.Scheme, corev1.EventSource{Component: "machineconfigcontroller-nodecontroller"})),
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
 			workqueue.TypedRateLimitingQueueConfig[string]{Name: "machineconfigcontroller-draincontroller"}),


### PR DESCRIPTION
OCPBUGS-120741: Manual cherry-pick of #6446 for release-4.19: Use kubernetes scheme in drain controller event recorder

**- What I did**
Use kubernetes scheme in drain controller event recorder

**- How to verify it**
1- Apply a PodDisruptionBudget that prevent drain:

```
apiVersion: policy/v1
kind: PodDisruptionBudget
metadata:
  namespace: openshift-ingress
  name: test
spec:
  maxUnavailable: 0
  selector:
    matchLabels:
      ingresscontroller.operator.openshift.io/deployment-ingresscontroller: default
```
2- Add a MachineConfig that bumps the worker MachineConfigPool

```
apiVersion: machineconfiguration.openshift.io/v1
kind: MachineConfig
metadata:
  name: 99-worker-drain-test
  labels:
    machineconfiguration.openshift.io/role: worker
spec:
  config:
    ignition:
      version: 3.4.0
    storage:
      files:
        - path: /etc/drain-test-trigger
          mode: 0644
          contents:
            source: data:,drain-test
```
3 - Logs should not report the following log should not construct reference, will not report event" err="no kind is registered for the type v1.Node in scheme

```
$ oc logs -n openshift-machine-config-operator -l k8s-app=machine-config-controller -c machine-config-controller -f \
  | grep -E "DrainThresholdExceeded|will not report event"
```
4 - Check for Events about the failed Node drain

`$ oc get events -n default | grep DrainThresholdExceeded # OR all namespaces`
