### PR TITLE
NO-ISSUE: check mosb failed message in test 85980

### DIFF
--- a/test/extended-priv/mco_ocb_longduration.go
+++ b/test/extended-priv/mco_ocb_longduration.go
@@ -730,6 +730,8 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/longdurati
 		logger.Infof("MOSB created: %s\n", failedMOSB.GetName())
 		o.Eventually(failedMOSB, "20m", "20s").Should(HaveConditionField("Failed", "status", TrueString),
 			"MOSB should fail due to incorrect containerfile")
+		o.Eventually(failedMOSB, "2m", "20s").Should(HaveConditionField("Failed", "message", o.ContainSubstring("Job has reached the specified backoff limit")),
+			"MOSB should report a failure message describing the problem")
 		logger.Infof("MOSB failed as expected\n")
 
 		exutil.By("Verify MCP is degraded with ImageBuildDegraded condition")


### PR DESCRIPTION

**- What I did**

Check MOSB Failed message in test case 85980

After https://redhat.atlassian.net/browse/OCPBUGS-112465 when a MOSB fails it reports the failure message in the Failed condition.

**- How to verify it**

Test  85980 checks the failed message and passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded coverage for machine operating system build failures.
  - Tests now verify that a failed build reports a clear failure message when the retry limit is reached.
  - Added a time-bound check to confirm the expected failure status is surfaced promptly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->