### PR TITLE
OPNET-801: Switch on-prem HAProxy pods to haproxy-router-haproxy32 image

### DIFF
--- a/cmd/machine-config-operator/bootstrap.go
+++ b/cmd/machine-config-operator/bootstrap.go
@@ -132,7 +132,7 @@ func runBootstrapCmd(_ *cobra.Command, _ []string) {
 		bootstrapOpts.oauthProxyImage = findImageOrDie(imgstream, "oauth-proxy")
 		bootstrapOpts.kubeRbacProxyImage = findImageOrDie(imgstream, "kube-rbac-proxy")
 		bootstrapOpts.infraImage = findImageOrDie(imgstream, "pod")
-		bootstrapOpts.haproxyImage = findImageOrDie(imgstream, "haproxy-router")
+		bootstrapOpts.haproxyImage = findImageOrDie(imgstream, "haproxy-router-haproxy32")
 		bootstrapOpts.dockerRegistryImage = findImageOrDie(imgstream, "docker-registry")
 		bootstrapOpts.baseOSContainerImage, err = findImage(imgstream, baseOSContainerImageTag)
 		if err != nil {

--- a/install/0000_80_machine-config_02_images.configmap.yaml
+++ b/install/0000_80_machine-config_02_images.configmap.yaml
@@ -15,7 +15,7 @@ data:
       "infraImage": "placeholder.url.oc.will.replace.this.org/placeholdernamespace:pod",
       "keepalivedImage": "placeholder.url.oc.will.replace.this.org/placeholdernamespace:keepalived-ipfailover",
       "corednsImage": "placeholder.url.oc.will.replace.this.org/placeholdernamespace:coredns",
-      "haproxyImage": "placeholder.url.oc.will.replace.this.org/placeholdernamespace:haproxy-router",
+      "haproxyImage": "placeholder.url.oc.will.replace.this.org/placeholdernamespace:haproxy-router-haproxy32",
       "baremetalRuntimeCfgImage": "placeholder.url.oc.will.replace.this.org/placeholdernamespace:baremetal-runtimecfg",
       "oauthProxy": "placeholder.url.oc.will.replace.this.org/placeholdernamespace:oauth-proxy",
       "kubeRbacProxy": "placeholder.url.oc.will.replace.this.org/placeholdernamespace:kube-rbac-proxy",

--- a/install/image-references
+++ b/install/image-references
@@ -44,10 +44,10 @@ spec:
     from:
       kind: DockerImage
       name: placeholder.url.oc.will.replace.this.org/placeholdernamespace:coredns
-  - name: haproxy-router
+  - name: haproxy-router-haproxy32
     from:
       kind: DockerImage
-      name: placeholder.url.oc.will.replace.this.org/placeholdernamespace:haproxy-router
+      name: placeholder.url.oc.will.replace.this.org/placeholdernamespace:haproxy-router-haproxy32
   - name: baremetal-runtimecfg
     from:
       kind: DockerImage

--- a/pkg/controller/template/constants.go
+++ b/pkg/controller/template/constants.go
@@ -16,7 +16,7 @@ const (
 	// CorednsKey is the key that references the coredns image in the controller
 	CorednsKey string = "corednsImage"
 
-	// HaproxyKey is the key that references the haproxy-router image in the controller
+	// HaproxyKey is the key that references the haproxy-router-haproxy32 image in the controller
 	HaproxyKey string = "haproxyImage"
 
 	// BaremetalRuntimeCfgKey is the key that references the baremetal-runtimecfg image in the controller

--- a/templates/master/00-master/on-prem/files/haproxy.yaml
+++ b/templates/master/00-master/on-prem/files/haproxy.yaml
@@ -24,6 +24,8 @@ contents:
           path: "/var/lib/kubelet"
       - name: run-dir
         empty-dir: {}
+      - name: lib-run-dir
+        empty-dir: {}
       - name: conf-dir
         hostPath:
           path: "/etc/haproxy"
@@ -53,8 +55,6 @@ contents:
       containers:
       - name: haproxy
         image: {{.Images.haproxyImage}}
-        securityContext:
-          runAsUser: 0
         env:
           - name: OLD_HAPROXY_PS_FORCE_DEL_TIMEOUT
             value: "120"
@@ -102,10 +102,6 @@ contents:
             done
           }
           set -ex
-          # The haproxy-router-haproxy32 (HAProxy 3.2) image does not ship the
-          # /var/lib/haproxy/run directory that older haproxy-router images did.
-          # HAProxy needs it to create the stats socket and pid file, so ensure it exists.
-          mkdir -p /var/lib/haproxy/run
           declare -r haproxy_sock="/var/run/haproxy/haproxy-master.sock"
           declare -r haproxy_log_sock="/var/run/haproxy/haproxy-log.sock"
           export -f msg_handler
@@ -127,6 +123,8 @@ contents:
           mountPropagation: HostToContainer
         - name: run-dir
           mountPath: "/var/run/haproxy"
+        - name: lib-run-dir
+          mountPath: "/var/lib/haproxy/run"
         livenessProbe:
           initialDelaySeconds: 50
           httpGet:

--- a/templates/master/00-master/on-prem/files/haproxy.yaml
+++ b/templates/master/00-master/on-prem/files/haproxy.yaml
@@ -53,6 +53,8 @@ contents:
       containers:
       - name: haproxy
         image: {{.Images.haproxyImage}}
+        securityContext:
+          runAsUser: 0
         env:
           - name: OLD_HAPROXY_PS_FORCE_DEL_TIMEOUT
             value: "120"
@@ -100,6 +102,10 @@ contents:
             done
           }
           set -ex
+          # The haproxy-router-haproxy32 (HAProxy 3.2) image does not ship the
+          # /var/lib/haproxy/run directory that older haproxy-router images did.
+          # HAProxy needs it to create the stats socket and pid file, so ensure it exists.
+          mkdir -p /var/lib/haproxy/run
           declare -r haproxy_sock="/var/run/haproxy/haproxy-master.sock"
           declare -r haproxy_log_sock="/var/run/haproxy/haproxy-log.sock"
           export -f msg_handler


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Point the on-prem/baremetal apiserver load-balancer HAProxy static pod at the
`haproxy-router-haproxy32` (HAProxy 3.2) payload component instead of
`haproxy-router`.

**- How to verify it**


**- Description for the changelog**
Switch on-prem HAProxy pods to haproxy-router-haproxy32 image
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * HAProxy image references now consistently use the `haproxy-router-haproxy32` tag across bootstrap, installation, and image mapping configuration.
  * Related configuration references were updated to resolve the intended HAProxy image.

* **Bug Fixes**
  * On-premises HAProxy startup now provides the required runtime directory for the stats socket and PID file.
  * The HAProxy container no longer runs as root.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->