### PR TITLE
MCO-1989: Fix RHEL9-specific MCD Logic for RHEL10/CentOS10 for adaptability

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -13,7 +13,9 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"regexp"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -525,23 +527,29 @@ func ReexecuteForTargetRoot(target string) error {
 		return fmt.Errorf("failed to get target OS: %w", err)
 	}
 
-	var sourceBinarySuffix string
+	sourceBinary := "/usr/bin/machine-config-daemon"
 	if sourceOsVersion.IsLikeRHEL() && targetOsVersion.IsLikeRHEL() {
-		sourceMajor := sourceOsVersion.BaseVersionMajor()
-		targetMajor := targetOsVersion.BaseVersionMajor()
-
+		sourceVersion := sourceOsVersion.BaseVersionMajor()
+		targetVersion := targetOsVersion.BaseVersionMajor()
 		// When container is newer than target, use target-compatible binary
-		switch {
-		case sourceMajor == 10 && targetMajor == 9:
-			sourceBinarySuffix = ".rhel9"
-			klog.Info("container is rhel10, target is rhel9")
-		default:
-			klog.Infof("using appropriate binary for source=rhel-%d target=rhel-%d", sourceMajor, targetMajor)
+		if sourceVersion > targetVersion {
+			suffixes, err := getVersionedBinarySuffixes(sourceBinary + "*")
+			if err != nil {
+				return fmt.Errorf("failed to get machine-config-daemon versioned binaries: %w", err)
+			}
+			suffix, exists := suffixes[targetVersion]
+			if !exists {
+				return fmt.Errorf("no RHEL%d-compatible machine-config-daemon binary found (container is RHEL%d, target is RHEL%d)", targetVersion, sourceVersion, targetVersion)
+			}
+			sourceBinary += suffix
+			klog.Infof("container is rhel%d, target is rhel%d, using binary: %s", sourceVersion, targetVersion, sourceBinary)
+		} else {
+			klog.Infof("using appropriate binary for source=rhel-%d target=rhel-%d", sourceVersion, targetVersion)
 		}
+
 	} else {
 		klog.Info("assuming we can use container binary chroot() to host")
 	}
-	sourceBinary := "/usr/bin/machine-config-daemon" + sourceBinarySuffix
 	src, err := os.Open(sourceBinary)
 	if err != nil {
 		return fmt.Errorf("opening %s: %w", sourceBinary, err)
@@ -591,6 +599,46 @@ func ReexecuteForTargetRoot(target string) error {
 	newEnv := append(os.Environ(), fmt.Sprintf("%s=1", reexecEnv))
 	klog.Infof("Invoking re-exec %s", targetBin)
 	return syscall.Exec(targetBin, newArgv, newEnv)
+}
+
+// regexRhelSuffix matches RHEL-versioned binary suffixes like ".rhel8", ".rhel9", ".rhel10"
+// The regex ensures we only match the specific pattern and not similar-looking files
+// like ".backup8" or ".test9"
+var regexRhelSuffix = regexp.MustCompile(`^\.rhel(\d+)$`)
+
+// getVersionedBinarySuffixes discovers available versioned binaries by globbing the filesystem.
+// For a base path like "/usr/bin/machine-config-daemon*", it finds files like:
+// - /usr/bin/machine-config-daemon.rhel8
+// - /usr/bin/machine-config-daemon.rhel9
+// Returns a map of version number (e.g., 8, 9) to suffix (e.g., ".rhel8", ".rhel9")
+// Only files matching the exact pattern ".rhel<N>" are recognized.
+func getVersionedBinarySuffixes(basePath string) (map[int]string, error) {
+	result := map[int]string{}
+	matches, err := filepath.Glob(basePath)
+	if err != nil {
+		return nil, err
+	}
+	for _, match := range matches {
+		extension := filepath.Ext(match)
+		if extension == "" {
+			continue
+		}
+
+		// Only accept files with the exact ".rhel<N>" pattern
+		submatches := regexRhelSuffix.FindStringSubmatch(extension)
+		if submatches == nil {
+			// Skip files that don't match the pattern (e.g., .backup8, .test9)
+			continue
+		}
+
+		// submatches[1] contains the captured digit group
+		version, err := strconv.Atoi(submatches[1])
+		if err != nil {
+			return nil, err
+		}
+		result[version] = extension
+	}
+	return result, nil
 }
 
 // worker runs a worker thread that just dequeues items, processes them, and marks them done.


### PR DESCRIPTION
Refactor the ReexecuteForTargetRoot function to automatically discover and select versioned binaries instead of hardcoding version checks.

Previously, the code used a switch statement with hardcoded RHEL version pairs (e.g., RHEL10→RHEL9). This required code changes every time a new RHEL major version was released.

Now, the code dynamically discovers available versioned binaries (e.g., machine-config-daemon.rhel8, .rhel9, .rhel10) using filesystem globbing and automatically selects the appropriate one based on numeric comparison.

This approach:
- Eliminates the need for code changes when RHEL 11/12/etc. are released
- Handles all current and future version combinations automatically
- Is cleaner and more maintainable

Implementation:
- Added getVersionedBinarySuffixes() helper that uses filepath.Glob to discover binaries matching the pattern /usr/bin/machine-config-daemon*
- Uses regex to extract version numbers from file extensions
- Returns a map of version→suffix for easy lookup
- Added comprehensive unit tests

Addresses tech debt from PR #<rhel10-compatible> where this refactor was deferred due to time constraints during soft freeze.

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility when re-executing operations across different RHEL major versions.
  - The system now selects the daemon version matching the target environment, including when the running container uses a newer release.
  - Added reliable discovery of compatible versioned binaries and validation of their RHEL versions.
  - Re-execution now stops safely when a compatible binary is unavailable or cannot be identified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->