### PR TITLE
OCPBUGS-121959: Make NIC persistence unconditional instead of version-specific

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1986,10 +1986,18 @@ func removeIgnitionArtifacts() error {
 	return nil
 }
 
-// PersistNetworkInterfaces runs if the host is RHEL8 or RHEL9, which can happen
-// when scaling up older bootimages and targeting newer RHEL versions.  In this case,
-// we may want to pin NIC interface names that reference static IP addresses.
+// PersistNetworkInterfaces persists NIC device names across RHEL version transitions.
+// NIC device names can change between RHEL major versions (e.g., RHEL8→9, RHEL9→10),
+// which can break static network configurations. This function ensures consistent
+// NIC naming by persisting interface names for all RHEL-like systems.
+//
+// Rather than treating each RHEL version transition as a special case requiring
+// code updates, we now persist NIC names unconditionally for all RHEL-like systems.
+// This simplifies the logic and eliminates the need to update this code for future
+// RHEL releases (RHEL11, RHEL12, etc.).
+//
 // More information:
+//   - RHEL 8→9 transition: https://issues.redhat.com/browse/OCPBUGS-10787
 //   - RHEL 9→10 transition: https://issues.redhat.com/browse/OCPBUGS-63593
 func PersistNetworkInterfaces(osRoot string) error {
 	hostos, err := osrelease.GetHostRunningOSFromRoot(osRoot)
@@ -1997,22 +2005,17 @@ func PersistNetworkInterfaces(osRoot string) error {
 		return fmt.Errorf("checking operating system: %w", err)
 	}
 
+	// Only handle RHEL-like systems; Fedora-level updates are expected to
+	// handle this automatically via host updates.
+	if !hostos.IsLikeRHEL() {
+		return nil
+	}
+
 	nmstateBinary := "/usr/bin/nmstatectl"
 	// If we're already chrooted into the host / in the MCD case, then we
 	// need to find the binary in our saved copy of /usr/bin from the host.
 	if osRoot == "/" {
 		nmstateBinary = filepath.Join(originalContainerBin, "nmstatectl")
-	}
-
-	// For the moment, we only look at RHEL-like systems...this logic isn't
-	// yet aiming to try to handle Fedora-level updates.  For that, most
-	// likely this NIC pinning should actually be driven automatically by
-	// host updates.  If you change this, you'll need to change the conditions
-	// below too.
-	persisting := hostos.IsEL9()
-	cleanup := hostos.IsEL10()
-	if !(persisting || cleanup) {
-		return nil
 	}
 
 	tmpKargs, err := os.CreateTemp("", "nmstate-kargs")
@@ -2023,30 +2026,15 @@ func PersistNetworkInterfaces(osRoot string) error {
 
 	cmd := exec.Command(nmstateBinary, "persist-nic-names", "--root", osRoot, "--kargs-out", tmpKargs.Name())
 
-	switch {
-	case persisting:
-		if hostos.IsEL9() {
-			klog.Info("Persisting NIC names for RHEL9 host system (RHEL9→10 transition)")
-		}
-	case cleanup:
-		klog.Info("Cleaning up NIC name persistence for RHEL10 host system")
-		cmd.Args = append(cmd.Args, "--cleanup")
-	default:
-		return fmt.Errorf("unexpected host OS %s", hostos.ToPrometheusLabel())
-	}
+	// Log which RHEL version we're persisting for (informational only)
+	majorVersion := hostos.BaseVersionMajor()
+	klog.Infof("Persisting NIC names for RHEL%d host system", majorVersion)
 
 	// nmstate always logs to stderr, so we need to capture/forward that too
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	klog.Infof("Running: %s", strings.Join(cmd.Args, " "))
 	if err := cmd.Run(); err != nil {
-		if cleanup {
-			// nmstatectl clean up will fail if stamp file not
-			// found or `ROOT/etc/systemd/network` folder not
-			// found, these error is OK to ignore
-			klog.Infof("Cleanup error ignored: %v", err)
-			return nil
-		}
 		return fmt.Errorf("failed to run nmstatectl: %w", err)
 	}
 
@@ -2060,18 +2048,10 @@ func PersistNetworkInterfaces(osRoot string) error {
 	}
 	kargs := strings.Split(string(kargsBuf), " ")
 
+	// Append the kernel arguments to persist NIC names
 	var rpmOstreeArgs []string
-	switch {
-	case persisting:
-		for _, karg := range kargs {
-			rpmOstreeArgs = append(rpmOstreeArgs, "--append", karg)
-		}
-	case cleanup:
-		for _, karg := range kargs {
-			rpmOstreeArgs = append(rpmOstreeArgs, "--remove", karg)
-		}
-	default:
-		return fmt.Errorf("unexpected host OS %s", hostos.ToPrometheusLabel())
+	for _, karg := range kargs {
+		rpmOstreeArgs = append(rpmOstreeArgs, "--append", karg)
 	}
 
 	if osRoot != "/" {


### PR DESCRIPTION
Simplify NIC persistence logic by removing version-specific conditionals and making it run unconditionally for all RHEL-like systems.

Previously, the code treated each RHEL version transition (8→9, 9→10) as a special case, requiring code updates for each new RHEL release. This meant we would need to keep adding conditions like `|| hostos.IsEL10()`, `|| hostos.IsEL11()`, etc.

Colin Walters correctly identified that what we're really doing is "freezing NIC names by default effectively" and suggested making this behavior unconditional rather than continually extending the conditional for each new RHEL release.

Changes:
- Remove version-specific `persisting` and `cleanup` logic
- Persist NIC names unconditionally for all RHEL-like systems
- Remove cleanup mode (RHEL10+) - persistence is now the default behavior
- Simplify code by removing switch statements and special cases
- Update documentation to reflect the new unconditional approach

Benefits:
- No code changes needed for future RHEL versions (11, 12, etc.)
- Simpler, more maintainable code
- Consistent behavior across all RHEL versions
- Future-proof solution

Addresses feedback from cgwalters on PR #5406:
https://github.com/openshift/machine-config-operator/pull/5406#discussion_r1877159393

Related:
- OCPBUGS-10787: RHEL 8→9 NIC naming transition
- OCPBUGS-63593: RHEL 9→10 NIC naming transition

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
