### PR TITLE
NO-ISSUE: Add OKD to the deletion manifest feature set

### DIFF
--- a/install/0000_90_machine-config_90_deletion.yaml
+++ b/install/0000_90_machine-config_90_deletion.yaml
@@ -26,7 +26,7 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-set: Default
+    release.openshift.io/feature-set: Default,OKD
     release.openshift.io/delete: "true"
 ---
 apiVersion: v1
@@ -38,7 +38,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
-    release.openshift.io/feature-set: Default
+    release.openshift.io/feature-set: Default,OKD
     release.openshift.io/delete: "true"
 ---
 apiVersion: monitoring.coreos.com/v1
@@ -51,5 +51,5 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-set: Default
+    release.openshift.io/feature-set: Default,OKD
     release.openshift.io/delete: "true"


### PR DESCRIPTION
**- What I did**

Added `OKD` to the `release.openshift.io/feature-set` annotation (`Default,OKD`) of the three stale-object deletion entries.

**- How to verify it**

- Create a cluster running 4.20 or earlier and verify the Service/ServiceMonitor machine-config-operator objects exist.
- Upgrade the cluster to a release built from this PR (4.21 or later), then confirm the stale objects are deleted and the TargetDown alert clears.

**- Description for the changelog**

Make the stale-resource deletion manifests apply to OKD as well as Default clusters so upgraded OKD clusters stop keeping the obsolete machine-config-operator Service/ServiceMonitor, which caused a perpetual TargetDown alert.


Related: okd-project/okd#2303, #5593

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration**
  * Updated machine configuration cleanup, service, and monitoring resources to support both the Default and OKD feature sets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->