### PR TITLE
OCPBUGS-115002: Remove BootImageSkewEnforcement references to gate component from MCO

### DIFF
--- a/pkg/controller/bootimage/boot_image_controller.go
+++ b/pkg/controller/bootimage/boot_image_controller.go
@@ -473,10 +473,8 @@ func (ctrl *Controller) updateMachineConfiguration(oldMC, newMC interface{}) {
 	}
 
 	// Skip reconciliation if neither ManagedBootImagesStatus nor BootImageSkewEnforcementStatus has changed.
-	// BootImageSkewEnforcementStatus is only checked when the BootImageSkewEnforcement feature gate is enabled.
 	if reflect.DeepEqual(oldMachineConfiguration.Status.ManagedBootImagesStatus, newMachineConfiguration.Status.ManagedBootImagesStatus) &&
-		(!ctrl.fgHandler.Enabled(features.FeatureGateBootImageSkewEnforcement) ||
-			reflect.DeepEqual(oldMachineConfiguration.Status.BootImageSkewEnforcementStatus, newMachineConfiguration.Status.BootImageSkewEnforcementStatus)) {
+		reflect.DeepEqual(oldMachineConfiguration.Status.BootImageSkewEnforcementStatus, newMachineConfiguration.Status.BootImageSkewEnforcementStatus) {
 		return
 	}
 

--- a/pkg/controller/bootimage/ms_helpers.go
+++ b/pkg/controller/bootimage/ms_helpers.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	osconfigv1 "github.com/openshift/api/config/v1"
-	"github.com/openshift/api/features"
 	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
 	opv1 "github.com/openshift/api/operator/v1"
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
@@ -116,21 +115,19 @@ func (ctrl *Controller) syncMAPIMachineSets(reason string) {
 	}
 	// Update/Clear degrade conditions based on errors from this loop
 	ctrl.updateConditions(reason, kubeErrs.NewAggregate(syncErrors), opv1.MachineConfigurationBootImageUpdateDegraded)
-	if ctrl.fgHandler.Enabled(features.FeatureGateBootImageSkewEnforcement) {
-		switch {
-		case ctrl.mapiStats.skippedCount == 0 && len(syncErrors) == 0:
-			// All MachineSets reconciled cleanly — record the current OCP version.
-			ctrl.updateClusterBootImage(rhcosVersion)
-		case ctrl.mapiStats.skippedCount > 0 && len(syncErrors) == 0:
-			// One or more MachineSets were reconcileSkipped without an error. The existing
-			// ClusterBootImageAutomatic value is no longer trustworthy (a new or changed
-			// MachineSet may be running an older image), so reset it to the cluster install
-			// version to ensure the skew check surfaces a violation if warranted.
-			ctrl.resetClusterBootImage()
-		}
-		// Errors (syncErrors > 0) are already surfaced via the Degraded condition, which
-		// checkBootImageControllerReady checks first — no boot image record update needed.
+	switch {
+	case ctrl.mapiStats.skippedCount == 0 && len(syncErrors) == 0:
+		// All MachineSets reconciled cleanly — record the current OCP version.
+		ctrl.updateClusterBootImage(rhcosVersion)
+	case ctrl.mapiStats.skippedCount > 0 && len(syncErrors) == 0:
+		// One or more MachineSets were reconcileSkipped without an error. The existing
+		// ClusterBootImageAutomatic value is no longer trustworthy (a new or changed
+		// MachineSet may be running an older image), so reset it to the cluster install
+		// version to ensure the skew check surfaces a violation if warranted.
+		ctrl.resetClusterBootImage()
 	}
+	// Errors (syncErrors > 0) are already surfaced via the Degraded condition, which
+	// checkBootImageControllerReady checks first — no boot image record update needed.
 }
 
 // syncMAPIMachineSet will attempt to reconcile the provided machineset.

--- a/pkg/controller/node/node_controller.go
+++ b/pkg/controller/node/node_controller.go
@@ -2107,20 +2107,12 @@ func (ctrl *Controller) syncMetrics() error {
 
 // addMachineConfiguration handles MachineConfiguration add events to update the boot image skew enforcement metric.
 func (ctrl *Controller) addMachineConfiguration(obj any) {
-	if ctrl.fgHandler == nil || !ctrl.fgHandler.Enabled(features.FeatureGateBootImageSkewEnforcement) {
-		return
-	}
-
 	ctrl.syncBootImageSkewEnforcementMetric(obj)
 }
 
 // updateMachineConfiguration handles MachineConfiguration update events to update the boot image skew enforcement metric.
 // Only takes action if BootImageSkewEnforcementStatus has changed.
 func (ctrl *Controller) updateMachineConfiguration(old, cur any) {
-	if ctrl.fgHandler == nil || !ctrl.fgHandler.Enabled(features.FeatureGateBootImageSkewEnforcement) {
-		return
-	}
-
 	oldMCOP, ok := old.(*opv1.MachineConfiguration)
 	if !ok {
 		return
@@ -2140,10 +2132,6 @@ func (ctrl *Controller) updateMachineConfiguration(old, cur any) {
 
 // deleteMachineConfiguration handles MachineConfiguration delete events to reset the boot image skew enforcement metric.
 func (ctrl *Controller) deleteMachineConfiguration(_ any) {
-	if ctrl.fgHandler == nil || !ctrl.fgHandler.Enabled(features.FeatureGateBootImageSkewEnforcement) {
-		return
-	}
-
 	// Reset metric to 0 when MachineConfiguration is deleted
 	ctrlcommon.MCCBootImageSkewEnforcementNone.Set(0)
 }

--- a/pkg/operator/status.go
+++ b/pkg/operator/status.go
@@ -11,7 +11,6 @@ import (
 	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
 
 	configv1 "github.com/openshift/api/config/v1"
-	features "github.com/openshift/api/features"
 	opv1 "github.com/openshift/api/operator/v1"
 	cov1helpers "github.com/openshift/library-go/pkg/config/clusteroperator/v1helpers"
 	corev1 "k8s.io/api/core/v1"
@@ -676,11 +675,6 @@ func checkBootImageControllerReady(mcop *opv1.MachineConfiguration) (bool, error
 // It returns an error if there is no skew enforcement opinion specified. If one is specified,
 // it checks if boot image skew is within the expected limit.
 func (optr *Operator) checkBootImageSkewUpgradeableGuard() (bool, string, error) {
-	// Check if feature gate is enabled
-	if !optr.fgHandler.Enabled(features.FeatureGateBootImageSkewEnforcement) {
-		return false, "", nil
-	}
-
 	// Fetch MachineConfiguration
 	mcop, err := optr.mcopLister.Get(ctrlcommon.MCOOperatorKnobsObjectName)
 	if err != nil {

--- a/pkg/operator/status_test.go
+++ b/pkg/operator/status_test.go
@@ -20,7 +20,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/uuid"
 
 	configv1 "github.com/openshift/api/config/v1"
-	features "github.com/openshift/api/features"
 	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
 	opv1 "github.com/openshift/api/operator/v1"
 	fakeconfigclientset "github.com/openshift/client-go/config/clientset/versioned/fake"
@@ -642,6 +641,12 @@ func TestOperatorSyncStatus(t *testing.T) {
 			},
 		}
 
+		mcopIndexer := cache.NewIndexer(
+			cache.MetaNamespaceKeyFunc,
+			cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+		)
+		optr.mcopLister = mcoplistersv1.NewMachineConfigurationLister(mcopIndexer)
+
 		nodeIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 		optr.nodeLister = corelisterv1.NewNodeLister(nodeIndexer)
 		nodeIndexer.Add(&corev1.Node{
@@ -732,6 +737,13 @@ func TestInClusterBringUpStayOnErr(t *testing.T) {
 			helpers.NewMachineConfigPool("workers", nil, helpers.WorkerSelector, "v0"),
 		},
 	}
+
+	mcopIndexer := cache.NewIndexer(
+		cache.MetaNamespaceKeyFunc,
+		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+	)
+	optr.mcopLister = mcoplistersv1.NewMachineConfigurationLister(mcopIndexer)
+
 	nodeIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 	optr.nodeLister = corelisterv1.NewNodeLister(nodeIndexer)
 	nodeIndexer.Add(&corev1.Node{
@@ -793,7 +805,6 @@ func TestInClusterBringUpStayOnErr(t *testing.T) {
 func TestCheckBootImageSkewUpgradeableGuard(t *testing.T) {
 	tests := []struct {
 		name               string
-		featureGateEnabled bool
 		mcop               *opv1.MachineConfiguration
 		mcopNotFound       bool
 		mcopGetError       error
@@ -803,24 +814,14 @@ func TestCheckBootImageSkewUpgradeableGuard(t *testing.T) {
 		expectError        bool
 	}{
 		{
-			name:               "feature gate disabled",
-			featureGateEnabled: false,
-			mcop:               nil,
-			expectUpgradeBlock: false,
-			expectMessage:      "",
-			expectError:        false,
-		},
-		{
 			name:               "MachineConfiguration not found",
-			featureGateEnabled: true,
 			mcopNotFound:       true,
 			expectUpgradeBlock: false,
 			expectMessage:      "",
 			expectError:        false,
 		},
 		{
-			name:               "mode is None",
-			featureGateEnabled: true,
+			name: "mode is None",
 			mcop: &opv1.MachineConfiguration{
 				ObjectMeta: metav1.ObjectMeta{Name: ctrlcommon.MCOOperatorKnobsObjectName},
 				Status: opv1.MachineConfigurationStatus{
@@ -834,8 +835,7 @@ func TestCheckBootImageSkewUpgradeableGuard(t *testing.T) {
 			expectError:        false,
 		},
 		{
-			name:               "mode is unset",
-			featureGateEnabled: true,
+			name: "mode is unset",
 			mcop: &opv1.MachineConfiguration{
 				ObjectMeta: metav1.ObjectMeta{Name: ctrlcommon.MCOOperatorKnobsObjectName},
 				Status: opv1.MachineConfigurationStatus{
@@ -850,8 +850,7 @@ func TestCheckBootImageSkewUpgradeableGuard(t *testing.T) {
 		},
 		// Boot image controller readiness tests
 		{
-			name:               "boot image controller is degraded in Automatic mode",
-			featureGateEnabled: true,
+			name: "boot image controller is degraded in Automatic mode",
 			mcop: &opv1.MachineConfiguration{
 				ObjectMeta: metav1.ObjectMeta{Name: ctrlcommon.MCOOperatorKnobsObjectName},
 				Status: opv1.MachineConfigurationStatus{
@@ -875,8 +874,7 @@ func TestCheckBootImageSkewUpgradeableGuard(t *testing.T) {
 			expectError:        false,
 		},
 		{
-			name:               "boot image controller is progressing in Automatic mode",
-			featureGateEnabled: true,
+			name: "boot image controller is progressing in Automatic mode",
 			mcop: &opv1.MachineConfiguration{
 				ObjectMeta: metav1.ObjectMeta{Name: ctrlcommon.MCOOperatorKnobsObjectName},
 				Status: opv1.MachineConfigurationStatus{
@@ -899,8 +897,7 @@ func TestCheckBootImageSkewUpgradeableGuard(t *testing.T) {
 			expectError:        false,
 		},
 		{
-			name:               "boot image controller hasn't completed first pass in Automatic mode",
-			featureGateEnabled: true,
+			name: "boot image controller hasn't completed first pass in Automatic mode",
 			mcop: &opv1.MachineConfiguration{
 				ObjectMeta: metav1.ObjectMeta{Name: ctrlcommon.MCOOperatorKnobsObjectName},
 				Status: opv1.MachineConfigurationStatus{
@@ -919,8 +916,7 @@ func TestCheckBootImageSkewUpgradeableGuard(t *testing.T) {
 		},
 		// OCP version tests in automatic mode
 		{
-			name:               "mode is Automatic with OCP version within limit",
-			featureGateEnabled: true,
+			name: "mode is Automatic with OCP version within limit",
 			mcop: &opv1.MachineConfiguration{
 				ObjectMeta: metav1.ObjectMeta{Name: ctrlcommon.MCOOperatorKnobsObjectName},
 				Status: opv1.MachineConfigurationStatus{
@@ -943,8 +939,7 @@ func TestCheckBootImageSkewUpgradeableGuard(t *testing.T) {
 			expectError:        false,
 		},
 		{
-			name:               "mode is Automatic with OCP version below limit",
-			featureGateEnabled: true,
+			name: "mode is Automatic with OCP version below limit",
 			// History spans 4.12 (install) through 4.22 (current upgrade in progress),
 			// reflecting a cluster that never updated its boot images across many upgrades.
 			clusterVersion: buildClusterVersionWithMultipleHistory("4.22.0", "4.21.0", "4.20.0", "4.19.0", "4.18.0", "4.17.0", "4.16.0", "4.15.0", "4.14.0", "4.13.0", "4.12.0"),
@@ -970,8 +965,7 @@ func TestCheckBootImageSkewUpgradeableGuard(t *testing.T) {
 			expectError:        false,
 		},
 		{
-			name:               "mode is Automatic with OCP version below limit and no ClusterVersion",
-			featureGateEnabled: true,
+			name: "mode is Automatic with OCP version below limit and no ClusterVersion",
 			// No clusterVersion set — getCurrentOCPVersionFromClusterVersion returns "", docs URL falls back to "latest".
 			mcop: &opv1.MachineConfiguration{
 				ObjectMeta: metav1.ObjectMeta{Name: ctrlcommon.MCOOperatorKnobsObjectName},
@@ -996,8 +990,7 @@ func TestCheckBootImageSkewUpgradeableGuard(t *testing.T) {
 		},
 		// OCP version tests in manual mode
 		{
-			name:               "mode is Manual with OCP version within limit",
-			featureGateEnabled: true,
+			name: "mode is Manual with OCP version within limit",
 			mcop: &opv1.MachineConfiguration{
 				ObjectMeta: metav1.ObjectMeta{Name: ctrlcommon.MCOOperatorKnobsObjectName},
 				Status: opv1.MachineConfigurationStatus{
@@ -1015,8 +1008,7 @@ func TestCheckBootImageSkewUpgradeableGuard(t *testing.T) {
 			expectError:        false,
 		},
 		{
-			name:               "mode is Manual with OCP version below limit",
-			featureGateEnabled: true,
+			name: "mode is Manual with OCP version below limit",
 			// History spans 4.10 (install) through 4.22 (current upgrade in progress),
 			// reflecting a cluster that never updated its boot images across many upgrades.
 			clusterVersion: buildClusterVersionWithMultipleHistory("4.22.0", "4.21.0", "4.20.0", "4.19.0", "4.18.0", "4.17.0", "4.16.0", "4.15.0", "4.14.0", "4.13.0", "4.12.0", "4.11.0", "4.10.0"),
@@ -1037,8 +1029,7 @@ func TestCheckBootImageSkewUpgradeableGuard(t *testing.T) {
 			expectError:        false,
 		},
 		{
-			name:               "mode is Automatic with exact minimum OCP version",
-			featureGateEnabled: true,
+			name: "mode is Automatic with exact minimum OCP version",
 			mcop: &opv1.MachineConfiguration{
 				ObjectMeta: metav1.ObjectMeta{Name: ctrlcommon.MCOOperatorKnobsObjectName},
 				Status: opv1.MachineConfigurationStatus{
@@ -1062,8 +1053,7 @@ func TestCheckBootImageSkewUpgradeableGuard(t *testing.T) {
 		},
 		// RHCOS version tests in Automatic mode
 		{
-			name:               "mode is Automatic with modern RHCOS version within limit",
-			featureGateEnabled: true,
+			name: "mode is Automatic with modern RHCOS version within limit",
 			mcop: &opv1.MachineConfiguration{
 				ObjectMeta: metav1.ObjectMeta{Name: ctrlcommon.MCOOperatorKnobsObjectName},
 				Status: opv1.MachineConfigurationStatus{
@@ -1086,8 +1076,7 @@ func TestCheckBootImageSkewUpgradeableGuard(t *testing.T) {
 			expectError:        false,
 		},
 		{
-			name:               "mode is Automatic with modern RHCOS version below limit",
-			featureGateEnabled: true,
+			name: "mode is Automatic with modern RHCOS version below limit",
 			// RHEL 9 boot images were introduced in 4.13; history spans from there to 4.22.
 			clusterVersion: buildClusterVersionWithMultipleHistory("4.22.0", "4.21.0", "4.20.0", "4.19.0", "4.18.0", "4.17.0", "4.16.0", "4.15.0", "4.14.0", "4.13.0"),
 			mcop: &opv1.MachineConfiguration{
@@ -1112,8 +1101,7 @@ func TestCheckBootImageSkewUpgradeableGuard(t *testing.T) {
 			expectError:        false,
 		},
 		{
-			name:               "mode is Automatic with legacy RHCOS version within limit",
-			featureGateEnabled: true,
+			name: "mode is Automatic with legacy RHCOS version within limit",
 			mcop: &opv1.MachineConfiguration{
 				ObjectMeta: metav1.ObjectMeta{Name: ctrlcommon.MCOOperatorKnobsObjectName},
 				Status: opv1.MachineConfigurationStatus{
@@ -1136,8 +1124,7 @@ func TestCheckBootImageSkewUpgradeableGuard(t *testing.T) {
 			expectError:        false,
 		},
 		{
-			name:               "mode is Automatic with legacy RHCOS version below limit",
-			featureGateEnabled: true,
+			name: "mode is Automatic with legacy RHCOS version below limit",
 			// Legacy RHEL 8 (411.x) boot images originate from 4.11; history spans from there to 4.22.
 			clusterVersion: buildClusterVersionWithMultipleHistory("4.22.0", "4.21.0", "4.20.0", "4.19.0", "4.18.0", "4.17.0", "4.16.0", "4.15.0", "4.14.0", "4.13.0", "4.12.0", "4.11.0"),
 			mcop: &opv1.MachineConfiguration{
@@ -1163,8 +1150,7 @@ func TestCheckBootImageSkewUpgradeableGuard(t *testing.T) {
 		},
 
 		{
-			name:               "mode is Automatic with exact minimum RHCOS version",
-			featureGateEnabled: true,
+			name: "mode is Automatic with exact minimum RHCOS version",
 			mcop: &opv1.MachineConfiguration{
 				ObjectMeta: metav1.ObjectMeta{Name: ctrlcommon.MCOOperatorKnobsObjectName},
 				Status: opv1.MachineConfigurationStatus{
@@ -1188,8 +1174,7 @@ func TestCheckBootImageSkewUpgradeableGuard(t *testing.T) {
 		},
 		// RHCOS version tests in manual mode
 		{
-			name:               "mode is Manual with modern RHCOS version within limit",
-			featureGateEnabled: true,
+			name: "mode is Manual with modern RHCOS version within limit",
 			mcop: &opv1.MachineConfiguration{
 				ObjectMeta: metav1.ObjectMeta{Name: ctrlcommon.MCOOperatorKnobsObjectName},
 				Status: opv1.MachineConfigurationStatus{
@@ -1207,8 +1192,7 @@ func TestCheckBootImageSkewUpgradeableGuard(t *testing.T) {
 			expectError:        false,
 		},
 		{
-			name:               "mode is Manual with modern RHCOS version below limit",
-			featureGateEnabled: true,
+			name: "mode is Manual with modern RHCOS version below limit",
 			// RHEL 9 boot images were introduced in 4.13; history spans from there to 4.22.
 			clusterVersion: buildClusterVersionWithMultipleHistory("4.22.0", "4.21.0", "4.20.0", "4.19.0", "4.18.0", "4.17.0", "4.16.0", "4.15.0", "4.14.0", "4.13.0"),
 			mcop: &opv1.MachineConfiguration{
@@ -1228,8 +1212,7 @@ func TestCheckBootImageSkewUpgradeableGuard(t *testing.T) {
 			expectError:        false,
 		},
 		{
-			name:               "mode is Manual with legacy RHCOS version within limit",
-			featureGateEnabled: true,
+			name: "mode is Manual with legacy RHCOS version within limit",
 			mcop: &opv1.MachineConfiguration{
 				ObjectMeta: metav1.ObjectMeta{Name: ctrlcommon.MCOOperatorKnobsObjectName},
 				Status: opv1.MachineConfigurationStatus{
@@ -1247,8 +1230,7 @@ func TestCheckBootImageSkewUpgradeableGuard(t *testing.T) {
 			expectError:        false,
 		},
 		{
-			name:               "mode is Manual with legacy RHCOS version below limit",
-			featureGateEnabled: true,
+			name: "mode is Manual with legacy RHCOS version below limit",
 			// Legacy RHEL 8 (411.x) boot images originate from 4.11; history spans from there to 4.22.
 			clusterVersion: buildClusterVersionWithMultipleHistory("4.22.0", "4.21.0", "4.20.0", "4.19.0", "4.18.0", "4.17.0", "4.16.0", "4.15.0", "4.14.0", "4.13.0", "4.12.0", "4.11.0"),
 			mcop: &opv1.MachineConfiguration{
@@ -1268,8 +1250,7 @@ func TestCheckBootImageSkewUpgradeableGuard(t *testing.T) {
 			expectError:        false,
 		},
 		{
-			name:               "mode is manual with exact minimum RHCOS version",
-			featureGateEnabled: true,
+			name: "mode is manual with exact minimum RHCOS version",
 			mcop: &opv1.MachineConfiguration{
 				ObjectMeta: metav1.ObjectMeta{Name: ctrlcommon.MCOOperatorKnobsObjectName},
 				Status: opv1.MachineConfigurationStatus{
@@ -1292,9 +1273,6 @@ func TestCheckBootImageSkewUpgradeableGuard(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			// Set up feature gate handler
 			enabledFeatures := []configv1.FeatureGateName{}
-			if tc.featureGateEnabled {
-				enabledFeatures = append(enabledFeatures, features.FeatureGateBootImageSkewEnforcement)
-			}
 			fgHandler := ctrlcommon.NewFeatureGatesHardcodedHandler(enabledFeatures, []configv1.FeatureGateName{})
 
 			// Set up mcopLister

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -2579,10 +2579,6 @@ func (optr *Operator) syncPreBuiltImageMachineConfigs() error {
 // syncBootImageSkewEnforcementStatus determines the appropriate BootImageSkewEnforcementStatus based on
 // the MachineConfiguration spec, platform defaults, and cluster version information.
 func (optr *Operator) syncBootImageSkewEnforcementStatus(mcop *opv1.MachineConfiguration, newMachineConfigurationStatus *opv1.MachineConfigurationStatus, infra *configv1.Infrastructure, supportsBootImageUpdates bool) {
-	if !optr.fgHandler.Enabled(features.FeatureGateBootImageSkewEnforcement) {
-		return
-	}
-
 	// Grab install time OCP version
 	ocpVersionAtInstall := optr.getOCPInstallVersion()
 

--- a/pkg/operator/sync_test.go
+++ b/pkg/operator/sync_test.go
@@ -801,7 +801,7 @@ func TestSyncMachineConfiguration(t *testing.T) {
 				clusterVersionIndexer.Add(tc.clusterVersion)
 			}
 
-			enabledFeatureGates := []configv1.FeatureGateName{features.FeatureGateBootImageSkewEnforcement}
+			enabledFeatureGates := []configv1.FeatureGateName{}
 			if tc.enableCPMSFeatureGate {
 				enabledFeatureGates = append(enabledFeatureGates, features.FeatureGateManagedBootImagesCPMS)
 			}


### PR DESCRIPTION
As part of OCPBUGS-105412, this issue has meant to remove BootImageSkewEnforcement as part of default feature gate

**- What I did**
- Removed all feature gates checks related to BootImageSkewEnforcement feature gate
- Updated unit tests to be compliant to the FG default removal

**- How to verify it**
- All existing unit-tests should continue to pass
- All existing e2e-tests should continue to pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Boot image skew enforcement status is now evaluated and synchronized consistently, regardless of feature-gate configuration.
  - Changes to boot image skew settings now reliably trigger reconciliation.
  - Cluster boot image records and related monitoring metrics now stay synchronized with reconciliation results.
  - Operator status reporting now evaluates boot image skew conditions without requiring the feature gate to be enabled.
  - Updated validation coverage confirms consistent behavior when the feature gate is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->