### PR TITLE
OCPBUGS-121353: Pass missing proxy vars to bootstrap MCC

### DIFF
--- a/manifests/bootstrap-pod-v2.yaml
+++ b/manifests/bootstrap-pod-v2.yaml
@@ -24,6 +24,21 @@ spec:
       privileged: true
       readOnlyRootFilesystem: false
     terminationMessagePolicy: FallbackToLogsOnError
+    {{if .ControllerConfig.Proxy}}
+    env:
+    {{if .ControllerConfig.Proxy.HTTPProxy}}
+    - name: HTTP_PROXY
+      value: {{.ControllerConfig.Proxy.HTTPProxy}}
+    {{end}}
+    {{if .ControllerConfig.Proxy.HTTPSProxy}}
+    - name: HTTPS_PROXY
+      value: {{.ControllerConfig.Proxy.HTTPSProxy}}
+    {{end}}
+    {{if .ControllerConfig.Proxy.NoProxy}}
+    - name: NO_PROXY
+      value: "{{.ControllerConfig.Proxy.NoProxy}}"
+    {{end}}
+    {{end}}
     volumeMounts:
     - name: bootstrap-manifests
       mountPath: /etc/mcc/bootstrap

--- a/pkg/operator/render_test.go
+++ b/pkg/operator/render_test.go
@@ -321,6 +321,29 @@ func TestRenderAsset(t *testing.T) {
 				"--payload-version=4.8.0-rc.0",
 			},
 		},
+		{
+			// Test that bootstrap MCC pod is rendered correctly with proxy config
+			Path: "manifests/bootstrap-pod-v2.yaml",
+			RenderConfig: &renderConfig{
+				TargetNamespace: "testing-namespace",
+				ReleaseVersion:  "4.8.0-rc.0",
+				Images: &ctrlcommon.RenderConfigImages{
+					MachineConfigOperator: "mco-operator-image",
+				},
+				ControllerConfig: mcfgv1.ControllerConfigSpec{
+					Proxy: &configv1.ProxyStatus{
+						HTTPSProxy: "https://i.am.a.proxy.server",
+						NoProxy:    ".cluster.local",
+					},
+				},
+			},
+			FindExpected: []string{
+				"image: mco-operator-image",
+				"- name: HTTPS_PROXY\n      value: https://i.am.a.proxy.server",
+				"- name: NO_PROXY\n      value: \".cluster.local\"",
+				"--payload-version=4.8.0-rc.0",
+			},
+		},
 	}
 
 	for idx, test := range tests {


### PR DESCRIPTION
Closes: [#OCPBUGS-121353](https://redhat.atlassian.net/browse/OCPBUGS-121353)

**- What I did**

The previous workaround fix for NO_PROXY scenarios when pulling the images for OS Image Streams ([OCPBUGS-114709](https://github.com/openshift/machine-config-operator/pull/6424)) required all the executables to have the proper proxy env-vars set but the fix missed that the bootstrap MCC pod doesn't have the environment vars set.

**- How to verify it**

TBD

**- Description for the changelog**

Pass proxy environment variables to the MCC bootstrap pod too.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bootstrap components now support configured HTTP, HTTPS, and no-proxy settings.
  * Proxy settings are applied only when corresponding values are configured.
* **Tests**
  * Added coverage verifying proxy rendering, image details, release version, and quoted cluster-local exclusions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->