### PR TITLE
[release-4.19] OCPBUGS-122228: Update message for MachineOSBuildFailed condition

### DIFF
--- a/pkg/controller/build/imagebuilder/jobimagebuilder.go
+++ b/pkg/controller/build/imagebuilder/jobimagebuilder.go
@@ -12,6 +12,7 @@ import (
 	"github.com/openshift/machine-config-operator/pkg/controller/build/constants"
 	ctrlcommon "github.com/openshift/machine-config-operator/pkg/controller/common"
 	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
@@ -325,6 +326,34 @@ func (j *jobImageBuilder) validateBuilderType(builder buildrequest.Builder) erro
 	return fmt.Errorf("invalid type %T from builder, expected %T", j.builder, &batchv1.Job{})
 }
 
+// buildFailedConditionsFromJob returns MachineOSBuild failed conditions populated with the
+// failure reason and message from the job's Failed condition, falling back to generic values.
+func buildFailedConditionsFromJob(job *batchv1.Job) []metav1.Condition {
+	reason := "Failed"
+	message := "Build Failed"
+	for _, cond := range job.Status.Conditions {
+		if cond.Type == batchv1.JobFailed && cond.Status == corev1.ConditionTrue {
+			if cond.Reason != "" {
+				reason = cond.Reason
+			}
+			if cond.Message != "" {
+				message = cond.Message
+			}
+			break
+		}
+	}
+	message = fmt.Sprintf("Job %q failed after %d attempt(s): %s", job.Name, job.Status.Failed, message)
+	conditions := apihelpers.MachineOSBuildFailedConditions()
+	for i := range conditions {
+		if conditions[i].Type == string(mcfgv1.MachineOSBuildFailed) {
+			conditions[i].Reason = reason
+			conditions[i].Message = message
+			break
+		}
+	}
+	return conditions
+}
+
 // Maps a given batchv1.Job to a given MachineOSBuild status. Exported so that it can be used in e2e tests.
 func MapJobStatusToBuildStatus(job *batchv1.Job) (mcfgv1.BuildProgress, []metav1.Condition) {
 	// If the job is being deleted and it was not in either a successful or failed state
@@ -345,8 +374,7 @@ func MapJobStatusToBuildStatus(job *batchv1.Job) (mcfgv1.BuildProgress, []metav1
 	}
 	// Only return failed if there have been 4 pod failures as the backoffLimit is set to 3
 	if job.Status.Failed > constants.JobMaxRetries {
-		return mcfgv1.MachineOSBuildFailed, apihelpers.MachineOSBuildFailedConditions()
-
+		return mcfgv1.MachineOSBuildFailed, buildFailedConditionsFromJob(job)
 	}
 
 	return "", apihelpers.MachineOSBuildInitialConditions()


### PR DESCRIPTION
Closes: OCPBUGS-122228

**- What I did**
This is a manual backport for https://github.com/openshift/machine-config-operator/pull/6518.

**- How to verify it**
1. Launch a 4.19 cluster with this PR included.
2. Enable OCL in a pool with a MachineOSConfig that will cause a MachineOSBuild failure. I do this by setting `docker-password` to an invalid value in the following flow.
```
$ oc create secret docker-registry quay-push-secret \
    -n openshift-machine-config-operator \
    --docker-server=quay.io \
    --docker-username=<>
    --docker-password=<>
$ oc create -f - << EOF
apiVersion: machineconfiguration.openshift.io/v1
kind: MachineConfigPool
metadata:
 name: layered
spec:
 machineConfigSelector:
  matchExpressions:
   - {key: machineconfiguration.openshift.io/role, operator: In, values: [worker,layered]}
 nodeSelector:
  matchLabels:
   node-role.kubernetes.io/layered: ""
EOF
$ oc label node <node> node-role.kubernetes.io/layered=
$ oc apply -f - << EOF
apiVersion: machineconfiguration.openshift.io/v1
kind: MachineOSConfig
metadata:
  name: layered
spec:
  machineConfigPool:
    name: layered
  containerFile:
  - containerfileArch: NoArch
    content: |-
      FROM configs AS final
      RUN dnf install -y nmap && \
        dnf clean all && \
        bootc container lint
  imageBuilder:
    imageBuilderType: Job
  renderedImagePushSecret:
    name: quay-push-secret
  renderedImagePushSpec: "quay.io/<repo-path>:ocl-testing"
EOF
```
3. Once the MachineOSBuild fails, check that the `Message` field for the `Failed` condition is being set to a clear value.
```
$ oc describe machineosbuild layered-15f925a3dabd6139c709d8bb54ffb0bc
Name:         layered-15f925a3dabd6139c709d8bb54ffb0bc
...
Status:
...
  Conditions:
...
    Last Transition Time:  2026-09-10T17:24:56Z
    Message:               Job "build-layered-15f925a3dabd6139c709d8bb54ffb0bc" failed after 4 attempt(s): Job has reached the specified backoff limit
    Reason:                BackoffLimitExceeded
    Status:                True
    Type:                  Failed
```

**- Description for the changelog**
OCPBUGS-122228: Update message for MachineOSBuildFailed condition
