### PR TITLE
OCPBUGS-116491: Correctly handle MC deletion in image mode when no new build is required

### DIFF
--- a/pkg/controller/build/helpers.go
+++ b/pkg/controller/build/helpers.go
@@ -168,6 +168,14 @@ func isMachineOSBuildStatusUpdateNeeded(oldStatus, curStatus mcfgv1.MachineOSBui
 
 	// From {success, failure, interrupted} -> {success, failure, interrupted}
 	if oldState.IsInTerminalState() && curState.IsInTerminalState() {
+		// Allow the update when DigestedImagePushSpec changes: this is the image-reuse path where
+		// an existing successful MOSB is reassigned a new image (reuseImageForNewMOSB). Without this
+		// exception the MOSB's API state stays stale and node_controller's MachineOSBuildIsCurrent
+		// check always returns false, causing the MCP to hang in Updating indefinitely.
+		// See: https://redhat.atlassian.net/browse/OCPBUGS-116491
+		if oldStatus.DigestedImagePushSpec != curStatus.DigestedImagePushSpec {
+			return true, fmt.Sprintf("DigestedImagePushSpec updated in terminal state (%s)", curTerminalState)
+		}
 		return false, fmt.Sprintf("transitioned from terminal state (%s) -> terminal state (%s)", oldTerminalState, curTerminalState)
 	}
 

--- a/pkg/controller/build/helpers_test.go
+++ b/pkg/controller/build/helpers_test.go
@@ -200,6 +200,37 @@ func TestIsMachineOSBuildStatusUpdateNeeded(t *testing.T) {
 	}
 }
 
+func TestIsMachineOSBuildStatusUpdateNeededDigestedImagePushSpec(t *testing.T) {
+	t.Parallel()
+
+	succeeded := apihelpers.MachineOSBuildSucceededConditions()
+
+	// Terminal → Terminal with a changed DigestedImagePushSpec must be allowed
+	// (the image-reuse path reassigns a new image to an existing successful MOSB).
+	oldDifferent := mcfgv1.MachineOSBuildStatus{
+		Conditions:            succeeded,
+		DigestedImagePushSpec: "registry.example.com/image@sha256:aaa",
+	}
+	curDifferent := mcfgv1.MachineOSBuildStatus{
+		Conditions:            succeeded,
+		DigestedImagePushSpec: "registry.example.com/image@sha256:bbb",
+	}
+	result, reason := isMachineOSBuildStatusUpdateNeeded(oldDifferent, curDifferent)
+	assert.True(t, result, "expected update when DigestedImagePushSpec changes in terminal state: %s", reason)
+
+	// Terminal → Terminal with the same DigestedImagePushSpec must still be blocked.
+	oldSame := mcfgv1.MachineOSBuildStatus{
+		Conditions:            succeeded,
+		DigestedImagePushSpec: "registry.example.com/image@sha256:aaa",
+	}
+	curSame := mcfgv1.MachineOSBuildStatus{
+		Conditions:            succeeded,
+		DigestedImagePushSpec: "registry.example.com/image@sha256:aaa",
+	}
+	result2, reason2 := isMachineOSBuildStatusUpdateNeeded(oldSame, curSame)
+	assert.False(t, result2, "expected no update when DigestedImagePushSpec is unchanged in terminal state: %s", reason2)
+}
+
 func TestNeedsPreBuiltImageAnnotationCleanup(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Closes: OCPBUGS-116491

**- What I did**
This updates the `isMachineOSBuildStatusUpdateNeeded` helper to handle an edge case where an old MOSB should be used in a MC deletion not requiring a new image build.

**- How to verify it**

1. Launch a 5.1 cluster with this PR included.
```
launch 5.1.0-0.nightly-2026-09-09-023423,openshift/machine-config-operator#6528 gcp
```

2. Enable OCL in a custom MCP.
```
$ oc create -f - << EOF
apiVersion: machineconfiguration.openshift.io/v1
kind: MachineConfigPool
metadata:
 name: infra
spec:
 machineConfigSelector:
  matchExpressions:
   - {key: machineconfiguration.openshift.io/role, operator: In, values: [worker,infra]}
 nodeSelector:
  matchLabels:
   node-role.kubernetes.io/infra: ""
EOF
$ oc label node <node-name> node-role.kubernetes.io/infra=
$ oc create -f - << EOF
apiVersion: machineconfiguration.openshift.io/v1
kind: MachineOSConfig
metadata:
  name: infra
spec:
  machineConfigPool:
    name: infra
  imageBuilder:
    imageBuilderType: Job
  renderedImagePushSecret:
    name: $(oc get -n openshift-machine-config-operator sa builder -ojsonpath='{.secrets[0].name}')
  renderedImagePushSpec: "image-registry.openshift-image-registry.svc:5000/openshift-machine-config-operator/ocb-image:latest"
EOF
```

3. Apply a MC that requires a new image build (this example applies an extension). Wait for the MCP to become updated.
```
$ oc create -f - << EOF
apiVersion: machineconfiguration.openshift.io/v1
kind: MachineConfig
metadata:
  labels:
    machineconfiguration.openshift.io/role: infra 
  name: 80-infra-extensions
spec:
  config:
    ignition:
      version: 3.2.0
  extensions:
    - usbguard
EOF
```

4. Apply a MC that does not require a new image build. Wait for the MCP to become updated.
```
$ oc create -f - << EOF
apiVersion: machineconfiguration.openshift.io/v1
kind: MachineConfig
metadata:
  labels:
    machineconfiguration.openshift.io/role: infra 
  name: 99-infra-testfile
spec:
  config:
    ignition:
      version: 3.2.0
    storage:
      files:
      - contents:
          source: data:,hello%20world%0A
        mode: 420
        path: /home/core/test
EOF
```

5. Delete the MC from step 3 that requires a new image build. Wait for the MCP to become updated.
```
$ oc delete mc 80-infra-extensions
```

6. Delete the MC from step 4 that does not require a new image build. The MCP should successfully update after this MC removal. 
```
$ oc delete mc 99-infra-testfile
$ oc get mcp infra -w
NAME    CONFIG                                            UPDATED   UPDATING   DEGRADED   MACHINECOUNT   READYMACHINECOUNT   UPDATEDMACHINECOUNT   DEGRADEDMACHINECOUNT   AGE
infra   rendered-infra-37175a62b3ac75c91fc8cb3086d2938f   True      False      False      1              1                   1                     0                      54m
infra   rendered-infra-37175a62b3ac75c91fc8cb3086d2938f   False     True       False      1              0                   0                     0                      54m
infra   rendered-infra-37175a62b3ac75c91fc8cb3086d2938f   False     True       False      1              0                   0                     0                      54m
infra   rendered-infra-1b8dc81b8ceb0df5047f27a3b8977392   True      False      False      1              1                   1                     0                      56m
```

**- Description for the changelog**
OCPBUGS-116491: Correctly handle MC deletion in image mode when no new build is required


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Terminal builds now update correctly when the digested image push configuration changes, enabling image reuse for a new build.
  * Unchanged terminal build configurations continue to avoid unnecessary updates.

* **Tests**
  * Added regression coverage for terminal-to-terminal build status updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->