### PR TITLE
MCO-2570: remove poll methods

### DIFF
--- a/test/extended-priv/machineconfigpool.go
+++ b/test/extended-priv/machineconfigpool.go
@@ -236,25 +236,24 @@ func (mcp *MachineConfigPool) getUpdatedMachineCount() (int, error) {
 	return umachineCount, nil
 }
 
-func (mcp *MachineConfigPool) pollMachineCount() func() string {
-	return mcp.Poll(`{.status.machineCount}`)
+// GetMachineCountStatus returns the value of 'machineCount' in the MCP status as a string
+func (mcp *MachineConfigPool) GetMachineCountStatus() (string, error) {
+	return mcp.Get(`{.status.machineCount}`)
 }
 
-func (mcp *MachineConfigPool) pollReadyMachineCount() func() string {
-	return mcp.Poll(`{.status.readyMachineCount}`)
+// GetReadyMachineCountStatus returns the value of 'readyMachineCount' in the MCP status as a string
+func (mcp *MachineConfigPool) GetReadyMachineCountStatus() (string, error) {
+	return mcp.Get(`{.status.readyMachineCount}`)
 }
 
-func (mcp *MachineConfigPool) pollDegradedMachineCount() func() string {
-	return mcp.Poll(`{.status.degradedMachineCount}`)
+// GetDegradedMachineCountStatus returns the value of 'degradedMachineCount' in the MCP status as a string
+func (mcp *MachineConfigPool) GetDegradedMachineCountStatus() (string, error) {
+	return mcp.Get(`{.status.degradedMachineCount}`)
 }
 
 // GetDegradedStatus returns the value of the 'Degraded' condition in the MCP
 func (mcp *MachineConfigPool) GetDegradedStatus() (string, error) {
 	return mcp.Get(`{.status.conditions[?(@.type=="Degraded")].status}`)
-}
-
-func (mcp *MachineConfigPool) pollDegradedStatus() func() string {
-	return mcp.Poll(`{.status.conditions[?(@.type=="Degraded")].status}`)
 }
 
 // GetUpdatedStatus returns the value of the 'Updated' condition in the MCP
@@ -265,10 +264,6 @@ func (mcp *MachineConfigPool) GetUpdatedStatus() (string, error) {
 // GetUpdatingStatus returns the value of 'Updating' condition in the MCP
 func (mcp *MachineConfigPool) GetUpdatingStatus() (string, error) {
 	return mcp.Get(`{.status.conditions[?(@.type=="Updating")].status}`)
-}
-
-func (mcp *MachineConfigPool) pollUpdatedStatus() func() string {
-	return mcp.Poll(`{.status.conditions[?(@.type=="Updated")].status}`)
 }
 
 func (mcp *MachineConfigPool) estimateWaitDuration() time.Duration {

--- a/test/extended-priv/mco_configdrift.go
+++ b/test/extended-priv/mco_configdrift.go
@@ -246,9 +246,9 @@ func verifyDriftConfig(mcp *MachineConfigPool, rf *RemoteFile, newMode string, f
 	o.Expect(rferr).NotTo(o.HaveOccurred())
 
 	o.Expect(rf.GetTextContent()).To(o.Equal(newContent), "File content should be updated")
-	o.Eventually(mcp.pollDegradedMachineCount(), "10m", "30s").Should(o.Equal("1"), "There should be 1 degraded machine")
-	o.Eventually(mcp.pollDegradedStatus(), "10m", "30s").Should(o.Equal("True"), "The worker MCP should report a True Degraded status")
-	o.Eventually(mcp.pollUpdatedStatus(), "10m", "30s").Should(o.Equal("False"), "The worker MCP should report a False Updated status")
+	o.Eventually(mcp.GetDegradedMachineCountStatus, "10m", "30s").Should(o.Equal("1"), "There should be 1 degraded machine")
+	o.Eventually(mcp, "10m", "30s").Should(BeDegraded(), "The worker MCP should report a True Degraded status")
+	o.Eventually(mcp, "10m", "30s").Should(HaveConditionField("Updated", "status", "False"), "The worker MCP should report a False Updated status")
 
 	exutil.By("Verify that node annotations describe the reason for the Degraded status")
 	reason := workerNode.GetAnnotationOrFail("machineconfiguration.openshift.io/reason")
@@ -262,9 +262,9 @@ func verifyDriftConfig(mcp *MachineConfigPool, rf *RemoteFile, newMode string, f
 		o.Expect(rf.PushNewTextContent(origContent)).NotTo(o.HaveOccurred())
 	}
 
-	o.Eventually(mcp.pollDegradedMachineCount(), "10m", "30s").Should(o.Equal("0"), "There should be no degraded machines")
-	o.Eventually(mcp.pollDegradedStatus(), "10m", "30s").Should(o.Equal("False"), "The worker MCP should report a False Degraded status")
-	o.Eventually(mcp.pollUpdatedStatus(), "15m", "30s").Should(o.Equal("True"), "The worker MCP should report a True Updated status")
+	o.Eventually(mcp.GetDegradedMachineCountStatus, "10m", "30s").Should(o.Equal("0"), "There should be no degraded machines")
+	o.Eventually(mcp, "10m", "30s").ShouldNot(BeDegraded(), "The worker MCP should report a False Degraded status")
+	o.Eventually(mcp, "15m", "30s").Should(HaveConditionField("Updated", "status", "True"), "The worker MCP should report a True Updated status")
 	rferr = rf.Fetch()
 	o.Expect(rferr).NotTo(o.HaveOccurred())
 	o.Expect(rf.GetTextContent()).To(o.Equal(origContent), "Original file content should be restored")
@@ -279,9 +279,9 @@ func verifyDriftConfig(mcp *MachineConfigPool, rf *RemoteFile, newMode string, f
 	o.Expect(rferr).NotTo(o.HaveOccurred())
 
 	o.Expect(rf.GetNpermissions()).To(o.Equal(newMode), "%s File permissions should be %s", rf.fullPath, newMode)
-	o.Eventually(mcp.pollDegradedMachineCount(), "10m", "30s").Should(o.Equal("1"), "There should be 1 degraded machine")
-	o.Eventually(mcp.pollDegradedStatus(), "10m", "30s").Should(o.Equal("True"), "The worker MCP should report a True Degraded status")
-	o.Eventually(mcp.pollUpdatedStatus(), "10m", "30s").Should(o.Equal("False"), "The worker MCP should report a False Updated status")
+	o.Eventually(mcp.GetDegradedMachineCountStatus, "10m", "30s").Should(o.Equal("1"), "There should be 1 degraded machine")
+	o.Eventually(mcp, "10m", "30s").Should(BeDegraded(), "The worker MCP should report a True Degraded status")
+	o.Eventually(mcp, "10m", "30s").Should(HaveConditionField("Updated", "status", "False"), "The worker MCP should report a False Updated status")
 
 	exutil.By("Verify that node annotations describe the reason for the Degraded status")
 	reason = workerNode.GetAnnotationOrFail("machineconfiguration.openshift.io/reason")
@@ -293,9 +293,9 @@ func verifyDriftConfig(mcp *MachineConfigPool, rf *RemoteFile, newMode string, f
 	o.Expect(rferr).NotTo(o.HaveOccurred())
 
 	o.Expect(rf.GetNpermissions()).To(o.Equal(origMode), "%s File permissions should be %s", rf.fullPath, origMode)
-	o.Eventually(mcp.pollDegradedMachineCount(), "10m", "30s").Should(o.Equal("0"), "There should be no degraded machines")
-	o.Eventually(mcp.pollDegradedStatus(), "10m", "30s").Should(o.Equal("False"), "The worker MCP should report a False Degraded status")
-	o.Eventually(mcp.pollUpdatedStatus(), "10m", "30s").Should(o.Equal("True"), "The worker MCP should report a True Updated status")
+	o.Eventually(mcp.GetDegradedMachineCountStatus, "10m", "30s").Should(o.Equal("0"), "There should be no degraded machines")
+	o.Eventually(mcp, "10m", "30s").ShouldNot(BeDegraded(), "The worker MCP should report a False Degraded status")
+	o.Eventually(mcp, "10m", "30s").Should(HaveConditionField("Updated", "status", "True"), "The worker MCP should report a True Updated status")
 
 	exutil.By("Verify that node annotations have been cleaned")
 	reason = workerNode.GetAnnotationOrFail("machineconfiguration.openshift.io/reason")

--- a/test/extended-priv/mco_drain.go
+++ b/test/extended-priv/mco_drain.go
@@ -62,8 +62,8 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/longdurati
 		mc.create()
 
 		exutil.By("Wait until node is cordoned")
-		o.Eventually(workerNode.Poll(`{.spec.taints[?(@.effect=="NoSchedule")].effect}`),
-			"20m", "1m").Should(o.Equal("NoSchedule"), fmt.Sprintf("Node %s was not cordoned", workerNode.name))
+		o.Eventually(workerNode.Get, "20m", "1m").WithArguments(`{.spec.taints[?(@.effect=="NoSchedule")].effect}`).
+				Should(o.Equal("NoSchedule"), fmt.Sprintf("Node %s was not cordoned", workerNode.name))
 
 		exutil.By("Check MCC logs to see the early sleep interval b/w failed drains")
 		var podLogs string

--- a/test/extended-priv/mco_machineconfigpool.go
+++ b/test/extended-priv/mco_machineconfigpool.go
@@ -41,12 +41,12 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/longdurati
 		logger.Infof("OK!\n")
 
 		exutil.By("Check MCP status")
-		o.Consistently(mcp.pollDegradedMachineCount(), "30s", "10s").Should(o.Equal("0"), "There are degraded nodes in pool")
-		o.Eventually(mcp.pollDegradedStatus(), "1m", "20s").Should(o.Equal("False"), "The pool status is 'Degraded'")
-		o.Eventually(mcp.pollUpdatedStatus(), "1m", "20s").Should(o.Equal("True"), "The pool is reporting that it is not updated")
-		o.Eventually(mcp.pollMachineCount(), "1m", "10s").Should(o.Equal("0"), "The pool should report 0 machine count")
-		o.Eventually(mcp.pollReadyMachineCount(), "1m", "10s").Should(o.Equal("0"), "The pool should report 0 machine ready")
-		o.Eventually(wMcp.pollMachineCount(), "1m", "10s").Should(o.Equal(strconv.Itoa(initialNumWorkers)),
+		o.Consistently(mcp.GetDegradedMachineCountStatus, "30s", "10s").Should(o.Equal("0"), "There are degraded nodes in pool")
+		o.Eventually(mcp, "1m", "20s").ShouldNot(BeDegraded(), "The pool status is 'Degraded'")
+		o.Eventually(mcp, "1m", "20s").Should(HaveConditionField("Updated", "status", "True"), "The pool is reporting that it is not updated")
+		o.Eventually(mcp.GetMachineCountStatus, "1m", "10s").Should(o.Equal("0"), "The pool should report 0 machine count")
+		o.Eventually(mcp.GetReadyMachineCountStatus, "1m", "10s").Should(o.Equal("0"), "The pool should report 0 machine ready")
+		o.Eventually(wMcp.GetMachineCountStatus, "1m", "10s").Should(o.Equal(strconv.Itoa(initialNumWorkers)),
 			"The worker pool should report %d machine count", initialNumWorkers)
 
 		logger.Infof("Custom mcp is created successfully!")
@@ -61,12 +61,12 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/longdurati
 		logger.Infof("OK!\n")
 
 		exutil.By("Check MCP status")
-		o.Consistently(mcp.pollDegradedMachineCount(), "30s", "10s").Should(o.Equal("0"), "There are degraded nodes in pool")
-		o.Eventually(mcp.pollDegradedStatus(), "1m", "20s").Should(o.Equal("False"), "The pool status is 'Degraded'")
-		o.Eventually(mcp.pollUpdatedStatus(), "1m", "20s").Should(o.Equal("True"), "The pool is reporting that it is not updated")
-		o.Eventually(mcp.pollMachineCount(), "1m", "10s").Should(o.Equal("1"), "The pool should report 1 machine count")
-		o.Eventually(mcp.pollReadyMachineCount(), "1m", "10s").Should(o.Equal("1"), "The pool should report 1 machine ready")
-		o.Eventually(wMcp.pollMachineCount(), "1m", "10s").Should(o.Equal(strconv.Itoa(initialNumWorkers-1)),
+		o.Consistently(mcp.GetDegradedMachineCountStatus, "30s", "10s").Should(o.Equal("0"), "There are degraded nodes in pool")
+		o.Eventually(mcp, "1m", "20s").ShouldNot(BeDegraded(), "The pool status is 'Degraded'")
+		o.Eventually(mcp, "1m", "20s").Should(HaveConditionField("Updated", "status", "True"), "The pool is reporting that it is not updated")
+		o.Eventually(mcp.GetMachineCountStatus, "1m", "10s").Should(o.Equal("1"), "The pool should report 1 machine count")
+		o.Eventually(mcp.GetReadyMachineCountStatus, "1m", "10s").Should(o.Equal("1"), "The pool should report 1 machine ready")
+		o.Eventually(wMcp.GetMachineCountStatus, "1m", "10s").Should(o.Equal(strconv.Itoa(initialNumWorkers-1)),
 			"The worker pool should report %d machine count", initialNumWorkers-1)
 
 		logger.Infof("Custom mcp is created successfully!")
@@ -82,11 +82,11 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/longdurati
 		logger.Infof("OK!\n")
 
 		exutil.By("Verify that the information is updated in MCP")
-		o.Eventually(mcp.pollUpdatedStatus(), "5m", "20s").Should(o.Equal("True"), "The pool is reporting that it is not updated")
-		o.Eventually(mcp.pollMachineCount(), "5m", "20s").Should(o.Equal("0"), "The pool should report 0 machine count")
-		o.Eventually(mcp.pollReadyMachineCount(), "5m", "20s").Should(o.Equal("0"), "The pool should report 0 machine ready")
-		o.Consistently(mcp.pollDegradedMachineCount(), "30s", "10s").Should(o.Equal("0"), "There are degraded nodes in pool")
-		o.Eventually(mcp.pollDegradedStatus(), "5m", "20s").Should(o.Equal("False"), "The pool status is 'Degraded'")
+		o.Eventually(mcp, "5m", "20s").Should(HaveConditionField("Updated", "status", "True"), "The pool is reporting that it is not updated")
+		o.Eventually(mcp.GetMachineCountStatus, "5m", "20s").Should(o.Equal("0"), "The pool should report 0 machine count")
+		o.Eventually(mcp.GetReadyMachineCountStatus, "5m", "20s").Should(o.Equal("0"), "The pool should report 0 machine ready")
+		o.Consistently(mcp.GetDegradedMachineCountStatus, "30s", "10s").Should(o.Equal("0"), "There are degraded nodes in pool")
+		o.Eventually(mcp, "5m", "20s").ShouldNot(BeDegraded(), "The pool status is 'Degraded'")
 		logger.Infof("OK!\n")
 
 		exutil.By("Remove custom infra mcp")

--- a/test/extended-priv/mco_observability.go
+++ b/test/extended-priv/mco_observability.go
@@ -358,19 +358,17 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/longdurati
 		logger.Infof("OK!\n")
 
 		exutil.By("Wait until node is cordoned")
-		o.Eventually(workerNode.Poll(`{.spec.taints[?(@.effect=="NoSchedule")].effect}`),
-			"20m", "1m").Should(o.Equal("NoSchedule"), fmt.Sprintf("Node %s was not cordoned", workerNode.name))
+		o.Eventually(workerNode.Get, "20m", "1m").WithArguments(`{.spec.taints[?(@.effect=="NoSchedule")].effect}`).
+				Should(o.Equal("NoSchedule"), fmt.Sprintf("Node %s was not cordoned", workerNode.name))
 		logger.Infof("OK!\n")
 
 		exutil.By("Verify that node is not degraded until the alarm timeout")
-		o.Consistently(mcp.pollDegradedStatus(),
-			"58m", "5m").Should(o.Equal("False"),
+		o.Consistently(mcp, "58m", "5m").ShouldNot(BeDegraded(),
 			"The worker MCP was degraded too soon. The worker MCP should not be degraded until 1 hour timeout happens")
 		logger.Infof("OK!\n")
 
 		exutil.By("Verify that node is degraded after the 1h timeout")
-		o.Eventually(mcp.pollDegradedStatus(),
-			"5m", "1m").Should(o.Equal("True"),
+		o.Eventually(mcp, "5m", "1m").Should(BeDegraded(),
 			"1 hour passed since the eviction problems were reported and the worker MCP has not been degraded")
 		logger.Infof("OK!\n")
 
@@ -431,8 +429,7 @@ var _ = g.Describe("[sig-mco][Suite:openshift/machine-config-operator/longdurati
 		logger.Infof("OK!\n")
 
 		exutil.By("Verfiy that the pool stops being degraded")
-		o.Eventually(mcp.pollDegradedStatus(),
-			"10m", "30s").Should(o.Equal("False"),
+		o.Eventually(mcp, "10m", "30s").ShouldNot(BeDegraded(),
 			"After removing the PodDisruptionBudget the eviction should have succeeded and the worker pool should stop being degraded")
 		logger.Infof("OK!\n")
 

--- a/test/extended-priv/node.go
+++ b/test/extended-priv/node.go
@@ -645,18 +645,6 @@ func (n *Node) GetMCDaemonLogs(filter string) (string, error) {
 	return mcdLogs, err
 }
 
-// PollMCDaemonLogs returns a function that can be used by gomega Eventually/Consistently functions to poll logs results
-// If there is an error, it will return empty string, new need to take that into account building our Eventually/Consistently statement
-func (n *Node) PollMCDaemonLogs(filter string) func() string {
-	return func() string {
-		logs, err := n.GetMCDaemonLogs(filter)
-		if err != nil {
-			return ""
-		}
-		return logs
-	}
-}
-
 // CaptureMCDaemonLogsUntilRestartWithTimeout captures all the logs in the MachineConfig daemon pod for this node until the daemon pod is restarted
 func (n *Node) CaptureMCDaemonLogsUntilRestartWithTimeout(timeout string) (string, error) {
 	var (

--- a/test/extended-priv/resource.go
+++ b/test/extended-priv/resource.go
@@ -38,7 +38,6 @@ type ResourceInterface interface {
 	Get(jsonPath string, extraParams ...string) (string, error)
 	GetSafe(jsonPath string, defaultValue string, extraParams ...string) string
 	GetOrFail(jsonPath string, extraParams ...string) string
-	Poll(jsonPath string) func() string
 	Delete(extraParams ...string) error
 	DeleteOrFail(extraParams ...string)
 	Exists() bool
@@ -162,14 +161,6 @@ func (r *ocGetter) GetOrFail(jsonPath string, extraParams ...string) string {
 	}
 
 	return ret
-}
-
-// PollValue returns a function suitable to be used with the gomega Eventually/Consistently checks
-func (r *ocGetter) Poll(jsonPath string) func() string {
-	return func() string {
-		ret, _ := r.Get(jsonPath)
-		return ret
-	}
 }
 
 // String implements the Stringer interface


### PR DESCRIPTION
**- What I did**
In old gomega versions gomega couldn't accept a method in "Eventually/Consistently" it accepted a fixed function definition. Hence, "Poll" methods were created to wrap the logic to provide those functions.

In new versions gomega supports passing methods to "Eventually/Consitently" with "WithArguments" and the "Poll" methods are not necessary anymore.

We remove those "Poll" methods in this PR:

**- How to verify it**

All regression tests should pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated extended tests to use direct resource lookups and matcher-based status checks.
  - Improved validation of machine configuration pool health, readiness, degradation, updates, and node cordoning.
  - Standardized asynchronous assertions across configuration drift, draining, observability, and machine pool scenarios.

- **Removed**
  - Removed legacy polling helpers for resource values and Machine Config Daemon logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->