### PR TITLE
OCPBUGS-122237: [TNF] Add infinite retry on untaint systemd unit

### DIFF
--- a/templates/master/00-master/two-node-with-fencing/units/untaint-node@.service.yaml
+++ b/templates/master/00-master/two-node-with-fencing/units/untaint-node@.service.yaml
@@ -3,8 +3,7 @@ contents: |
   [Unit]
   Description=Untaint pacemaker-annotated nodes (triggered by %i rejoin)
   After=network.target taint-node@%i.service
-  StartLimitIntervalSec=600
-  StartLimitBurst=10
+  StartLimitIntervalSec=0
 
   [Service]
   Type=oneshot


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
Fixes OCPBUGS-122237 https://redhat.atlassian.net/browse/OCPBUGS-122237

**- What I did**

- Ensure that the untaint systemd unit retries indefinitely until all the exit criteria are met, instead of timing out. In some scenarios, a node can take more than 10 minutes to recover and become ready, so we need to ensure the taint is removed to make the workloads schedulable in such onde

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Add infinite retry on untaint systemd unit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Reliability Improvements**
  - Node recovery operations can now retry without being blocked by system service start-rate limits.
  - This improves resilience when repeated recovery attempts are required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->